### PR TITLE
Add automatically generated zsh completion

### DIFF
--- a/etc/_lf
+++ b/etc/_lf
@@ -1,0 +1,20 @@
+#compdef lf
+
+# zsh completions for 'lf'
+# automatically generated with http://github.com/RobSis/zsh-completion-generator
+local arguments
+
+arguments=(
+  '-command[command to execute on client initialization]'
+  '-cpuprofile[path to the file to write the CPU profile]'
+  '-doc[show documentation]'
+  '-last-dir-path[path to the file to write the last dir on exit (to use for cd)]'
+  '-memprofile[path to the file to write the memory profile]'
+  '-remote[send remote command to server]'
+  '-selection-path[path to the file to write selected files on open (to use as open file dialog)]'
+  '-server[start server (automatic)]'
+  '-version[show version]'
+  '*:filename:_files'
+)
+
+_arguments -s $arguments

--- a/etc/lf.zsh
+++ b/etc/lf.zsh
@@ -1,5 +1,14 @@
 #compdef lf
 
+# For using these completions you must: 
+# - rename this file to _lf
+# - add the containing folder to $fpath in .zshrc, like this:
+# '''
+# fpath=(/path/to/folder/containing_lf $fpath)
+# autoload -U compinit
+# compinit
+# '''
+#
 # zsh completions for 'lf'
 # automatically generated with http://github.com/RobSis/zsh-completion-generator
 local arguments


### PR DESCRIPTION
if put this file is put in $fpath for zsh shell, then it will produce completion

![image](https://user-images.githubusercontent.com/32071671/66148961-5ddbda80-e612-11e9-9c4b-74537961c2c5.png)


Note: I have no experience with zsh completions, so I am not sure if there is some way to automatically install them. I could not find any resources, however, if there are any, let me know.