### PR TITLE
count applies also to listExpr

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -697,9 +697,7 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.ui.loadFile(app.nav)
 		app.ui.loadFileInfo(app.nav)
 	case "toggle":
-		for i := 0; i < e.count; i++ {
-			app.nav.toggle()
-		}
+		app.nav.toggle()
 		app.ui.loadFile(app.nav)
 		app.ui.loadFileInfo(app.nav)
 	case "invert":
@@ -1401,7 +1399,9 @@ func (e *execExpr) eval(app *app, args []string) {
 }
 
 func (e *listExpr) eval(app *app, args []string) {
-	for _, expr := range e.exprs {
-		expr.eval(app, nil)
+	for i := 0; i < e.count; i++ {
+		for _, expr := range e.exprs {
+			expr.eval(app, nil)
+		}
 	}
 }

--- a/eval_test.go
+++ b/eval_test.go
@@ -158,25 +158,25 @@ var gEvalTests = []struct {
 	{
 		":set ratios 1:2:3",
 		[]string{":", "set", "ratios", "1:2:3", "\n", "\n"},
-		[]expr{&listExpr{[]expr{&setExpr{"ratios", "1:2:3"}}}},
+		[]expr{&listExpr{[]expr{&setExpr{"ratios", "1:2:3"}}, 1}},
 	},
 
 	{
 		":set ratios 1:2:3\nset hidden",
 		[]string{":", "set", "ratios", "1:2:3", "\n", "\n", "set", "hidden", "\n"},
-		[]expr{&listExpr{[]expr{&setExpr{"ratios", "1:2:3"}}}, &setExpr{"hidden", ""}},
+		[]expr{&listExpr{[]expr{&setExpr{"ratios", "1:2:3"}}, 1}, &setExpr{"hidden", ""}},
 	},
 
 	{
 		":set ratios 1:2:3;",
 		[]string{":", "set", "ratios", "1:2:3", ";", "\n"},
-		[]expr{&listExpr{[]expr{&setExpr{"ratios", "1:2:3"}}}},
+		[]expr{&listExpr{[]expr{&setExpr{"ratios", "1:2:3"}}, 1}},
 	},
 
 	{
 		":set ratios 1:2:3;\nset hidden",
 		[]string{":", "set", "ratios", "1:2:3", ";", "\n", "set", "hidden", "\n"},
-		[]expr{&listExpr{[]expr{&setExpr{"ratios", "1:2:3"}}}, &setExpr{"hidden", ""}},
+		[]expr{&listExpr{[]expr{&setExpr{"ratios", "1:2:3"}}, 1}, &setExpr{"hidden", ""}},
 	},
 
 	{
@@ -194,13 +194,13 @@ var gEvalTests = []struct {
 	{
 		"map gh :cd ~",
 		[]string{"map", "gh", ":", "cd", "~", "\n", "\n"},
-		[]expr{&mapExpr{"gh", &listExpr{[]expr{&callExpr{"cd", []string{"~"}, 1}}}}},
+		[]expr{&mapExpr{"gh", &listExpr{[]expr{&callExpr{"cd", []string{"~"}, 1}}, 1}}},
 	},
 
 	{
 		"map gh :cd ~;",
 		[]string{"map", "gh", ":", "cd", "~", ";", "\n"},
-		[]expr{&mapExpr{"gh", &listExpr{[]expr{&callExpr{"cd", []string{"~"}, 1}}}}},
+		[]expr{&mapExpr{"gh", &listExpr{[]expr{&callExpr{"cd", []string{"~"}, 1}}, 1}}},
 	},
 
 	{
@@ -236,13 +236,13 @@ var gEvalTests = []struct {
 	{
 		"map u :usage",
 		[]string{"map", "u", ":", "usage", "\n", "\n"},
-		[]expr{&mapExpr{"u", &listExpr{[]expr{&callExpr{"usage", nil, 1}}}}},
+		[]expr{&mapExpr{"u", &listExpr{[]expr{&callExpr{"usage", nil, 1}}, 1}}},
 	},
 
 	{
 		"map u :usage;",
 		[]string{"map", "u", ":", "usage", ";", "\n"},
-		[]expr{&mapExpr{"u", &listExpr{[]expr{&callExpr{"usage", nil, 1}}}}},
+		[]expr{&mapExpr{"u", &listExpr{[]expr{&callExpr{"usage", nil, 1}}, 1}}},
 	},
 
 	{
@@ -266,13 +266,13 @@ var gEvalTests = []struct {
 	{
 		"map r :push :rename<space>",
 		[]string{"map", "r", ":", "push", ":rename<space>", "\n", "\n"},
-		[]expr{&mapExpr{"r", &listExpr{[]expr{&callExpr{"push", []string{":rename<space>"}, 1}}}}},
+		[]expr{&mapExpr{"r", &listExpr{[]expr{&callExpr{"push", []string{":rename<space>"}, 1}}, 1}}},
 	},
 
 	{
 		"map r :push :rename<space> ; set hidden",
 		[]string{"map", "r", ":", "push", ":rename<space>", ";", "set", "hidden", "\n", "\n"},
-		[]expr{&mapExpr{"r", &listExpr{[]expr{&callExpr{"push", []string{":rename<space>"}, 1}, &setExpr{"hidden", ""}}}}},
+		[]expr{&mapExpr{"r", &listExpr{[]expr{&callExpr{"push", []string{":rename<space>"}, 1}, &setExpr{"hidden", ""}}, 1}}},
 	},
 
 	{
@@ -296,13 +296,13 @@ var gEvalTests = []struct {
 	{
 		"map ss :set sortby size; set info size",
 		[]string{"map", "ss", ":", "set", "sortby", "size", ";", "set", "info", "size", "\n", "\n"},
-		[]expr{&mapExpr{"ss", &listExpr{[]expr{&setExpr{"sortby", "size"}, &setExpr{"info", "size"}}}}},
+		[]expr{&mapExpr{"ss", &listExpr{[]expr{&setExpr{"sortby", "size"}, &setExpr{"info", "size"}}, 1}}},
 	},
 
 	{
 		"map ss :set sortby size; set info size;",
 		[]string{"map", "ss", ":", "set", "sortby", "size", ";", "set", "info", "size", ";", "\n"},
-		[]expr{&mapExpr{"ss", &listExpr{[]expr{&setExpr{"sortby", "size"}, &setExpr{"info", "size"}}}}},
+		[]expr{&mapExpr{"ss", &listExpr{[]expr{&setExpr{"sortby", "size"}, &setExpr{"info", "size"}}, 1}}},
 	},
 
 	{
@@ -320,7 +320,7 @@ var gEvalTests = []struct {
 			"gohome", &listExpr{[]expr{
 				&callExpr{"cd", []string{"~"}, 1},
 				&setExpr{"hidden", ""},
-			}},
+			}, 1},
 		}},
 	},
 
@@ -339,7 +339,7 @@ var gEvalTests = []struct {
 			"gh", &listExpr{[]expr{
 				&callExpr{"cd", []string{"~"}, 1},
 				&setExpr{"hidden", ""},
-			}},
+			}, 1},
 		}},
 	},
 

--- a/opts.go
+++ b/opts.go
@@ -120,7 +120,7 @@ func init() {
 	gOpts.keys["<home>"] = &callExpr{"top", nil, 1}
 	gOpts.keys["G"] = &callExpr{"bottom", nil, 1}
 	gOpts.keys["<end>"] = &callExpr{"bottom", nil, 1}
-	gOpts.keys["<space>"] = &listExpr{[]expr{&callExpr{"toggle", nil, 1}, &callExpr{"down", nil, 1}}}
+	gOpts.keys["<space>"] = &listExpr{[]expr{&callExpr{"toggle", nil, 1}, &callExpr{"down", nil, 1}}, 1}
 	gOpts.keys["v"] = &callExpr{"invert", nil, 1}
 	gOpts.keys["u"] = &callExpr{"unselect", nil, 1}
 	gOpts.keys["y"] = &callExpr{"copy", nil, 1}
@@ -155,12 +155,12 @@ func init() {
 	gOpts.keys["zs"] = &setExpr{"info", "size"}
 	gOpts.keys["zt"] = &setExpr{"info", "time"}
 	gOpts.keys["za"] = &setExpr{"info", "size:time"}
-	gOpts.keys["sn"] = &listExpr{[]expr{&setExpr{"sortby", "natural"}, &setExpr{"info", ""}}}
-	gOpts.keys["ss"] = &listExpr{[]expr{&setExpr{"sortby", "size"}, &setExpr{"info", "size"}}}
-	gOpts.keys["st"] = &listExpr{[]expr{&setExpr{"sortby", "time"}, &setExpr{"info", "time"}}}
-	gOpts.keys["sa"] = &listExpr{[]expr{&setExpr{"sortby", "atime"}, &setExpr{"info", "atime"}}}
-	gOpts.keys["sc"] = &listExpr{[]expr{&setExpr{"sortby", "ctime"}, &setExpr{"info", "ctime"}}}
-	gOpts.keys["se"] = &listExpr{[]expr{&setExpr{"sortby", "ext"}, &setExpr{"info", ""}}}
+	gOpts.keys["sn"] = &listExpr{[]expr{&setExpr{"sortby", "natural"}, &setExpr{"info", ""}}, 1}
+	gOpts.keys["ss"] = &listExpr{[]expr{&setExpr{"sortby", "size"}, &setExpr{"info", "size"}}, 1}
+	gOpts.keys["st"] = &listExpr{[]expr{&setExpr{"sortby", "time"}, &setExpr{"info", "time"}}, 1}
+	gOpts.keys["sa"] = &listExpr{[]expr{&setExpr{"sortby", "atime"}, &setExpr{"info", "atime"}}, 1}
+	gOpts.keys["sc"] = &listExpr{[]expr{&setExpr{"sortby", "ctime"}, &setExpr{"info", "ctime"}}, 1}
+	gOpts.keys["se"] = &listExpr{[]expr{&setExpr{"sortby", "ext"}, &setExpr{"info", ""}}, 1}
 	gOpts.keys["gh"] = &callExpr{"cd", []string{"~"}, 1}
 
 	gOpts.cmdkeys = make(map[string]expr)

--- a/parse.go
+++ b/parse.go
@@ -114,6 +114,7 @@ func (e *execExpr) String() string {
 
 type listExpr struct {
 	exprs []expr
+	count int
 }
 
 func (e *listExpr) String() string {
@@ -265,7 +266,7 @@ func (p *parser) parseExpr() expr {
 
 		s.scan()
 
-		result = &listExpr{exprs}
+		result = &listExpr{exprs, 1}
 	case tokenPrefix:
 		var expr string
 

--- a/ui.go
+++ b/ui.go
@@ -894,6 +894,8 @@ func (ui *ui) readEvent(ch chan<- expr, ev termbox.Event) {
 				expr := gOpts.keys[string(ui.keyAcc)]
 				if e, ok := expr.(*callExpr); ok {
 					e.count = count
+				} else if e, ok := expr.(*listExpr); ok {
+					e.count = count
 				}
 				ch <- expr
 				ui.keyAcc = nil


### PR DESCRIPTION
'count' for listExpr is stored in their first callExpr (if there is). 
Also now command "toggle" doesn't move the cursor, so its count is
useless.