### PR TITLE
Improved stderr output, now goes to /dev/null

### DIFF
--- a/app.go
+++ b/app.go
@@ -5,9 +5,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"runtime"
 	"strings"
-	"syscall"
 )
 
 type App struct {
@@ -102,11 +100,10 @@ func (app *App) runShell(s string, args []string, wait bool, async bool) {
 	args = append([]string{"-c", s, "--"}, args...)
 	cmd := exec.Command(envShell, args...)
 
+	const devnull = 3
+	Stdnull := os.NewFile(uintptr(devnull), os.DevNull)
+
 	if !async {
-		var Stdnull *os.File
-		if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
-			Stdnull = os.NewFile(uintptr(syscall.Stdout), "/dev/stdout")
-		}
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = Stdnull

--- a/app.go
+++ b/app.go
@@ -5,7 +5,9 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
+	"syscall"
 )
 
 type App struct {
@@ -101,9 +103,13 @@ func (app *App) runShell(s string, args []string, wait bool, async bool) {
 	cmd := exec.Command(envShell, args...)
 
 	if !async {
+		var Stdnull *os.File
+		if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
+			Stdnull = os.NewFile(uintptr(syscall.Stdout), "/dev/stdout")
+		}
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
+		cmd.Stderr = Stdnull
 	}
 
 	if wait {


### PR DESCRIPTION
Hi I made a small modification, to redirect the application stderr to /dev/null, since when using lf on my machines the errors and warnings from third party apps where showing on the background making difficult to use the app.