### PR TITLE
Sort By Change Time

### DIFF
--- a/docstring.go
+++ b/docstring.go
@@ -177,6 +177,8 @@ The following additional keybindings are provided by default:
     map sn :set sortby natural; set info
     map ss :set sortby size; set info size
     map st :set sortby time; set info time
+    map sa :set sortby atime; set info atime
+    map sc :set sortby ctime; set info ctime
     map gh cd ~
 
 The following keybindings to applications are provided by default:

--- a/eval.go
+++ b/eval.go
@@ -238,10 +238,6 @@ func (e *setExpr) eval(app *app, args []string) {
 	case "shell":
 		gOpts.shell = e.val
 	case "sortby":
-		if e.val != "natural" && e.val != "name" && e.val != "size" && e.val != "time" {
-			app.ui.echoerr("sortby: value should either be 'natural', 'name', 'size' or 'time'")
-			return
-		}
 		switch e.val {
 		case "natural":
 			gOpts.sortType.method = naturalSort
@@ -251,6 +247,13 @@ func (e *setExpr) eval(app *app, args []string) {
 			gOpts.sortType.method = sizeSort
 		case "time":
 			gOpts.sortType.method = timeSort
+		case "ctime":
+			gOpts.sortType.method = ctimeSort
+		case "atime":
+			gOpts.sortType.method = atimeSort
+		default:
+			app.ui.echoerr("sortby: value should either be 'natural', 'name', 'size', 'time', 'atime' or 'ctime'")
+			return
 		}
 		app.nav.sort()
 		app.ui.sort()
@@ -281,8 +284,10 @@ func (e *setExpr) eval(app *app, args []string) {
 	case "info":
 		toks := strings.Split(e.val, ":")
 		for _, s := range toks {
-			if s != "" && s != "size" && s != "time" {
-				app.ui.echoerr("info: should consist of 'size' or 'time' separated with colon")
+			switch s {
+			case "", "size", "time", "atime", "ctime":
+			default:
+				app.ui.echoerr("info: should consist of 'size', 'time', 'atime' or 'ctime' separated with colon")
 				return
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.12
 require (
 	github.com/mattn/go-runewidth v0.0.4
 	github.com/nsf/termbox-go v0.0.0-20190325093121-288510b9734e
+	gopkg.in/djherbis/times.v1 v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/nsf/termbox-go v0.0.0-20190325093121-288510b9734e h1:Vbib8wJAaMEF9jusI/kMSYMr/LtRzM7+F9MJgt/nH8k=
 github.com/nsf/termbox-go v0.0.0-20190325093121-288510b9734e/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
+gopkg.in/djherbis/times.v1 v1.2.0 h1:UCvDKl1L/fmBygl2Y7hubXCnY7t4Yj46ZrBFNUipFbM=
+gopkg.in/djherbis/times.v1 v1.2.0/go.mod h1:AQlg6unIsrsCEdQYhTzERy542dz6SFdQFZFv6mUY0P8=

--- a/opts.go
+++ b/opts.go
@@ -9,6 +9,8 @@ const (
 	nameSort
 	sizeSort
 	timeSort
+	atimeSort
+	ctimeSort
 )
 
 type sortOption byte
@@ -153,6 +155,8 @@ func init() {
 	gOpts.keys["sn"] = &listExpr{[]expr{&setExpr{"sortby", "natural"}, &setExpr{"info", ""}}}
 	gOpts.keys["ss"] = &listExpr{[]expr{&setExpr{"sortby", "size"}, &setExpr{"info", "size"}}}
 	gOpts.keys["st"] = &listExpr{[]expr{&setExpr{"sortby", "time"}, &setExpr{"info", "time"}}}
+	gOpts.keys["sa"] = &listExpr{[]expr{&setExpr{"sortby", "atime"}, &setExpr{"info", "atime"}}}
+	gOpts.keys["sc"] = &listExpr{[]expr{&setExpr{"sortby", "ctime"}, &setExpr{"info", "ctime"}}}
 	gOpts.keys["gh"] = &callExpr{"cd", []string{"~"}, 1}
 
 	gOpts.cmdkeys = make(map[string]expr)

--- a/ui.go
+++ b/ui.go
@@ -231,6 +231,10 @@ func fileInfo(f *file, d *dir) string {
 			}
 		case "time":
 			info = fmt.Sprintf("%s %12s", info, f.ModTime().Format("Jan _2 15:04"))
+		case "atime":
+			info = fmt.Sprintf("%s %12s", info, f.accessTime.Format("Jan _2 15:04"))
+		case "ctime":
+			info = fmt.Sprintf("%s %12s", info, f.changeTime.Format("Jan _2 15:04"))
 		default:
 			log.Printf("unknown info type: %s", s)
 		}


### PR DESCRIPTION
Sort file list by file change time. Slightly dirty, no tests.

This probably doesn't follow contributing rules (PRs are for bugfixes according to the contributing guidelines) but I didn't know the best way to raise this. See details below.

----

Just recently run into **lf** (by seeing it on @LukeSmithxyz's site, thanks btw) and I was hooked by the very fact that it's written in Go so I decided to try it out.

Then I hit the most curious of walls; for some reason **ranger** was sorting files by time in a different way to **lf**. Soon after I realized I was using `oc` on **ranger** which sorts by *change time* while **lf**'s only time sort was using `os.FileInfo.ModTime` (aka *modification time*). On a whim, I decided to see if I could implement *change time* sorting.

It's weird that go stdlib doesn't expose file change times so I sought out an answer (DDG to the rescue), first landing on an [SO question](https://stackoverflow.com/questions/20875336/how-can-i-get-a-files-ctime-atime-mtime-and-change-them-using-golang) and then to https://github.com/djherbis/times which at least attempts to be cross-platform. Some quick hacks later and the code below was born (BTW this was very quick, a testament to how organized this codebase is).

I'm presuming that I've probably overstepped by starting a PR directly, not to mention introducing a new lib and not writing tests. But I thought starting an issue while I already had working code would be a roundabout way of getting here and I wanted to see if the code could speak for itself.

Is this something that can get merged in and if so what would I need to do to clean it up to something merge-able?