### PR TITLE
Sort by file extensions

### DIFF
--- a/docstring.go
+++ b/docstring.go
@@ -179,6 +179,7 @@ The following additional keybindings are provided by default:
     map st :set sortby time; set info time
     map sa :set sortby atime; set info atime
     map sc :set sortby ctime; set info ctime
+	map se :set sortby ext; set info
     map gh cd ~
 
 The following keybindings to applications are provided by default:

--- a/eval.go
+++ b/eval.go
@@ -251,8 +251,10 @@ func (e *setExpr) eval(app *app, args []string) {
 			gOpts.sortType.method = ctimeSort
 		case "atime":
 			gOpts.sortType.method = atimeSort
+		case "ext":
+			gOpts.sortType.method = extSort
 		default:
-			app.ui.echoerr("sortby: value should either be 'natural', 'name', 'size', 'time', 'atime' or 'ctime'")
+			app.ui.echoerr("sortby: value should either be 'natural', 'name', 'size', 'time', 'atime', 'ctime' or 'ext'")
 			return
 		}
 		app.nav.sort()

--- a/opts.go
+++ b/opts.go
@@ -11,6 +11,7 @@ const (
 	timeSort
 	atimeSort
 	ctimeSort
+	extSort
 )
 
 type sortOption byte
@@ -157,6 +158,7 @@ func init() {
 	gOpts.keys["st"] = &listExpr{[]expr{&setExpr{"sortby", "time"}, &setExpr{"info", "time"}}}
 	gOpts.keys["sa"] = &listExpr{[]expr{&setExpr{"sortby", "atime"}, &setExpr{"info", "atime"}}}
 	gOpts.keys["sc"] = &listExpr{[]expr{&setExpr{"sortby", "ctime"}, &setExpr{"info", "ctime"}}}
+	gOpts.keys["se"] = &listExpr{[]expr{&setExpr{"sortby", "ext"}, &setExpr{"info", ""}}}
 	gOpts.keys["gh"] = &callExpr{"cd", []string{"~"}, 1}
 
 	gOpts.cmdkeys = make(map[string]expr)


### PR DESCRIPTION
- preserve natural ordering of filenames if extensions are the same
  or are missing
- files without extensions rank higher on ascending sort and lower
  on descending sort