### PR TITLE
Remain in command mode after last cmd-history-next

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -949,7 +949,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			app.ui.menuBuf = nil
 			app.ui.cmdAccLeft = nil
 			app.ui.cmdAccRight = nil
-			app.ui.cmdPrefix = ""
+			app.ui.cmdPrefix = ":"
 			return
 		}
 		cmd := app.cmdHistory[len(app.cmdHistory)-app.cmdHistoryInd]


### PR DESCRIPTION
A quick fix which will ensure the user is left in command mode after going through all the history with `cmd-history-next`, instead of exiting back to normal mode.

This matches the behavior of how going down the history works in vim and ranger. This makes it possible to hold down the down arrow and remain in the command prompt after the latest history, instead of it continuing going through the list of files when done.