### PR TITLE
Remove opener option from docs

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -29,7 +29,6 @@
     scrolloff  int     (default 0)
     sortby     string  (default name)
     showinfo   string  (default none)
-    opener     string  (default xdg-open)
     ratios     string  (default 1:2:3)
 
 ## Variables


### PR DESCRIPTION
It doesn't exist anymore, right?