### PR TITLE
Fix bug where lfcd.cmd does not CD to different drive

### DIFF
--- a/etc/lfcd.cmd
+++ b/etc/lfcd.cmd
@@ -5,11 +5,11 @@ rem You need to put this file to a folder in %PATH% variable.
 
 :tmploop
 set tmpfile="%tmp%\lf.%random%.tmp"
-if exist "%tmpfile%" goto:tmploop
-lf -last-dir-path="%tmpfile%" %*
-if not exist "%tmpfile%" exit
-set /p dir=<"%tmpfile%"
-del /f "%tmpfile%"
+if exist %tmpfile% goto:tmploop
+lf -last-dir-path=%tmpfile% %*
+if not exist %tmpfile% exit
+set /p dir=<%tmpfile%
+del /f %tmpfile%
 if not exist "%dir%" exit
 if "%dir%" == "%cd%" exit
-cd "%dir%"
+cd /d "%dir%"


### PR DESCRIPTION
Fixes #220 

Also cleaned up additional quotes around `%tmpfile%` (let me know if this is not desired).