### PR TITLE
Quit the lf server on last client exit

### DIFF
--- a/app.go
+++ b/app.go
@@ -164,7 +164,7 @@ func (app *app) loop() {
 	}
 
 	for _, path := range gConfigPaths {
-		if _, err := os.Stat(path); !os.IsNotExist(err) {
+		if checkFileExists(path) {
 			app.readFile(path)
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -48,7 +48,7 @@ func readExpr() <-chan expr {
 	ch := make(chan expr)
 
 	go func() {
-		duration := 1 * time.Second
+		duration := 10 * time.Millisecond
 
 		c, err := net.Dial(gSocketProt, gSocketPath)
 		for err != nil {

--- a/complete.go
+++ b/complete.go
@@ -180,7 +180,7 @@ func matchExec(s string) (matches []string, longest string) {
 	paths := strings.Split(envPath, string(filepath.ListSeparator))
 
 	for _, p := range paths {
-		if _, err := os.Stat(p); os.IsNotExist(err) {
+		if !checkFileExists(p) {
 			continue
 		}
 

--- a/copy.go
+++ b/copy.go
@@ -11,12 +11,11 @@ func copySize(srcs []string) (int64, error) {
 	var total int64
 
 	for _, src := range srcs {
-		_, err := os.Stat(src)
-		if os.IsNotExist(err) {
+		if !checkFileExists(src) {
 			return total, fmt.Errorf("src does not exist: %q", src)
 		}
 
-		err = filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		err := filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return fmt.Errorf("walk: %s", err)
 			}
@@ -86,12 +85,10 @@ func copyAll(srcs []string, dstDir string) (nums chan int64, errs chan error) {
 		for _, src := range srcs {
 			dst := filepath.Join(dstDir, filepath.Base(src))
 
-			_, err := os.Stat(dst)
-			if !os.IsNotExist(err) {
-				var newPath string
-				for i := 1; !os.IsNotExist(err); i++ {
+			if checkFileExists(dst) {
+				newPath := fmt.Sprintf("%s.~%d~", dst, 1)
+				for i := 2; checkFileExists(newPath); i++ {
 					newPath = fmt.Sprintf("%s.~%d~", dst, i)
-					_, err = os.Stat(newPath)
 				}
 				dst = newPath
 			}

--- a/eval.go
+++ b/eval.go
@@ -1128,7 +1128,7 @@ func (e *callExpr) eval(app *app, args []string) {
 				app.nav.renameNewPath = newPath
 
 				if dir, _ := filepath.Split(s); dir != "" {
-					if _, err := os.Stat(filepath.Join(wd, dir)); err != nil {
+					if !checkFileExists(filepath.Join(wd, dir)) {
 						app.ui.cmdPrefix = "create path " + dir + "?[y/N]"
 						return
 					}

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func startServer() {
 
 func checkServer() {
 	if gSocketProt == "unix" {
-		if _, err := os.Stat(gSocketPath); os.IsNotExist(err) {
+		if !checkFileExists(gSocketPath) {
 			startServer()
 		} else if _, err := net.Dial(gSocketProt, gSocketPath); err != nil {
 			os.Remove(gSocketPath)
@@ -162,7 +162,7 @@ func main() {
 
 		gClientID = 1000
 		gLogPath = filepath.Join(os.TempDir(), fmt.Sprintf("lf.%s.%d.log", gUser.Username, gClientID))
-		for _, err := os.Stat(gLogPath); !os.IsNotExist(err); _, err = os.Stat(gLogPath) {
+		for checkFileExists(gLogPath) {
 			gClientID++
 			gLogPath = filepath.Join(os.TempDir(), fmt.Sprintf("lf.%s.%d.log", gUser.Username, gClientID))
 		}

--- a/misc.go
+++ b/misc.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -212,6 +213,11 @@ func max(a, b int) int {
 		return a
 	}
 	return b
+}
+
+func checkFileExists(path string) bool {
+	_, err := os.Stat(path)
+	return !os.IsNotExist(err)
 }
 
 // We don't need no generic code

--- a/nav.go
+++ b/nav.go
@@ -389,7 +389,7 @@ func (nav *nav) renew() {
 	}
 
 	for m := range nav.selections {
-		if _, err := os.Stat(m); os.IsNotExist(err) {
+		if !checkFileExists(m) {
 			delete(nav.selections, m)
 		}
 	}
@@ -734,10 +734,9 @@ func (nav *nav) moveAsync(ui *ui, srcs []string, dstDir string) {
 			ui.exprChan <- echo
 			continue
 		} else if !os.IsNotExist(err) {
-			var newPath string
-			for i := 1; !os.IsNotExist(err); i++ {
+			newPath := fmt.Sprintf("%s.~%d~", dst, 1)
+			for i := 2; checkFileExists(newPath); i++ {
 				newPath = fmt.Sprintf("%s.~%d~", dst, i)
-				_, err = os.Stat(newPath)
 			}
 			dst = newPath
 		}

--- a/server.go
+++ b/server.go
@@ -48,9 +48,10 @@ func listen(l net.Listener) {
 				log.Printf("bye!")
 				return
 			default:
-				log.Printf("accepting connection: %s", err)
+				log.Printf("failed to accept connection: %s", err)
 			}
 		}
+		log.Println("accepted new connection")
 		go handleConn(c)
 	}
 }


### PR DESCRIPTION
The server maintains an integer indicating how many active connections it currently has, whenever a client disconnects this value is decremented and when a client connects it is incremented  
When the value reaches zero the server saves the files selected for moving or copying are saved under /tmp/lf.$USER.server.files. The first line of the file indicates whether it is a copy operation or not and the rest of the lines are the files selected.  
If there are no files selected for moving or deletion, this file is instead deleted when the server quits.

**Note:** If the server were to fail during deletion or writing of the file, the server will **not** exit. It can thus retry the operation it failed again when another last client exists.

Fixes: #177 