### PR TITLE
draft rename

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -53,6 +53,7 @@ var (
 		"mark-save",
 		"mark-remove",
 		"mark-load",
+		"rename",
 		"sync",
 		"echo",
 		"echomsg",

--- a/doc.go
+++ b/doc.go
@@ -37,6 +37,7 @@ The following commands are provided by lf with default keybindings:
     redraw                   (default '<c-l>')
     reload                   (default '<c-r>')
     read                     (default ':')
+    rename                   (default 'r')
     shell                    (default '$')
     shell-pipe               (default '%')
     shell-wait               (default '!')

--- a/docstring.go
+++ b/docstring.go
@@ -40,6 +40,7 @@ The following commands are provided by lf with default keybindings:
     redraw                   (default '<c-l>')
     reload                   (default '<c-r>')
     read                     (default ':')
+    rename                   (default 'r')
     shell                    (default '$')
     shell-pipe               (default '%')
     shell-wait               (default '!')

--- a/eval.go
+++ b/eval.go
@@ -1048,10 +1048,12 @@ func (e *callExpr) eval(app *app, args []string) {
 				newPathTo := filepath.Join(wd, s)
 
 				if dir, _ := filepath.Split(newPathTo); dir != "" {
+					// TODO: prompt
 					os.MkdirAll(dir, os.ModePerm)
 				}
 
-				// TODO: make directories if necessary
+				// TODO: prompt if such renamed file exists alrdy
+
 				if err := os.Rename(oldPathTo, newPathTo); err != nil {
 					app.ui.echoerrf("rename: %s", err)
 				}

--- a/eval.go
+++ b/eval.go
@@ -387,7 +387,6 @@ func update(app *app) {
 		app.ui.loadFile(app.nav)
 		app.ui.loadFileInfo(app.nav)
 	}
-
 }
 
 func normal(app *app) {

--- a/eval.go
+++ b/eval.go
@@ -387,6 +387,7 @@ func update(app *app) {
 		app.ui.loadFile(app.nav)
 		app.ui.loadFileInfo(app.nav)
 	}
+
 }
 
 func normal(app *app) {
@@ -523,7 +524,8 @@ func insert(app *app, arg string) {
 		if err := remote("send sync"); err != nil {
 			app.ui.echoerrf("mark-remove: %s", err)
 		}
-
+	case strings.HasPrefix(app.ui.cmdPrefix, "rename"):
+		app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(arg)...)
 	default:
 		app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(arg)...)
 	}
@@ -818,6 +820,15 @@ func (e *callExpr) eval(app *app, args []string) {
 	case "mark-remove":
 		app.ui.menuBuf = listMarks(app.nav.marks)
 		app.ui.cmdPrefix = "mark-remove: "
+	case "rename":
+		if curr, err := app.nav.currFile(); err != nil {
+			app.ui.echoerrf("rename: %s:", err)
+			return
+		} else {
+			app.ui.cmdPrefix = "rename: "
+			app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(curr.Name())...)
+		}
+
 	case "sync":
 		if err := app.nav.sync(); err != nil {
 			app.ui.echoerrf("sync: %s", err)
@@ -1029,6 +1040,10 @@ func (e *callExpr) eval(app *app, args []string) {
 				app.ui.loadFile(app.nav)
 				app.ui.loadFileInfo(app.nav)
 			}
+		case "rename: ":
+			app.ui.cmdPrefix = ""
+			// TODO: do rename
+			return
 		default:
 			log.Printf("entering unknown execution prefix: %q", app.ui.cmdPrefix)
 		}

--- a/eval.go
+++ b/eval.go
@@ -524,8 +524,6 @@ func insert(app *app, arg string) {
 		if err := remote("send sync"); err != nil {
 			app.ui.echoerrf("mark-remove: %s", err)
 		}
-	case strings.HasPrefix(app.ui.cmdPrefix, "rename"):
-		app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(arg)...)
 	default:
 		app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(arg)...)
 	}
@@ -1042,8 +1040,18 @@ func (e *callExpr) eval(app *app, args []string) {
 			}
 		case "rename: ":
 			app.ui.cmdPrefix = ""
-			// TODO: do rename
-			return
+			if curr, err := app.nav.currFile(); err != nil {
+				app.ui.echoerrf("rename: %s", err)
+			} else {
+				wd, _ := os.Getwd()
+				oldPathTo := filepath.Join(wd, curr.Name())
+				newPathTo := filepath.Join(wd, s)
+				// TODO: make directories if necessary
+				if err := os.Rename(oldPathTo, newPathTo); err != nil {
+					app.ui.echoerrf("rename: %s", err)
+				}
+				// TODO: change selection
+			}
 		default:
 			log.Printf("entering unknown execution prefix: %q", app.ui.cmdPrefix)
 		}

--- a/eval.go
+++ b/eval.go
@@ -1046,6 +1046,11 @@ func (e *callExpr) eval(app *app, args []string) {
 				wd, _ := os.Getwd()
 				oldPathTo := filepath.Join(wd, curr.Name())
 				newPathTo := filepath.Join(wd, s)
+
+				if dir, _ := filepath.Split(newPathTo); dir != "" {
+					os.MkdirAll(dir, os.ModePerm)
+				}
+
 				// TODO: make directories if necessary
 				if err := os.Rename(oldPathTo, newPathTo); err != nil {
 					app.ui.echoerrf("rename: %s", err)

--- a/lf.1
+++ b/lf.1
@@ -47,6 +47,7 @@ The following commands are provided by lf with default keybindings:
     redraw                   (default '<c-l>')
     reload                   (default '<c-r>')
     read                     (default ':')
+    rename                   (default 'r')
     shell                    (default '$')
     shell-pipe               (default '%')
     shell-wait               (default '!')

--- a/nav.go
+++ b/nav.go
@@ -757,6 +757,8 @@ func (nav *nav) rename(ui *ui) error {
 	if err := nav.sel(newPath); err != nil {
 		return err
 	}
+	ui.loadFile(nav)
+	ui.loadFileInfo(nav)
 	return nil
 }
 

--- a/nav.go
+++ b/nav.go
@@ -738,7 +738,18 @@ func (nav *nav) del() error {
 	return nil
 }
 
-func (nav *nav) rename(oldPath, newPath string, ui *ui) error {
+func (nav *nav) rename(ui *ui) error {
+	oldPath := nav.renameCache[0]
+	newPath := nav.renameCache[1]
+	if dir, _ := filepath.Split(newPath); dir != "" {
+		os.MkdirAll(dir, os.ModePerm)
+	}
+
+	if _, err := os.Stat(newPath); err == nil { // file exists
+		if err := os.Remove(newPath); err != nil {
+			return err
+		}
+	}
 	if err := os.Rename(oldPath, newPath); err != nil {
 		return err
 	}

--- a/nav.go
+++ b/nav.go
@@ -205,6 +205,7 @@ type nav struct {
 	regCache      map[string]*reg
 	saves         map[string]bool
 	marks         map[string]string
+	renameCache   []string
 	selections    map[string]int
 	selectionInd  int
 	height        int
@@ -291,6 +292,7 @@ func newNav(height int) *nav {
 		regCache:      make(map[string]*reg),
 		saves:         make(map[string]bool),
 		marks:         make(map[string]string),
+		renameCache:   make([]string, 2),
 		selections:    make(map[string]int),
 		selectionInd:  0,
 		height:        height,
@@ -732,6 +734,17 @@ func (nav *nav) del() error {
 			return err
 		}
 	}
+
+	return nil
+}
+
+func (nav *nav) rename(oldPath, newPath string, ui *ui) error {
+	if err := os.Rename(oldPath, newPath); err != nil {
+		return err
+	}
+	// TODO: change selection
+	ui.loadFile(nav)
+	ui.loadFileInfo(nav)
 
 	return nil
 }

--- a/nav.go
+++ b/nav.go
@@ -741,9 +741,8 @@ func (nav *nav) del() error {
 func (nav *nav) rename(ui *ui) error {
 	oldPath := nav.renameCache[0]
 	newPath := nav.renameCache[1]
-	if dir, _ := filepath.Split(newPath); dir != "" {
-		os.MkdirAll(dir, os.ModePerm)
-	}
+	dir, _ := filepath.Split(newPath)
+	os.MkdirAll(dir, os.ModePerm)
 
 	if _, err := os.Stat(newPath); err == nil { // file exists
 		if err := os.Remove(newPath); err != nil {
@@ -753,10 +752,11 @@ func (nav *nav) rename(ui *ui) error {
 	if err := os.Rename(oldPath, newPath); err != nil {
 		return err
 	}
+	nav.renew()
 	// TODO: change selection
-	ui.loadFile(nav)
-	ui.loadFileInfo(nav)
-
+	if err := nav.sel(newPath); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/opts.go
+++ b/opts.go
@@ -140,7 +140,7 @@ func init() {
 	gOpts.keys["m"] = &callExpr{"mark-save", nil, 1}
 	gOpts.keys["'"] = &callExpr{"mark-load", nil, 1}
 	gOpts.keys[`"`] = &callExpr{"mark-remove", nil, 1}
-	gOpts.keys[`R`] = &callExpr{"rename", nil, 1}
+	gOpts.keys[`r`] = &callExpr{"rename", nil, 1}
 	gOpts.keys["<c-n>"] = &callExpr{"cmd-history-next", nil, 1}
 	gOpts.keys["<c-p>"] = &callExpr{"cmd-history-prev", nil, 1}
 

--- a/opts.go
+++ b/opts.go
@@ -140,6 +140,7 @@ func init() {
 	gOpts.keys["m"] = &callExpr{"mark-save", nil, 1}
 	gOpts.keys["'"] = &callExpr{"mark-load", nil, 1}
 	gOpts.keys[`"`] = &callExpr{"mark-remove", nil, 1}
+	gOpts.keys[`R`] = &callExpr{"rename", nil, 1}
 	gOpts.keys["<c-n>"] = &callExpr{"cmd-history-next", nil, 1}
 	gOpts.keys["<c-p>"] = &callExpr{"cmd-history-prev", nil, 1}
 


### PR DESCRIPTION
Done:

> It should add the current filename to the execution line with the cursor at the end

> It should work with filenames with spaces without the need for quotes

> It should use the underlying operating system call with os.Rename

- Create parent path when renamed to a path

> We should ideally check the destination file existence before and prompt user for an overwrite for safety, kind of like the same prompt mechanism as delete.

TODO:

> It should move the current file selection to the same file if its position is changed

Prompt for creating parent directories

-------------------------------

Prompting for creating the parent directories could get messy with current structure,  let me know if we want to do that at all or if you have any nice ideas on how to do it.

Moving the file selection to the renamed file with `app.nav.sel`, I could not get it working, if you have any ideas let me know.

