### PR TITLE
Properly handle SIGHUP and SIGTERM

### DIFF
--- a/app.go
+++ b/app.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"os/signal"
+	"syscall"
 	"path/filepath"
 	"strings"
 	"time"
@@ -34,11 +36,21 @@ func newApp() *app {
 	ui := newUI()
 	nav := newNav(ui.wins[0].h)
 
+	quitChan := make(chan bool, 1)
+
+	osChan := make(chan os.Signal, 1)
+	signal.Notify(osChan, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-osChan
+		quitChan <- true
+		return
+	}()
+
 	return &app{
 		ui:       ui,
 		nav:      nav,
 		ticker:   new(time.Ticker),
-		quitChan: make(chan bool, 1),
+		quitChan: quitChan,
 	}
 }
 

--- a/app.go
+++ b/app.go
@@ -42,6 +42,9 @@ func newApp() *app {
 	signal.Notify(osChan, os.Interrupt, syscall.SIGHUP, syscall.SIGTERM)
 	go func() {
 		<-osChan
+		nav.copyTotal = 0
+		nav.moveTotal = 0
+		nav.deleteTotal = 0
 		quitChan <- true
 		return
 	}()

--- a/app.go
+++ b/app.go
@@ -39,7 +39,7 @@ func newApp() *app {
 	quitChan := make(chan bool, 1)
 
 	osChan := make(chan os.Signal, 1)
-	signal.Notify(osChan, os.Interrupt, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(osChan, os.Interrupt, syscall.SIGHUP, syscall.SIGTERM)
 	go func() {
 		<-osChan
 		quitChan <- true

--- a/app.go
+++ b/app.go
@@ -42,9 +42,9 @@ func newApp() *app {
 	signal.Notify(osChan, os.Interrupt, syscall.SIGHUP, syscall.SIGTERM)
 	go func() {
 		<-osChan
-		nav.copyTotal = 0
-		nav.moveTotal = 0
-		nav.deleteTotal = 0
+		nav.copyTotalChan <- -nav.copyTotal
+		nav.moveTotalChan <- -nav.moveTotal
+		nav.deleteTotalChan <- -nav.deleteTotal
 		quitChan <- true
 		return
 	}()


### PR DESCRIPTION
Properly handle exit signals SIGHUP and SIGTERM to avoid exiting prematurely.

Fixes #300, #292 

To preserve system independence, according to the [documentation](https://golang.org/pkg/os/signal/), when Windows sends CTRL_CLOSE_EVENT, CTRL_LOGOFF_EVENT or CTRL_SHUTDOWN_EVENT, Notify will return SIGTERM like a *nix system.