### PR TITLE
Refactor sorting types to only implement Len and Swap once

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode"
@@ -155,6 +156,22 @@ func max(a, b int) int {
 		return a
 	}
 	return b
+}
+
+type filesSortable struct {
+	files []*File
+	less  func(i, j int) bool
+}
+
+func (f filesSortable) Len() int { return len(f.files) }
+
+func (f filesSortable) Swap(i, j int) { f.files[i], f.files[j] = f.files[j], f.files[i] }
+
+func (f filesSortable) Less(i, j int) bool { return f.less(i, j) }
+
+// TODO: Replace with `sort.SliceStable` once available
+func sortFilesStable(files []*File, less func(i, j int) bool) {
+	sort.Stable(filesSortable{files: files, less: less})
 }
 
 // We don't need no generic code


### PR DESCRIPTION
This is not complete yet, but I'd like to know your opinion.

Using this embedding "trick", we could implement `Len` and `Swap` parts of the `sort.Interface` once and leave only `Less` to be implemented by concrete sort types. The two former funcs are very unlikely to be different even when new sort types appear and if they are, we should be able to override them anyway (haven't tested, but we should :-)).
One caveat is that now `Less` functions would have to use `b.Files` as the collection to compare, instead of just `b`.

[We could then also use the `Files` type instead `[]*File` in some places, but that's just a side effect.]

@gokcehan what do you think?
If you like the idea, I'll finish the implementation in the coming days.