### PR TITLE
Add command to invert marks in current directory

### DIFF
--- a/comp.go
+++ b/comp.go
@@ -32,6 +32,7 @@ var (
 		"search",
 		"search-back",
 		"toggle",
+		"invert",
 		"yank",
 		"delete",
 		"paste",

--- a/doc.go
+++ b/doc.go
@@ -30,6 +30,7 @@ The following commands are provided by lf with default keybindings.
     search            (default "/")
     search-back       (default "?")
     toggle            (default "<space>")
+    invert            (default "v")
     yank              (default "y")
     delete            (default "d")
     paste             (default "p")

--- a/docstring.go
+++ b/docstring.go
@@ -34,6 +34,7 @@ The following commands are provided by lf with default keybindings.
     search            (default "/")
     search-back       (default "?")
     toggle            (default "<space>")
+    invert            (default "v")
     yank              (default "y")
     delete            (default "d")
     paste             (default "p")

--- a/eval.go
+++ b/eval.go
@@ -280,6 +280,8 @@ func (e *CallExpr) eval(app *App, args []string) {
 		// TODO: implement
 	case "toggle":
 		app.nav.toggle()
+	case "invert":
+		app.nav.invert()
 	case "yank":
 		if err := app.nav.save(true); err != nil {
 			msg := fmt.Sprintf("yank: %s", err)

--- a/nav.go
+++ b/nav.go
@@ -343,20 +343,30 @@ func (nav *Nav) cd(wd string) error {
 	return nil
 }
 
-func (nav *Nav) toggle() {
-	if nav.currEmpty() {
-		return
-	}
-
-	path := nav.currPath()
-
+func (nav *Nav) toggleMark(path string) {
 	if nav.marks[path] {
 		delete(nav.marks, path)
 	} else {
 		nav.marks[path] = true
 	}
+}
+
+func (nav *Nav) toggle() {
+	if nav.currEmpty() {
+		return
+	}
+
+	nav.toggleMark(nav.currPath())
 
 	nav.down(1)
+}
+
+func (nav *Nav) invert() {
+	last := nav.currDir()
+	for _, f := range last.fi {
+		path := filepath.Join(last.path, f.Name())
+		nav.toggleMark(path)
+	}
 }
 
 func (nav *Nav) save(keep bool) error {

--- a/opts.go
+++ b/opts.go
@@ -49,6 +49,7 @@ func init() {
 	gOpts.keys["/"] = &CallExpr{"search", nil}
 	gOpts.keys["?"] = &CallExpr{"search-back", nil}
 	gOpts.keys["<space>"] = &CallExpr{"toggle", nil}
+	gOpts.keys["v"] = &CallExpr{"invert", nil}
 	gOpts.keys["y"] = &CallExpr{"yank", nil}
 	gOpts.keys["d"] = &CallExpr{"delete", nil}
 	gOpts.keys["p"] = &CallExpr{"paste", nil}


### PR DESCRIPTION
Much like in ranger, `v` will now toggle marks for all entries in the current directory. 
I mostly use it for selecting everything at once.