### PR TITLE
Prepare lf to use stpv (image previews)

### DIFF
--- a/app.go
+++ b/app.go
@@ -32,7 +32,9 @@ type app struct {
 
 func newApp() *app {
 	ui := newUI()
-	nav := newNav(ui.wins[0].h)
+	// TODO: is this really the right way?
+	lastWin := ui.wins[len(ui.wins)-1]
+	nav := newNav(lastWin.w, lastWin.h, lastWin.x, lastWin.y)
 
 	return &app{
 		ui:       ui,

--- a/complete.go
+++ b/complete.go
@@ -132,6 +132,7 @@ var (
 		"filesep",
 		"ifs",
 		"previewer",
+		"cleaner",
 		"promptfmt",
 		"shell",
 		"sortby",

--- a/eval.go
+++ b/eval.go
@@ -233,6 +233,8 @@ func (e *setExpr) eval(app *app, args []string) {
 		gOpts.ifs = e.val
 	case "previewer":
 		gOpts.previewer = strings.Replace(e.val, "~", gUser.HomeDir, -1)
+	case "cleaner":
+		gOpts.cleaner = strings.Replace(e.val, "~", gUser.HomeDir, -1)
 	case "promptfmt":
 		gOpts.promptfmt = e.val
 	case "shell":

--- a/nav.go
+++ b/nav.go
@@ -12,7 +12,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -398,15 +397,10 @@ func (nav *nav) preview() {
 
 		defer func() {
 			if err := cmd.Wait(); err != nil {
-				if exiterr, ok := err.(*exec.ExitError); ok {
-					if stat, ok := exiterr.Sys().(syscall.WaitStatus); ok {
-						status := stat.ExitStatus()
-						if status == 5 {
-							nav.regCache[curr.path].volatile = true
-							nav.regCache[curr.path].loading = false
-							nav.regChan <- nav.regCache[curr.path]
-						}
-					}
+				if cmd.ProcessState.ExitCode() == 5 {
+					nav.regCache[curr.path].volatile = true
+					nav.regCache[curr.path].loading = false
+					nav.regChan <- nav.regCache[curr.path]
 				} else {
 					log.Printf("previewing file: %s", err)
 				}

--- a/nav.go
+++ b/nav.go
@@ -367,9 +367,8 @@ func (nav *nav) position() {
 }
 
 func (nav *nav) previewClear() {
-	// TODO: maybe add an option for this to reduce calls?
-	if len(gOpts.previewer) != 0 {
-		exec.Command(gOpts.previewer, "--clear", strconv.Itoa(gClientID)).Start()
+	if len(gOpts.cleaner) != 0 {
+		exec.Command(gOpts.cleaner, strconv.Itoa(gClientID)).Start()
 	}
 }
 
@@ -443,7 +442,7 @@ func (nav *nav) preview() {
 }
 
 func (nav *nav) loadReg(ui *ui, path string) *reg {
-	go nav.previewClear()
+	nav.previewClear()
 	r, ok := nav.regCache[path]
 	if !ok || r.volatile {
 		go nav.preview()

--- a/opts.go
+++ b/opts.go
@@ -49,6 +49,7 @@ var gOpts struct {
 	filesep        string
 	ifs            string
 	previewer      string
+	cleaner        string
 	promptfmt      string
 	shell          string
 	timefmt        string
@@ -86,6 +87,7 @@ func init() {
 	gOpts.filesep = "\n"
 	gOpts.ifs = ""
 	gOpts.previewer = ""
+	gOpts.cleaner = ""
 	gOpts.promptfmt = "\033[32;1m%u@%h\033[0m:\033[34;1m%w/\033[0m\033[1m%f\033[0m"
 	gOpts.shell = gDefaultShell
 	gOpts.timefmt = time.ANSIC

--- a/ui.go
+++ b/ui.go
@@ -524,6 +524,7 @@ type reg struct {
 	loadTime time.Time
 	path     string
 	lines    []string
+	volatile bool
 }
 
 func (ui *ui) loadFile(nav *nav) {
@@ -538,6 +539,7 @@ func (ui *ui) loadFile(nav *nav) {
 
 	if curr.IsDir() {
 		ui.dirPrev = nav.loadDir(curr.path)
+		go nav.previewClear()
 	} else if curr.Mode().IsRegular() {
 		ui.regPrev = nav.loadReg(ui, curr.path)
 	}

--- a/ui.go
+++ b/ui.go
@@ -539,7 +539,7 @@ func (ui *ui) loadFile(nav *nav) {
 
 	if curr.IsDir() {
 		ui.dirPrev = nav.loadDir(curr.path)
-		go nav.previewClear()
+		nav.previewClear()
 	} else if curr.Mode().IsRegular() {
 		ui.regPrev = nav.loadReg(ui, curr.path)
 	}


### PR DESCRIPTION
Finally image previews working! #134

This does not add the functionality of previewing images to LF, it only provide the right environment for the scripts to do their work.

From my quick test, it works. It needs [THIS](https://github.com/Naheel-Azawy/stpv), `set previewer stpv`, and LF launched as @gokcehan mentioned in the issue comments:

```
fid="$(mktemp)"
lf -command '$printf $id > '"$fid"'; stpvimg --listen $id &' -last-dir-path="$tmp" "$@"
stpvimg --end "$(cat $fid)"
rm $fid
```

There are two `TODO`s though that I'm not so sure about yet. @gokcehan, if you can check and let me know.