### PR TITLE
Mark clear

### DIFF
--- a/app.go
+++ b/app.go
@@ -181,10 +181,6 @@ func (app *app) loop() {
 
 			log.Print("bye!")
 
-			if err := app.nav.writeMarks(); err != nil {
-				log.Printf("writing marks file: %s", err)
-			}
-
 			if err := app.writeHistory(); err != nil {
 				log.Printf("writing history file: %s", err)
 			}

--- a/complete.go
+++ b/complete.go
@@ -51,7 +51,7 @@ var (
 		"search-next",
 		"search-prev",
 		"mark-save",
-        "mark-clear",
+		"mark-clear",
 		"mark-load",
 		"sync",
 		"echo",

--- a/complete.go
+++ b/complete.go
@@ -51,6 +51,7 @@ var (
 		"search-next",
 		"search-prev",
 		"mark-save",
+        "mark-clear",
 		"mark-load",
 		"sync",
 		"echo",

--- a/complete.go
+++ b/complete.go
@@ -51,7 +51,6 @@ var (
 		"search-next",
 		"search-prev",
 		"mark-save",
-        "mark-clear",
 		"mark-load",
 		"sync",
 		"echo",

--- a/complete.go
+++ b/complete.go
@@ -52,6 +52,7 @@ var (
 		"search-prev",
 		"mark-save",
 		"mark-clear",
+		"mark-remove",
 		"mark-load",
 		"sync",
 		"echo",

--- a/complete.go
+++ b/complete.go
@@ -51,7 +51,6 @@ var (
 		"search-next",
 		"search-prev",
 		"mark-save",
-		"mark-clear",
 		"mark-remove",
 		"mark-load",
 		"sync",

--- a/doc.go
+++ b/doc.go
@@ -64,6 +64,7 @@ The following commands are provided by lf without default keybindings:
     select   change current file selection to the argument
     glob-select select files that match the given glob
     glob-unselect unselect files that match the given glob
+    mark-clear remove the marks given as argument or all marks if no argument
     source   read the configuration file in the argument
     push     simulate key pushes given in the argument
     delete   remove the current file or selected file(s)

--- a/doc.go
+++ b/doc.go
@@ -64,7 +64,8 @@ The following commands are provided by lf without default keybindings:
     select   change current file selection to the argument
     glob-select select files that match the given glob
     glob-unselect unselect files that match the given glob
-    mark-clear remove the marks given as argument or all marks if no argument
+    mark-clear remove all marks
+    mark-remove remove the marks specified in the arguments
     source   read the configuration file in the argument
     push     simulate key pushes given in the argument
     delete   remove the current file or selected file(s)

--- a/doc.go
+++ b/doc.go
@@ -51,6 +51,7 @@ The following commands are provided by lf with default keybindings:
     search-prev              (default 'N')
     mark-save                (default 'm')
     mark-load                (default "'")
+    mark-remove              (default `"`)
 
 The following commands are provided by lf without default keybindings:
 
@@ -64,8 +65,6 @@ The following commands are provided by lf without default keybindings:
     select   change current file selection to the argument
     glob-select select files that match the given glob
     glob-unselect unselect files that match the given glob
-    mark-clear remove all marks
-    mark-remove remove the marks specified in the arguments
     source   read the configuration file in the argument
     push     simulate key pushes given in the argument
     delete   remove the current file or selected file(s)

--- a/docstring.go
+++ b/docstring.go
@@ -67,6 +67,7 @@ The following commands are provided by lf without default keybindings:
     select   change current file selection to the argument
     glob-select select files that match the given glob
     glob-unselect unselect files that match the given glob
+    mark-clear remove the marks given as argument or all marks if no argument
     source   read the configuration file in the argument
     push     simulate key pushes given in the argument
     delete   remove the current file or selected file(s)

--- a/docstring.go
+++ b/docstring.go
@@ -67,7 +67,8 @@ The following commands are provided by lf without default keybindings:
     select   change current file selection to the argument
     glob-select select files that match the given glob
     glob-unselect unselect files that match the given glob
-    mark-clear remove the marks given as argument or all marks if no argument
+    mark-clear remove all marks
+    mark-remove remove the marks specified in the arguments
     source   read the configuration file in the argument
     push     simulate key pushes given in the argument
     delete   remove the current file or selected file(s)

--- a/docstring.go
+++ b/docstring.go
@@ -54,6 +54,7 @@ The following commands are provided by lf with default keybindings:
     search-prev              (default 'N')
     mark-save                (default 'm')
     mark-load                (default "'")
+    mark-remove              (default '"')
 
 The following commands are provided by lf without default keybindings:
 
@@ -67,8 +68,6 @@ The following commands are provided by lf without default keybindings:
     select   change current file selection to the argument
     glob-select select files that match the given glob
     glob-unselect unselect files that match the given glob
-    mark-clear remove all marks
-    mark-remove remove the marks specified in the arguments
     source   read the configuration file in the argument
     push     simulate key pushes given in the argument
     delete   remove the current file or selected file(s)

--- a/eval.go
+++ b/eval.go
@@ -772,9 +772,15 @@ func (e *callExpr) eval(app *app, args []string) {
 			app.ui.echoerrf("mark-clear: %s", err)
 			return
 		}
-		app.nav.writeMarks()
+		if err := app.nav.writeMarks(); err != nil {
+			app.ui.echoerrf("mark-clear: %s", err)
+			return
+		}
 		if msg != "" {
-			remote("send " + msg)
+			if err := remote("send " + msg); err != nil {
+				app.ui.echoerrf("mark-clear: %s", err)
+				return
+			}
 		}
 	case "sync":
 		if err := app.nav.sync(); err != nil {

--- a/eval.go
+++ b/eval.go
@@ -470,6 +470,7 @@ func insert(app *app, arg string) {
 			return
 		}
 		app.nav.marks[arg] = wd
+
 	case app.ui.cmdPrefix == "mark-load: ":
 		normal(app)
 
@@ -766,6 +767,24 @@ func (e *callExpr) eval(app *app, args []string) {
 	case "mark-load":
 		app.ui.menuBuf = listMarks(app.nav.marks)
 		app.ui.cmdPrefix = "mark-load: "
+    case "mark-clear":
+        if len(app.nav.marks) != 0 {
+            if (len(args) != 0) {
+                for _, v:= range args {
+                    if _, ok := app.nav.marks[v]; ok {
+                        delete(app.nav.marks, v)
+                    }
+                }
+            } else {
+                app.ui.echoerrf("removing everything")
+                os.Create(gMarksPath)
+                app.nav.marks = make(map[string]string)
+                if err := remote("send mark-clear " + strings.Join(args[:], " ")); err != nil {
+                    app.ui.echoerrf("remote mark-clear: %s", err)
+                    return
+                }
+            }
+        }
 	case "sync":
 		if err := app.nav.sync(); err != nil {
 			app.ui.echoerrf("sync: %s", err)

--- a/eval.go
+++ b/eval.go
@@ -767,24 +767,16 @@ func (e *callExpr) eval(app *app, args []string) {
 	case "mark-load":
 		app.ui.menuBuf = listMarks(app.nav.marks)
 		app.ui.cmdPrefix = "mark-load: "
-    case "mark-clear":
-        if len(app.nav.marks) != 0 {
-            if (len(args) != 0) {
-                for _, v:= range args {
-                    if _, ok := app.nav.marks[v]; ok {
-                        delete(app.nav.marks, v)
-                    }
-                }
-            } else {
-                app.ui.echoerrf("removing everything")
-                os.Create(gMarksPath)
-                app.nav.marks = make(map[string]string)
-                if err := remote("send mark-clear " + strings.Join(args[:], " ")); err != nil {
-                    app.ui.echoerrf("remote mark-clear: %s", err)
-                    return
-                }
-            }
-        }
+	case "mark-clear":
+		msg, err := app.nav.clearMarks(e.args)
+		if err != nil {
+			app.ui.echoerrf("mark-clear: %s", err)
+			return
+		}
+		app.nav.writeMarks()
+		if msg != "" {
+			remote("send " + msg)
+		}
 	case "sync":
 		if err := app.nav.sync(); err != nil {
 			app.ui.echoerrf("sync: %s", err)

--- a/eval.go
+++ b/eval.go
@@ -470,7 +470,6 @@ func insert(app *app, arg string) {
 			return
 		}
 		app.nav.marks[arg] = wd
-
 	case app.ui.cmdPrefix == "mark-load: ":
 		normal(app)
 

--- a/eval.go
+++ b/eval.go
@@ -470,6 +470,12 @@ func insert(app *app, arg string) {
 			return
 		}
 		app.nav.marks[arg] = wd
+		if err := app.nav.writeMarks(); err != nil {
+			app.ui.echoerrf("mark-save: %s", err)
+		}
+		if err := remote("send sync"); err != nil {
+			app.ui.echoerrf("mark-save: %s", err)
+		}
 	case app.ui.cmdPrefix == "mark-load: ":
 		normal(app)
 
@@ -493,6 +499,20 @@ func insert(app *app, arg string) {
 		if wd != path {
 			app.nav.marks["'"] = wd
 		}
+	case app.ui.cmdPrefix == "mark-remove: ":
+		normal(app)
+		if err := app.nav.removeMark(arg); err != nil {
+			app.ui.echoerrf("mark-remove: %s", err)
+			return
+		}
+		if err := app.nav.writeMarks(); err != nil {
+			app.ui.echoerrf("mark-remove: %s", err)
+			return
+		}
+		if err := remote("send sync"); err != nil {
+			app.ui.echoerrf("mark-remove: %s", err)
+		}
+
 	default:
 		app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(arg)...)
 	}
@@ -766,30 +786,9 @@ func (e *callExpr) eval(app *app, args []string) {
 	case "mark-load":
 		app.ui.menuBuf = listMarks(app.nav.marks)
 		app.ui.cmdPrefix = "mark-load: "
-	case "mark-clear":
-		shouldRemote, err := app.nav.clearMarks()
-		if err != nil {
-			app.ui.echoerrf("mark-clear: %s", err)
-			return
-		}
-		if shouldRemote {
-			if err := remote("send mark-clear"); err != nil {
-				app.ui.echoerrf("mark-clear: %s", err)
-				return
-			}
-		}
 	case "mark-remove":
-		for _, v := range e.args {
-			if shouldRemote, err := app.nav.removeMark(v); err != nil {
-				app.ui.echoerrf("mark-remove: %s", err)
-				return
-			} else if shouldRemote {
-				if err := remote("send mark-remove " + v); err != nil {
-					app.ui.echoerrf("mark-remove: %s", err)
-					return
-				}
-			}
-		}
+		app.ui.menuBuf = listMarks(app.nav.marks)
+		app.ui.cmdPrefix = "mark-remove: "
 	case "sync":
 		if err := app.nav.sync(); err != nil {
 			app.ui.echoerrf("sync: %s", err)

--- a/eval.go
+++ b/eval.go
@@ -470,7 +470,6 @@ func insert(app *app, arg string) {
 			return
 		}
 		app.nav.marks[arg] = wd
-
 	case app.ui.cmdPrefix == "mark-load: ":
 		normal(app)
 
@@ -767,24 +766,6 @@ func (e *callExpr) eval(app *app, args []string) {
 	case "mark-load":
 		app.ui.menuBuf = listMarks(app.nav.marks)
 		app.ui.cmdPrefix = "mark-load: "
-    case "mark-clear":
-        if len(app.nav.marks) != 0 {
-            if (len(args) != 0) {
-                for _, v:= range args {
-                    if _, ok := app.nav.marks[v]; ok {
-                        delete(app.nav.marks, v)
-                    }
-                }
-            } else {
-                app.ui.echoerrf("removing everything")
-                os.Create(gMarksPath)
-                app.nav.marks = make(map[string]string)
-                if err := remote("send mark-clear " + strings.Join(args[:], " ")); err != nil {
-                    app.ui.echoerrf("remote mark-clear: %s", err)
-                    return
-                }
-            }
-        }
 	case "sync":
 		if err := app.nav.sync(); err != nil {
 			app.ui.echoerrf("sync: %s", err)

--- a/eval.go
+++ b/eval.go
@@ -767,19 +767,27 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.ui.menuBuf = listMarks(app.nav.marks)
 		app.ui.cmdPrefix = "mark-load: "
 	case "mark-clear":
-		msg, err := app.nav.clearMarks(e.args)
+		shouldRemote, err := app.nav.clearMarks()
 		if err != nil {
 			app.ui.echoerrf("mark-clear: %s", err)
 			return
 		}
-		if err := app.nav.writeMarks(); err != nil {
-			app.ui.echoerrf("mark-clear: %s", err)
-			return
-		}
-		if msg != "" {
-			if err := remote("send " + msg); err != nil {
+		if shouldRemote {
+			if err := remote("send mark-clear"); err != nil {
 				app.ui.echoerrf("mark-clear: %s", err)
 				return
+			}
+		}
+	case "mark-remove":
+		for _, v := range e.args {
+			if shouldRemote, err := app.nav.removeMark(v); err != nil {
+				app.ui.echoerrf("mark-remove: %s", err)
+				return
+			} else if shouldRemote {
+				if err := remote("send mark-remove " + v); err != nil {
+					app.ui.echoerrf("mark-remove: %s", err)
+					return
+				}
 			}
 		}
 	case "sync":

--- a/lf.1
+++ b/lf.1
@@ -76,6 +76,7 @@ The following commands are provided by lf without default keybindings:
     select   change current file selection to the argument
     glob-select select files that match the given glob
     glob-unselect unselect files that match the given glob
+    mark-clear remove the marks given as argument or all marks if no argument
     source   read the configuration file in the argument
     push     simulate key pushes given in the argument
     delete   remove the current file or selected file(s)

--- a/lf.1
+++ b/lf.1
@@ -61,6 +61,7 @@ The following commands are provided by lf with default keybindings:
     search-prev              (default 'N')
     mark-save                (default 'm')
     mark-load                (default "'")
+    mark-remove              (default `"`)
 .EE
 .PP
 The following commands are provided by lf without default keybindings:
@@ -76,8 +77,6 @@ The following commands are provided by lf without default keybindings:
     select   change current file selection to the argument
     glob-select select files that match the given glob
     glob-unselect unselect files that match the given glob
-    mark-clear remove all marks
-    mark-remove remove the marks specified in the arguments
     source   read the configuration file in the argument
     push     simulate key pushes given in the argument
     delete   remove the current file or selected file(s)

--- a/lf.1
+++ b/lf.1
@@ -76,7 +76,8 @@ The following commands are provided by lf without default keybindings:
     select   change current file selection to the argument
     glob-select select files that match the given glob
     glob-unselect unselect files that match the given glob
-    mark-clear remove the marks given as argument or all marks if no argument
+    mark-clear remove all marks
+    mark-remove remove the marks specified in the arguments
     source   read the configuration file in the argument
     push     simulate key pushes given in the argument
     delete   remove the current file or selected file(s)

--- a/nav.go
+++ b/nav.go
@@ -980,15 +980,7 @@ func (nav *nav) clearMarks(badMarks []string) (string, error) {
 		return "", nil
 	}
 	remoteMsg := ""         // msg that needs to be sent to the server
-	if len(badMarks) == 0 { // clear all marks
-		f, err := os.Create(gMarksPath)
-		if err != nil {
-			return "", fmt.Errorf("recreating marks file: %s", err)
-		}
-		defer f.Close()
-		nav.marks = make(map[string]string)
-		remoteMsg = "mark-clear"
-	} else { // clear the marks supplied in the arguments
+	if len(badMarks) != 0 { // clear the marks supplied in the arguments
 		for _, v := range badMarks {
 			if len(v) != 1 {
 				return "", fmt.Errorf("wrong argument (must be one character): %s", v)
@@ -1000,6 +992,17 @@ func (nav *nav) clearMarks(badMarks []string) (string, error) {
 				}
 				remoteMsg += " " + v
 			}
+		}
+	}
+	if len(badMarks) == 0 || len(nav.marks) == 0 { // clear all marks
+		f, err := os.Create(gMarksPath)
+		if err != nil {
+			return "", fmt.Errorf("recreating marks file: %s", err)
+		}
+		defer f.Close()
+		nav.marks = make(map[string]string)
+		if remoteMsg == "" {
+			remoteMsg = "mark-clear"
 		}
 	}
 	return remoteMsg, nil

--- a/nav.go
+++ b/nav.go
@@ -1010,20 +1010,7 @@ func (nav *nav) readMarks() error {
 	return nil
 }
 
-func resetMarksFile() error {
-	f, err := os.Create(gMarksPath)
-	if err != nil {
-		return fmt.Errorf("recreating marks file: %s", err)
-	}
-	f.Close()
-	return nil
-}
-
 func (nav *nav) writeMarks() error {
-	if len(nav.marks) == 0 {
-		return resetMarksFile()
-	}
-
 	if err := os.MkdirAll(filepath.Dir(gMarksPath), os.ModePerm); err != nil {
 		return fmt.Errorf("creating data directory: %s", err)
 	}

--- a/nav.go
+++ b/nav.go
@@ -747,9 +747,7 @@ func (nav *nav) sync() error {
 		nav.saves[f] = cp
 	}
 
-	nav.readMarks()
-
-	return nil
+	return nav.readMarks()
 }
 
 func (nav *nav) cd(wd string) error {

--- a/nav.go
+++ b/nav.go
@@ -976,11 +976,11 @@ func (nav *nav) searchPrev() error {
 }
 
 func (nav *nav) clearMarks(badMarks []string) (string, error) {
-	if len(nav.marks) == 0 { // to stop recursive remote calls
+	if len(nav.marks) == 0 { // to stop infinite remote calls
 		return "", nil
 	}
-	remoteMsg := ""
-	if len(badMarks) == 0 {
+	remoteMsg := "" // msg that needs to be sent to the server
+	if len(badMarks) == 0 { // clear all marks
 		f, err := os.Create(gMarksPath)
 		if err != nil {
 			return "", fmt.Errorf("recreating marks file: %s", err)
@@ -988,7 +988,7 @@ func (nav *nav) clearMarks(badMarks []string) (string, error) {
 		defer f.Close()
 		nav.marks = make(map[string]string)
 		remoteMsg = "mark-clear"
-	} else {
+	} else { // clear the marks supplied in the arguments
 		for _, v := range badMarks {
 			if _, ok := nav.marks[v]; ok {
 				delete(nav.marks, v)

--- a/nav.go
+++ b/nav.go
@@ -979,7 +979,7 @@ func (nav *nav) clearMarks(badMarks []string) (string, error) {
 	if len(nav.marks) == 0 { // to stop infinite remote calls
 		return "", nil
 	}
-	remoteMsg := "" // msg that needs to be sent to the server
+	remoteMsg := ""         // msg that needs to be sent to the server
 	if len(badMarks) == 0 { // clear all marks
 		f, err := os.Create(gMarksPath)
 		if err != nil {

--- a/nav.go
+++ b/nav.go
@@ -975,6 +975,33 @@ func (nav *nav) searchPrev() error {
 	return nil
 }
 
+func (nav *nav) clearMarks(badMarks []string) (string, error) {
+	if len(nav.marks) == 0 { // to stop recursive remote calls
+		return "", nil
+	}
+	remoteMsg := ""
+	if len(badMarks) == 0 {
+		f, err := os.Create(gMarksPath)
+		if err != nil {
+			return "", fmt.Errorf("recreating marks file: %s", err)
+		}
+		defer f.Close()
+		nav.marks = make(map[string]string)
+		remoteMsg = "mark-clear"
+	} else {
+		for _, v := range badMarks {
+			if _, ok := nav.marks[v]; ok {
+				delete(nav.marks, v)
+				if remoteMsg == "" {
+					remoteMsg = "mark-clear"
+				}
+				remoteMsg += " " + v
+			}
+		}
+	}
+	return remoteMsg, nil
+}
+
 func (nav *nav) readMarks() error {
 	f, err := os.Open(gMarksPath)
 	if os.IsNotExist(err) {

--- a/nav.go
+++ b/nav.go
@@ -979,7 +979,7 @@ func (nav *nav) clearMarks() (bool, error) {
 	if len(nav.marks) == 0 { // to stop infinite remote calls
 		return false, nil
 	}
-    resetMarksFile()
+	resetMarksFile()
 	nav.marks = make(map[string]string)
 	return true, nil
 }
@@ -992,11 +992,11 @@ func (nav *nav) removeMark(mark string) (bool, error) {
 	if ok {
 		delete(nav.marks, mark)
 	}
-    if len(nav.marks) == 0 { // writeMarks will not process these marks
-        if err := resetMarksFile(); err != nil {
-            return false, err
-        }
-    }
+	if len(nav.marks) == 0 { // writeMarks will not process these marks
+		if err := resetMarksFile(); err != nil {
+			return false, err
+		}
+	}
 	return ok, nil
 }
 
@@ -1006,7 +1006,7 @@ func resetMarksFile() error {
 		return fmt.Errorf("recreating marks file: %s", err)
 	}
 	f.Close()
-    return nil
+	return nil
 }
 
 func (nav *nav) readMarks() error {

--- a/nav.go
+++ b/nav.go
@@ -990,6 +990,9 @@ func (nav *nav) clearMarks(badMarks []string) (string, error) {
 		remoteMsg = "mark-clear"
 	} else { // clear the marks supplied in the arguments
 		for _, v := range badMarks {
+			if len(v) != 1 {
+				return "", fmt.Errorf("wrong argument (must be one character): %s", v)
+			}
 			if _, ok := nav.marks[v]; ok {
 				delete(nav.marks, v)
 				if remoteMsg == "" {

--- a/opts.go
+++ b/opts.go
@@ -137,6 +137,7 @@ func init() {
 	gOpts.keys["N"] = &callExpr{"search-prev", nil, 1}
 	gOpts.keys["m"] = &callExpr{"mark-save", nil, 1}
 	gOpts.keys["'"] = &callExpr{"mark-load", nil, 1}
+	gOpts.keys[`"`] = &callExpr{"mark-remove", nil, 1}
 	gOpts.keys["<c-n>"] = &callExpr{"cmd-history-next", nil, 1}
 	gOpts.keys["<c-p>"] = &callExpr{"cmd-history-prev", nil, 1}
 

--- a/server.go
+++ b/server.go
@@ -113,7 +113,6 @@ func handleConn(c net.Conn) {
 					}
 				}
 			}
-
 		case "quit":
 			gQuitChan <- true
 			for _, c := range gConnList {

--- a/server.go
+++ b/server.go
@@ -113,6 +113,7 @@ func handleConn(c net.Conn) {
 					}
 				}
 			}
+
 		case "quit":
 			gQuitChan <- true
 			for _, c := range gConnList {


### PR DESCRIPTION
Implements the mark-clear functionality discussed in #188 .

Two scenarios:

- No arguments supplied: clear all marks

- Arguments (the keys of the mapping) supplied: clear those

The new marks are written to the marks file.
If non-existing marks are supplied, then they are ignored. Related to that, since mark-save does not synchronize between clients, there is a case that there is a mark on one client that is not on the other. Therefore, I thought that throwing an error and stopping the process is unnecessary. 
Consider case client1 has marks with keys :*o*,*p*, but client 2 has only mark *o*. If client 2 calls to delete mark *p* (in order to clear it from client1) then its simply not gonna happen (see how `remoteMsg` is built). Do you want this to act differently?

Afterward, initiate the same call to the server, to update the other clients.

I believe, that to make this mark synchronization feel even better, we should also update clients when we create a new mark (however, I could not figure out how to do that yet). This would also deal with some edge cases like previously described with client1 and client2.