### PR TITLE
Don't rename when name is the same. Fix #253

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -1090,6 +1090,9 @@ func (e *callExpr) eval(app *app, args []string) {
 				}
 				oldPathTo := filepath.Join(wd, curr.Name())
 				newPathTo := filepath.Join(wd, s)
+				if oldPathTo == newPathTo {
+					return
+				}
 				app.nav.renameCache = []string{oldPathTo, newPathTo}
 
 				if dir, _ := filepath.Split(s); dir != "" {


### PR DESCRIPTION
Currently, renaming a file without changing the name will prompt for replacing and then delete the file. This will instead cancel the renaming if the old and new names are the same.