### PR TITLE
Error clear

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -496,6 +496,7 @@ func insert(app *app, arg string) {
 	default:
 		app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(arg)...)
 	}
+	app.ui.loadFileInfo(app.nav)
 }
 
 func (e *callExpr) eval(app *app, args []string) {

--- a/ui.go
+++ b/ui.go
@@ -667,7 +667,6 @@ func (ui *ui) draw(nav *nav) {
 		ui.msgWin.print(len(ui.cmdPrefix)+len(ui.msg)+runeSliceWidth(ui.cmdAccLeft), 0, fg, bg, string(ui.cmdAccRight))
 		termbox.SetCursor(ui.msgWin.x+len(ui.cmdPrefix)+len(ui.msg)+runeSliceWidth(ui.cmdAccLeft), ui.msgWin.y)
 	default:
-		ui.msg = ""
 		ui.msgWin.printLine(0, 0, fg, bg, ui.cmdPrefix)
 		ui.msgWin.print(len(ui.cmdPrefix), 0, fg, bg, string(ui.cmdAccLeft))
 		ui.msgWin.print(len(ui.cmdPrefix)+runeSliceWidth(ui.cmdAccLeft), 0, fg, bg, string(ui.cmdAccRight))

--- a/ui.go
+++ b/ui.go
@@ -667,6 +667,7 @@ func (ui *ui) draw(nav *nav) {
 		ui.msgWin.print(len(ui.cmdPrefix)+len(ui.msg)+runeSliceWidth(ui.cmdAccLeft), 0, fg, bg, string(ui.cmdAccRight))
 		termbox.SetCursor(ui.msgWin.x+len(ui.cmdPrefix)+len(ui.msg)+runeSliceWidth(ui.cmdAccLeft), ui.msgWin.y)
 	default:
+		ui.msg = ""
 		ui.msgWin.printLine(0, 0, fg, bg, ui.cmdPrefix)
 		ui.msgWin.print(len(ui.cmdPrefix), 0, fg, bg, string(ui.cmdAccLeft))
 		ui.msgWin.print(len(ui.cmdPrefix)+runeSliceWidth(ui.cmdAccLeft), 0, fg, bg, string(ui.cmdAccRight))


### PR DESCRIPTION
Apparantely, the error clearing was not fixed entirely.
More specifically, it did not work for the modal commands.
See gif for example:
http://0x0.st/z_NH.jwgac3a
