### PR TITLE
Implement directory count info

### DIFF
--- a/comp.go
+++ b/comp.go
@@ -47,6 +47,9 @@ var (
 	}
 
 	gOptWords = []string{
+		"dircounts",
+		"nodircounts",
+		"dircounts!",
 		"dirfirst",
 		"nodirfirst",
 		"dirfirst!",

--- a/doc.go
+++ b/doc.go
@@ -68,6 +68,7 @@ keybindings:
 
 The following options can be used to customize the behavior of lf:
 
+    dircounts  boolean  (default off)
     dirfirst   boolean  (default on)
     hidden     boolean  (default off)
     preview    boolean  (default on)

--- a/docstring.go
+++ b/docstring.go
@@ -72,6 +72,7 @@ keybindings:
 
 The following options can be used to customize the behavior of lf:
 
+    dircounts  boolean  (default off)
     dirfirst   boolean  (default on)
     hidden     boolean  (default off)
     preview    boolean  (default on)

--- a/eval.go
+++ b/eval.go
@@ -11,6 +11,12 @@ import (
 
 func (e *setExpr) eval(app *app, args []string) {
 	switch e.opt {
+	case "dircounts":
+		gOpts.dircounts = true
+	case "nodircounts":
+		gOpts.dircounts = false
+	case "dircounts!":
+		gOpts.dircounts = !gOpts.dircounts
 	case "dirfirst":
 		gOpts.dirfirst = true
 		app.nav.renew(app.nav.height)

--- a/nav.go
+++ b/nav.go
@@ -23,6 +23,7 @@ type file struct {
 	os.FileInfo
 	LinkState linkState
 	Path      string
+	Count     int
 }
 
 type filesSortable struct {
@@ -126,6 +127,7 @@ func readdir(path string) ([]*file, error) {
 			FileInfo:  lstat,
 			LinkState: linkState,
 			Path:      fpath,
+			Count:     -1,
 		})
 	}
 	return fi, err

--- a/opts.go
+++ b/opts.go
@@ -3,6 +3,7 @@ package main
 import "time"
 
 var gOpts struct {
+	dircounts bool
 	dirfirst  bool
 	hidden    bool
 	preview   bool
@@ -24,6 +25,7 @@ var gOpts struct {
 }
 
 func init() {
+	gOpts.dircounts = false
 	gOpts.dirfirst = true
 	gOpts.hidden = false
 	gOpts.preview = true

--- a/ui.go
+++ b/ui.go
@@ -291,7 +291,29 @@ func (win *win) printd(dir *dir, marks map[string]int, saves map[string]bool) {
 		for _, s := range gOpts.info {
 			switch s {
 			case "size":
-				info = fmt.Sprintf("%s %4s", info, humanize(f.Size()))
+				if !(gOpts.dircounts && f.IsDir()) {
+					info = fmt.Sprintf("%s %4s", info, humanize(f.Size()))
+					continue
+				}
+
+				if f.Count == -1 {
+					d, err := os.Open(path)
+					if err != nil {
+						log.Printf("opening dir to read count: %s", err)
+						continue
+					}
+
+					names, err := d.Readdirnames(-1)
+					d.Close()
+
+					if err != nil {
+						log.Printf("reading dir count: %s", err)
+						continue
+					}
+
+					f.Count = len(names)
+				}
+				info = fmt.Sprintf("%s %d", info, f.Count)
 			case "time":
 				info = fmt.Sprintf("%s %12s", info, f.ModTime().Format("Jan _2 15:04"))
 			default:


### PR DESCRIPTION
So it took a while, again, unfortunately.
This is a simplified version, without the change to separate `dirinfo` and `fileinfo`, with a boolean flag instead. There's also no option to disable it for anything here, I'll probably add option to disable for preview later (for most perf. gain).
Like I've written before, it is implemented in a way that the counts are only read when actually showing the dir and then cached, as, with info disabled for preview (and possibly left pane, too), it was significantly faster than reading it right away, in my scenarios.

#19 