### PR TITLE
correct message for folders that lf has no permission for (#202)

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -82,6 +82,7 @@ type dir struct {
 	files    []*file   // displayed files in directory including or excluding hidden ones
 	allFiles []*file   // all files in directory including hidden ones (same array as files)
 	sortType sortType  // sort method and options from last sort
+	noPerm   bool      // whether lf has no permission to open the directory
 }
 
 func newDir(path string) *dir {
@@ -97,6 +98,7 @@ func newDir(path string) *dir {
 		path:     path,
 		files:    files,
 		allFiles: files,
+		noPerm:   os.IsPermission(err),
 	}
 }
 

--- a/ui.go
+++ b/ui.go
@@ -251,6 +251,11 @@ func (win *win) printDir(dir *dir, selections map[string]int, saves map[string]b
 		return
 	}
 
+	if dir.noPerm {
+		win.print(2, 0, termbox.AttrReverse, termbox.ColorDefault, "permission denied")
+		return
+	}
+
 	if len(dir.files) == 0 {
 		win.print(2, 0, termbox.AttrReverse, termbox.ColorDefault, "empty")
 		return


### PR DESCRIPTION
Fixes #202 .

 Store whether the `err` returned (when reading the dir) is a permission error, if so, then ui will output permission denied. 