### PR TITLE
Pass height to the previewer

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -257,7 +257,7 @@ func (win *Win) printr(reg *os.File) error {
 	}
 
 	if len(gOpts.previewer) != 0 {
-		cmd := exec.Command(gOpts.previewer, reg.Name())
+		cmd := exec.Command(gOpts.previewer, reg.Name(), strconv.Itoa(win.w), strconv.Itoa(win.h))
 
 		out, err := cmd.Output()
 		if err != nil {


### PR DESCRIPTION
This way, the script can do a little magic like
```bash
head -n $2 $1 | highlight -O ansi --syntax ${1##*.}
```
to avoid reading whole (possibly huge) file.