### PR TITLE
Fixes #408: async commands create zombie processes

### DIFF
--- a/app.go
+++ b/app.go
@@ -429,5 +429,11 @@ func (app *app) runShell(s string, args []string, prefix string) {
 			app.ui.cmdPrefix = ""
 			app.ui.exprChan <- &callExpr{"load", nil, 1}
 		}()
+	case "&":
+		go func() {
+			if err := cmd.Wait(); err != nil {
+				log.Printf("running shell: %s", err)
+			}
+		}()
 	}
 }


### PR DESCRIPTION
It seems that child processes need to be waited, so that they get removed from the process table. Otherwise, the become \<defunct\>, they are just there for their parent to know they have completed.



The new command is useful when one wants to append some files to the selection (from a script mostly). Previously, one had to do something like
````sh
lf -remote "send $id select '$TargetFile'"
lf -remote "send $id toggle"
````
Now
````
lf -remote "send $id filestoggle '$f1' '$f2' ... "
````
which is much more efficient.