### PR TITLE
show symlink destination

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -28,6 +28,7 @@ const (
 type file struct {
 	os.FileInfo
 	linkState  linkState
+	linkTarget string
 	path       string
 	dirCount   int
 	accessTime time.Time
@@ -56,6 +57,7 @@ func readdir(path string) ([]*file, error) {
 		}
 
 		var linkState linkState
+		var linkTarget string
 
 		if lstat.Mode()&os.ModeSymlink != 0 {
 			stat, err := os.Stat(fpath)
@@ -64,6 +66,10 @@ func readdir(path string) ([]*file, error) {
 				lstat = stat
 			} else {
 				linkState = broken
+			}
+			linkTarget, err = os.Readlink(fpath)
+			if err != nil {
+				return files, err
 			}
 		}
 
@@ -85,6 +91,7 @@ func readdir(path string) ([]*file, error) {
 		files = append(files, &file{
 			FileInfo:   lstat,
 			linkState:  linkState,
+			linkTarget: linkTarget,
 			path:       fpath,
 			dirCount:   -1,
 			accessTime: at,

--- a/ui.go
+++ b/ui.go
@@ -551,7 +551,11 @@ func (ui *ui) loadFileInfo(nav *nav) {
 		return
 	}
 
-	ui.echof("%v %4s %v", curr.Mode(), humanize(curr.Size()), curr.ModTime().Format(gOpts.timefmt))
+	var linkTarget string
+	if curr.linkTarget != "" {
+		linkTarget = " -> " + curr.linkTarget
+	}
+	ui.echof("%v %4s %v%s", curr.Mode(), humanize(curr.Size()), curr.ModTime().Format(gOpts.timefmt), linkTarget)
 }
 
 func (ui *ui) drawPromptLine(nav *nav) {


### PR DESCRIPTION
Closes #196.

Shows symlink destination at the bottom, at the right of permissions/size/time.

If it's a symlink to a symlink, it'll resolve only the first one, which I think makes sense.

I've also tried adding "target" option to `info`, but fairly long info strings are not being displayed at all. Even when there is a lot of space.

PS: this is my first ever code in Go :slightly_smiling_face: 