### PR TITLE
glob-select implementation

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -58,7 +58,7 @@ var (
 		"echoerr",
 		"cd",
 		"select",
-        "glob-select",
+        	"glob-select",
 		"source",
 		"push",
 	}

--- a/complete.go
+++ b/complete.go
@@ -58,7 +58,7 @@ var (
 		"echoerr",
 		"cd",
 		"select",
-        	"glob-select",
+		"glob-select",
 		"source",
 		"push",
 	}

--- a/complete.go
+++ b/complete.go
@@ -59,6 +59,7 @@ var (
 		"cd",
 		"select",
 		"glob-select",
+		"glob-unselect",
 		"source",
 		"push",
 	}

--- a/complete.go
+++ b/complete.go
@@ -58,6 +58,7 @@ var (
 		"echoerr",
 		"cd",
 		"select",
+        "glob-select",
 		"source",
 		"push",
 	}

--- a/doc.go
+++ b/doc.go
@@ -62,6 +62,7 @@ The following commands are provided by lf without default keybindings:
     echoerr  same as echomsg but red color
     cd       change working directory to the argument
     select   change current file selection to the argument
+    glob-select select files that match the given glob
     source   read the configuration file in the argument
     push     simulate key pushes given in the argument
     delete   remove the current file or selected file(s)

--- a/doc.go
+++ b/doc.go
@@ -63,6 +63,7 @@ The following commands are provided by lf without default keybindings:
     cd       change working directory to the argument
     select   change current file selection to the argument
     glob-select select files that match the given glob
+    glob-unselect unselect files that match the given glob
     source   read the configuration file in the argument
     push     simulate key pushes given in the argument
     delete   remove the current file or selected file(s)

--- a/docstring.go
+++ b/docstring.go
@@ -66,6 +66,7 @@ The following commands are provided by lf without default keybindings:
     cd       change working directory to the argument
     select   change current file selection to the argument
     glob-select select files that match the given glob
+    glob-unselect unselect files that match the given glob
     source   read the configuration file in the argument
     push     simulate key pushes given in the argument
     delete   remove the current file or selected file(s)

--- a/docstring.go
+++ b/docstring.go
@@ -65,6 +65,7 @@ The following commands are provided by lf without default keybindings:
     echoerr  same as echomsg but red color
     cd       change working directory to the argument
     select   change current file selection to the argument
+    glob-select select files that match the given glob
     source   read the configuration file in the argument
     push     simulate key pushes given in the argument
     delete   remove the current file or selected file(s)

--- a/eval.go
+++ b/eval.go
@@ -833,6 +833,19 @@ func (e *callExpr) eval(app *app, args []string) {
 		if wd != path {
 			app.nav.marks["'"] = wd
 		}
+    case "glob-select":
+		if len(e.args) != 1 {
+			app.ui.echoerr("glob-select: requires a pattern to match")
+			return
+		}
+
+        app.nav.unselect()
+
+		if err := app.nav.globSel(e.args[0]); err != nil {
+			app.ui.echoerrf("%s", err)
+			return
+		}
+
 	case "source":
 		if len(e.args) != 1 {
 			app.ui.echoerr("source: requires an argument")

--- a/eval.go
+++ b/eval.go
@@ -839,7 +839,16 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 
-		if err := app.nav.globSel(e.args[0]); err != nil {
+		if err := app.nav.globSel(e.args[0], false); err != nil {
+			app.ui.echoerrf("%s", err)
+			return
+		}
+    case "glob-unselect":
+		if len(e.args) != 1 {
+			app.ui.echoerr("glob-unselect: requires a pattern to match")
+        }
+
+		if err := app.nav.globSel(e.args[0], true); err != nil {
 			app.ui.echoerrf("%s", err)
 			return
 		}

--- a/eval.go
+++ b/eval.go
@@ -846,6 +846,7 @@ func (e *callExpr) eval(app *app, args []string) {
 	case "glob-unselect":
 		if len(e.args) != 1 {
 			app.ui.echoerr("glob-unselect: requires a pattern to match")
+			return
 		}
 
 		if err := app.nav.globSel(e.args[0], true); err != nil {

--- a/eval.go
+++ b/eval.go
@@ -833,7 +833,7 @@ func (e *callExpr) eval(app *app, args []string) {
 		if wd != path {
 			app.nav.marks["'"] = wd
 		}
-    case "glob-select":
+	case "glob-select":
 		if len(e.args) != 1 {
 			app.ui.echoerr("glob-select: requires a pattern to match")
 			return

--- a/eval.go
+++ b/eval.go
@@ -839,7 +839,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 
-        app.nav.unselect()
+        	app.nav.unselect()
 
 		if err := app.nav.globSel(e.args[0]); err != nil {
 			app.ui.echoerrf("%s", err)

--- a/eval.go
+++ b/eval.go
@@ -839,8 +839,6 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 
-        	app.nav.unselect()
-
 		if err := app.nav.globSel(e.args[0]); err != nil {
 			app.ui.echoerrf("%s", err)
 			return

--- a/eval.go
+++ b/eval.go
@@ -843,10 +843,10 @@ func (e *callExpr) eval(app *app, args []string) {
 			app.ui.echoerrf("%s", err)
 			return
 		}
-    case "glob-unselect":
+	case "glob-unselect":
 		if len(e.args) != 1 {
 			app.ui.echoerr("glob-unselect: requires a pattern to match")
-        }
+		}
 
 		if err := app.nav.globSel(e.args[0], true); err != nil {
 			app.ui.echoerrf("%s", err)

--- a/lf.1
+++ b/lf.1
@@ -74,6 +74,7 @@ The following commands are provided by lf without default keybindings:
     echoerr  same as echomsg but red color
     cd       change working directory to the argument
     select   change current file selection to the argument
+    glob-select select files that match the given glob
     source   read the configuration file in the argument
     push     simulate key pushes given in the argument
     delete   remove the current file or selected file(s)

--- a/lf.1
+++ b/lf.1
@@ -75,6 +75,7 @@ The following commands are provided by lf without default keybindings:
     cd       change working directory to the argument
     select   change current file selection to the argument
     glob-select select files that match the given glob
+    glob-unselect unselect files that match the given glob
     source   read the configuration file in the argument
     push     simulate key pushes given in the argument
     delete   remove the current file or selected file(s)

--- a/nav.go
+++ b/nav.go
@@ -795,24 +795,24 @@ func (nav *nav) sel(path string) error {
 }
 
 func (nav *nav) globSel(pattern string) error {
-    curDir := nav.currDir()
-    anyMatches := false
+    	curDir := nav.currDir()
+    	anyMatches := false
 
-    for i := 0; i < len(curDir.files); i++ {
-        match, err := filepath.Match(pattern, curDir.files[i].Name())
+    	for i := 0; i < len(curDir.files); i++ {
+        	match, err := filepath.Match(pattern, curDir.files[i].Name())
 
-        if err != nil {
-            return fmt.Errorf("glob-select: %s", err)
-        }
-        if match {
-            anyMatches = true
-            nav.toggleSelection(filepath.Join(curDir.path, curDir.files[i].Name()))
-        }
-    }
-    if !anyMatches {
-        return fmt.Errorf("glob-select: pattern not found: %s", pattern)
-    }
-    return nil
+        	if err != nil {
+            		return fmt.Errorf("glob-select: %s", err)
+        	}
+        	if match {
+            		anyMatches = true
+            		nav.toggleSelection(filepath.Join(curDir.path, curDir.files[i].Name()))
+        	}
+    	}
+    	if !anyMatches {
+        	return fmt.Errorf("glob-select: pattern not found: %s", pattern)
+    	}
+    	return nil
 }
 
 func findMatch(name, pattern string) bool {

--- a/nav.go
+++ b/nav.go
@@ -806,7 +806,10 @@ func (nav *nav) globSel(pattern string) error {
 		}
 		if match {
 			anyMatches = true
-			nav.toggleSelection(filepath.Join(curDir.path, curDir.files[i].Name()))
+			fpath := filepath.Join(curDir.path, curDir.files[i].Name())
+			if _, ok := nav.selections[fpath]; !ok {
+				nav.toggleSelection(fpath)
+			}
 		}
 	}
 	if !anyMatches {

--- a/nav.go
+++ b/nav.go
@@ -795,24 +795,24 @@ func (nav *nav) sel(path string) error {
 }
 
 func (nav *nav) globSel(pattern string) error {
-    	curDir := nav.currDir()
-    	anyMatches := false
+	curDir := nav.currDir()
+	anyMatches := false
 
-    	for i := 0; i < len(curDir.files); i++ {
-        	match, err := filepath.Match(pattern, curDir.files[i].Name())
+	for i := 0; i < len(curDir.files); i++ {
+		match, err := filepath.Match(pattern, curDir.files[i].Name())
 
-        	if err != nil {
-            		return fmt.Errorf("glob-select: %s", err)
-        	}
-        	if match {
-            		anyMatches = true
-            		nav.toggleSelection(filepath.Join(curDir.path, curDir.files[i].Name()))
-        	}
-    	}
-    	if !anyMatches {
-        	return fmt.Errorf("glob-select: pattern not found: %s", pattern)
-    	}
-    	return nil
+		if err != nil {
+			return fmt.Errorf("glob-select: %s", err)
+		}
+		if match {
+			anyMatches = true
+			nav.toggleSelection(filepath.Join(curDir.path, curDir.files[i].Name()))
+		}
+	}
+	if !anyMatches {
+		return fmt.Errorf("glob-select: pattern not found: %s", pattern)
+	}
+	return nil
 }
 
 func findMatch(name, pattern string) bool {

--- a/nav.go
+++ b/nav.go
@@ -794,7 +794,7 @@ func (nav *nav) sel(path string) error {
 	return nil
 }
 
-func (nav *nav) globSel(pattern string) error {
+func (nav *nav) globSel(pattern string, invert bool) error {
 	curDir := nav.currDir()
 	anyMatches := false
 
@@ -807,7 +807,7 @@ func (nav *nav) globSel(pattern string) error {
 		if match {
 			anyMatches = true
 			fpath := filepath.Join(curDir.path, curDir.files[i].Name())
-			if _, ok := nav.selections[fpath]; !ok {
+			if _, ok := nav.selections[fpath]; ok == invert {
 				nav.toggleSelection(fpath)
 			}
 		}

--- a/nav.go
+++ b/nav.go
@@ -794,6 +794,27 @@ func (nav *nav) sel(path string) error {
 	return nil
 }
 
+func (nav *nav) globSel(pattern string) error {
+    curDir := nav.currDir()
+    anyMatches := false
+
+    for i := 0; i < len(curDir.files); i++ {
+        match, err := filepath.Match(pattern, curDir.files[i].Name())
+
+        if err != nil {
+            return fmt.Errorf("glob-select: %s", err)
+        }
+        if match {
+            anyMatches = true
+            nav.toggleSelection(filepath.Join(curDir.path, curDir.files[i].Name()))
+        }
+    }
+    if !anyMatches {
+        return fmt.Errorf("glob-select: pattern not found: %s", pattern)
+    }
+    return nil
+}
+
 func findMatch(name, pattern string) bool {
 	if gOpts.ignorecase {
 		lpattern := strings.ToLower(pattern)


### PR DESCRIPTION
Found time tonight to implement #181 .
Unselects before any querying is done, this was a dilemma. Let me know if you want to keep the previous selection, and instead merge them (just requires removing the .unselect() call).

It uses filepath.Match to match filenames with the pattern, simply toggle selection on that particular file.

Throws errors if 

- no arguments are given

- filepath.Match throws an error (invalid pattern)

- no matches were found (find throws a similar error)

P.S. not sure whats up with my indentation. sometimes its fine, sometimes not, any ideas?
