### PR TITLE
add option to execute command on server initialization POC

### DIFF
--- a/app.go
+++ b/app.go
@@ -136,6 +136,14 @@ func (app *app) loop() {
 	clientChan := app.ui.readExpr()
 	serverChan := readExpr()
 
+	if gCommand != "" {
+		p := newParser(strings.NewReader(gCommand))
+		if e := p.parseExpr(); e != nil {
+			log.Printf("evaluating start command: %s", e.String())
+			e.eval(app, nil)
+		}
+	}
+
 	for {
 		select {
 		case <-app.quitChan:

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ var (
 	gHostname      string
 	gLastDirPath   string
 	gSelectionPath string
+	gCommand       string
 	gSocketProt    string
 	gSocketPath    string
 	gLogPath       string
@@ -102,6 +103,11 @@ func main() {
 		"selection-path",
 		"",
 		"path to the file to write selected files on open (to use as open file dialog)")
+
+	flag.StringVar(&gCommand,
+		"command",
+		"",
+		"command to execute on client initialization")
 
 	flag.Parse()
 


### PR DESCRIPTION
It's a command line flag that allows to execute lf commands on client start.

```
lf -command 'echo foo'
```

Main use case I see is integration with other programs and creating better aliases in shell. For example I'm working on [kakoune-lf](https://github.com/TeddyDD/kakoune-lf) plugin that integrates lf as file browser for Kakoune. 

My issues is: despite the fact you can easily send commands between Kakoune and lf, there is no way to spawn lf instance from Kakoune and obtain client id. I worked around this using env variable and configuration snippet that user have to paste into their `lfrc`. With this option I can spawn lf from Kakoune like this

```sh
lf -command '$echo "eval -client $kak_client set-option global lf_id $id" | kak -p $kak_session' $(basename $kak_buffile)
```

This snippet sets Kakoune variable `lf_id` to id of spawned lf instance. Then I can use id to send commands to lf with `lf -remote`, no need to mess with `lfrc`.

---

WDYT? Would this be useful? 

I don't know If I implemented this correctly (feels like simple hack), I'm happy to work on this further to ensure it's meets quality standards (my Go got bit rusty recently). I probably should mention this option in docs as well. If you don't like this feature feel free to close this PR.