### PR TITLE
preserve mark order in f[sx] variables

### DIFF
--- a/app.go
+++ b/app.go
@@ -108,12 +108,14 @@ func (app *app) exportVars() {
 		envFile = f.Path
 	}
 
-	envFiles := strings.Join(app.nav.marks, gOpts.filesep)
+	marks := app.nav.currMarks()
+
+	envFiles := strings.Join(marks, gOpts.filesep)
 
 	os.Setenv("f", envFile)
 	os.Setenv("fs", envFiles)
 
-	if len(app.nav.marks) == 0 {
+	if len(marks) == 0 {
 		os.Setenv("fx", envFile)
 	} else {
 		os.Setenv("fx", envFiles)

--- a/app.go
+++ b/app.go
@@ -108,14 +108,12 @@ func (app *app) exportVars() {
 		envFile = f.Path
 	}
 
-	marks := app.nav.currMarks()
-
-	envFiles := strings.Join(marks, gOpts.filesep)
+	envFiles := strings.Join(app.nav.marks, gOpts.filesep)
 
 	os.Setenv("f", envFile)
 	os.Setenv("fs", envFiles)
 
-	if len(marks) == 0 {
+	if len(app.nav.marks) == 0 {
 		os.Setenv("fx", envFile)
 	} else {
 		os.Setenv("fx", envFiles)

--- a/eval.go
+++ b/eval.go
@@ -292,7 +292,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			log.Printf(msg)
 			return
 		}
-		app.nav.marks = make(map[string]bool)
+		app.nav.marks = make(map[string]int)
 		if err := sendRemote("send sync"); err != nil {
 			msg := fmt.Sprintf("yank: %s", err)
 			app.ui.message = msg
@@ -305,7 +305,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			log.Printf(msg)
 			return
 		}
-		app.nav.marks = make(map[string]bool)
+		app.nav.marks = make(map[string]int)
 		if err := sendRemote("send sync"); err != nil {
 			msg := fmt.Sprintf("delete: %s", err)
 			app.ui.message = msg

--- a/eval.go
+++ b/eval.go
@@ -230,7 +230,8 @@ func (e *callExpr) eval(app *app, args []string) {
 
 			var path string
 			if len(app.nav.marks) != 0 {
-				path = strings.Join(app.nav.marks, "\n")
+				marks := app.nav.currMarks()
+				path = strings.Join(marks, "\n")
 			} else if curr, err := app.nav.currFile(); err == nil {
 				path = curr.Path
 			} else {
@@ -291,7 +292,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			log.Printf(msg)
 			return
 		}
-		app.nav.marks = make([]string, 0)
+		app.nav.marks = make(map[string]bool)
 		if err := sendRemote("send sync"); err != nil {
 			msg := fmt.Sprintf("yank: %s", err)
 			app.ui.message = msg
@@ -304,7 +305,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			log.Printf(msg)
 			return
 		}
-		app.nav.marks = make([]string, 0)
+		app.nav.marks = make(map[string]bool)
 		if err := sendRemote("send sync"); err != nil {
 			msg := fmt.Sprintf("delete: %s", err)
 			app.ui.message = msg

--- a/eval.go
+++ b/eval.go
@@ -230,8 +230,7 @@ func (e *callExpr) eval(app *app, args []string) {
 
 			var path string
 			if len(app.nav.marks) != 0 {
-				marks := app.nav.currMarks()
-				path = strings.Join(marks, "\n")
+				path = strings.Join(app.nav.marks, "\n")
 			} else if curr, err := app.nav.currFile(); err == nil {
 				path = curr.Path
 			} else {
@@ -292,7 +291,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			log.Printf(msg)
 			return
 		}
-		app.nav.marks = make(map[string]bool)
+		app.nav.marks = make([]string, 0)
 		if err := sendRemote("send sync"); err != nil {
 			msg := fmt.Sprintf("yank: %s", err)
 			app.ui.message = msg
@@ -305,7 +304,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			log.Printf(msg)
 			return
 		}
-		app.nav.marks = make(map[string]bool)
+		app.nav.marks = make([]string, 0)
 		if err := sendRemote("send sync"); err != nil {
 			msg := fmt.Sprintf("delete: %s", err)
 			app.ui.message = msg

--- a/nav.go
+++ b/nav.go
@@ -183,7 +183,7 @@ type nav struct {
 	inds   map[string]int
 	poss   map[string]int
 	names  map[string]string
-	marks  map[string]bool
+	marks  []string
 	saves  map[string]bool
 	height int
 	search string
@@ -225,7 +225,7 @@ func newNav(height int) *nav {
 		inds:   make(map[string]int),
 		poss:   make(map[string]int),
 		names:  make(map[string]string),
-		marks:  make(map[string]bool),
+		marks:  make([]string, 0),
 		saves:  make(map[string]bool),
 		height: height,
 	}
@@ -237,11 +237,13 @@ func (nav *nav) renew(height int) {
 		d.renew(nav.height)
 	}
 
-	for m := range nav.marks {
-		if _, err := os.Stat(m); os.IsNotExist(err) {
-			delete(nav.marks, m)
+	marks := make([]string, 0, len(nav.marks))
+	for _, m := range nav.marks {
+		if _, err := os.Stat(m); err == nil {
+			marks = append(marks, m)
 		}
 	}
+	nav.marks = marks
 }
 
 func (nav *nav) up(dist int) {
@@ -380,11 +382,13 @@ func (nav *nav) searchPrev() {
 }
 
 func (nav *nav) toggleMark(path string) {
-	if nav.marks[path] {
-		delete(nav.marks, path)
-	} else {
-		nav.marks[path] = true
+	for i, mark := range nav.marks {
+		if mark == path {
+			nav.marks = append(nav.marks[:i], nav.marks[i+1:]...)
+			return
+		}
 	}
+	nav.marks = append(nav.marks, path)
 }
 
 func (nav *nav) toggle() {
@@ -421,7 +425,7 @@ func (nav *nav) save(copy bool) error {
 		nav.saves[curr.Path] = copy
 	} else {
 		var fs []string
-		for f := range nav.marks {
+		for _, f := range nav.marks {
 			fs = append(fs, f)
 		}
 
@@ -430,7 +434,7 @@ func (nav *nav) save(copy bool) error {
 		}
 
 		nav.saves = make(map[string]bool)
-		for f := range nav.marks {
+		for _, f := range nav.marks {
 			nav.saves[f] = copy
 		}
 	}
@@ -500,12 +504,4 @@ func (nav *nav) currFile() (*file, error) {
 		return nil, fmt.Errorf("empty directory")
 	}
 	return last.fi[last.ind], nil
-}
-
-func (nav *nav) currMarks() []string {
-	marks := make([]string, 0, len(nav.marks))
-	for m := range nav.marks {
-		marks = append(marks, m)
-	}
-	return marks
 }

--- a/ui.go
+++ b/ui.go
@@ -209,7 +209,7 @@ func (win *win) printl(x, y int, fg, bg termbox.Attribute, s string) {
 	win.printf(x, y, fg, bg, "%s%*s", s, win.w-len(s), "")
 }
 
-func (win *win) printd(dir *dir, marks, saves map[string]bool) {
+func (win *win) printd(dir *dir, marks map[string]int, saves map[string]bool) {
 	if win.w < 3 {
 		return
 	}
@@ -254,7 +254,7 @@ func (win *win) printd(dir *dir, marks, saves map[string]bool) {
 
 		path := filepath.Join(dir.path, f.Name())
 
-		if marks[path] {
+		if _, ok := marks[path]; ok {
 			win.print(0, i, fg, termbox.ColorMagenta, " ")
 		} else if copy, ok := saves[path]; ok {
 			if copy {

--- a/ui.go
+++ b/ui.go
@@ -209,7 +209,7 @@ func (win *win) printl(x, y int, fg, bg termbox.Attribute, s string) {
 	win.printf(x, y, fg, bg, "%s%*s", s, win.w-len(s), "")
 }
 
-func (win *win) printd(dir *dir, marks, saves map[string]bool) {
+func (win *win) printd(dir *dir, marks []string, saves map[string]bool) {
 	if win.w < 3 {
 		return
 	}
@@ -254,15 +254,21 @@ func (win *win) printd(dir *dir, marks, saves map[string]bool) {
 
 		path := filepath.Join(dir.path, f.Name())
 
-		if marks[path] {
-			win.print(0, i, fg, termbox.ColorMagenta, " ")
-		} else if copy, ok := saves[path]; ok {
-			if copy {
-				win.print(0, i, fg, termbox.ColorYellow, " ")
-			} else {
-				win.print(0, i, fg, termbox.ColorRed, " ")
+		func() {
+			for _, m := range marks {
+				if m == path {
+					win.print(0, i, fg, termbox.ColorMagenta, " ")
+					return
+				}
 			}
-		}
+			if copy, ok := saves[path]; ok {
+				if copy {
+					win.print(0, i, fg, termbox.ColorYellow, " ")
+				} else {
+					win.print(0, i, fg, termbox.ColorRed, " ")
+				}
+			}
+		}()
 
 		if i == dir.pos {
 			fg |= termbox.AttrReverse

--- a/ui.go
+++ b/ui.go
@@ -209,7 +209,7 @@ func (win *win) printl(x, y int, fg, bg termbox.Attribute, s string) {
 	win.printf(x, y, fg, bg, "%s%*s", s, win.w-len(s), "")
 }
 
-func (win *win) printd(dir *dir, marks []string, saves map[string]bool) {
+func (win *win) printd(dir *dir, marks, saves map[string]bool) {
 	if win.w < 3 {
 		return
 	}
@@ -254,21 +254,15 @@ func (win *win) printd(dir *dir, marks []string, saves map[string]bool) {
 
 		path := filepath.Join(dir.path, f.Name())
 
-		func() {
-			for _, m := range marks {
-				if m == path {
-					win.print(0, i, fg, termbox.ColorMagenta, " ")
-					return
-				}
+		if marks[path] {
+			win.print(0, i, fg, termbox.ColorMagenta, " ")
+		} else if copy, ok := saves[path]; ok {
+			if copy {
+				win.print(0, i, fg, termbox.ColorYellow, " ")
+			} else {
+				win.print(0, i, fg, termbox.ColorRed, " ")
 			}
-			if copy, ok := saves[path]; ok {
-				if copy {
-					win.print(0, i, fg, termbox.ColorYellow, " ")
-				} else {
-					win.print(0, i, fg, termbox.ColorRed, " ")
-				}
-			}
-		}()
+		}
 
 		if i == dir.pos {
 			fg |= termbox.AttrReverse


### PR DESCRIPTION
Currently the order of the items in $fs and $fx is undefined because iterating on a map is random. This is annoying in some cases (e.g. music player with all files from an album marked). With this patch the order is the order in which the files are marked.

Printing a directory is probably less efficient with all the iteration needed, but it doesn't seem to be noticeable. Maybe you have a better solution for this.