### PR TITLE
Refactor Nav API around symlinks handling (mostly)

### DIFF
--- a/app.go
+++ b/app.go
@@ -76,11 +76,9 @@ func (app *App) handleInp() {
 }
 
 func (app *App) exportVars() {
-	dir := app.nav.currDir()
-
 	var envFile string
-	if len(dir.fi) != 0 {
-		envFile = app.nav.currPath()
+	if f, err := app.nav.currFile(); err == nil {
+		envFile = f.Path
 	}
 
 	marks := app.nav.currMarks()

--- a/ui.go
+++ b/ui.go
@@ -489,7 +489,7 @@ func (ui *UI) draw(nav *Nav) {
 	// leave the cursor at the beginning of the current file for screen readers
 	var length, woff, doff int
 	defer func() {
-		fmt.Printf("[%d;%dH", ui.wins[woff+length-1].y + nav.dirs[doff+length-1].pos + 1, ui.wins[woff+length-1].x + 1)
+		fmt.Printf("[%d;%dH", ui.wins[woff+length-1].y+nav.dirs[doff+length-1].pos+1, ui.wins[woff+length-1].x+1)
 	}()
 
 	defer termbox.Flush()


### PR DESCRIPTION
The brief summary is in the commit message, I'll elaborate here a bit about some things. There will be some comments inside the code as well.

Ad. 4: At first, I've mentioned that this might get annoying, but it turns out it's not. It's actually less annoying than having to get dir, check it's length, etc.
Ad. 7: Like I said, I like it better that way. Implementing an option to get the old behaviour back should be fairly easy, but is unrelated here. Maybe we can track it in #21? Or in other, separate issue.

I've used Capitalised fields names, but I've noticed (later) that you're using all small letters in most cases. It works, of course, but I tend to think of unexported fields as "private". Can change it to small, if you want, no big deal.

Oh, and it seems that one file was not fully `gofmt`'ed. Committed it separately, just sth my `vim` does automatically.

Hopefully I've remembered everything and did not break anything :-).

Fixes #20.
Relates #21.