### PR TITLE
'toggle' command now toggles selection on its arguments when at least one

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -63,7 +63,8 @@ The following commands are provided by lf without default keybindings:
     echoerr        same as echomsg but red color
     cd             change working directory to the argument
     select         change current file selection to the argument
-    toggle         toggle the selection of the current file
+    toggle         toggle the selection of the current file or,
+                   when passed arguments, of its arguments
     glob-select    select files that match the given glob
     glob-unselect  unselect files that match the given glob
     source         read the configuration file in the argument

--- a/docstring.go
+++ b/docstring.go
@@ -66,7 +66,8 @@ The following commands are provided by lf without default keybindings:
     echoerr        same as echomsg but red color
     cd             change working directory to the argument
     select         change current file selection to the argument
-    toggle         toggle the selection of the current file
+    toggle         toggle the selection of the current file or,
+                   when passed arguments, of its arguments
     glob-select    select files that match the given glob
     glob-unselect  unselect files that match the given glob
     source         read the configuration file in the argument

--- a/eval.go
+++ b/eval.go
@@ -683,15 +683,21 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.ui.loadFile(app.nav)
 		app.ui.loadFileInfo(app.nav)
 	case "toggle":
-		app.nav.toggle()
-		app.ui.loadFile(app.nav)
-		app.ui.loadFileInfo(app.nav)
+		if len(e.args) == 0 {
+			app.nav.toggle()
+		} else {
+			for _, path := range e.args {
+				if _, err := os.Stat(path); err == nil {
+					app.nav.toggleSelection(path)
+				} else {
+					log.Printf("toggle: %s", err)
+				}
+			}
+		}
 	case "invert":
 		app.nav.invert()
-		app.ui.loadFileInfo(app.nav)
 	case "unselect":
 		app.nav.unselect()
-		app.ui.loadFileInfo(app.nav)
 	case "copy":
 		if err := app.nav.save(true); err != nil {
 			app.ui.echoerrf("copy: %s", err)

--- a/lf.1
+++ b/lf.1
@@ -75,7 +75,8 @@ The following commands are provided by lf without default keybindings:
     echoerr        same as echomsg but red color
     cd             change working directory to the argument
     select         change current file selection to the argument
-    toggle         toggle the selection of the current file
+    toggle         toggle the selection of the current file or,
+                   when passed arguments, of its arguments
     glob-select    select files that match the given glob
     glob-unselect  unselect files that match the given glob
     source         read the configuration file in the argument


### PR DESCRIPTION
Modifies #407.
Synopsis:

`:toggle` works as before.
`:toggle paht1 path2 ... pathn` toggles selection of path1, path2, ... , pathn.

Note: the paths above are absolute paths (e.g. `/home/user/file.txt`).
Tilde substitution is NOT performed, i.e. `:toggle ~/file.txt` produces a `file not found` error. It seems to me that it would be unnecessary as this option is mostly useful when used in scripts:
````sh
for f in $(find "$PWD" -type f -maxdepth 2); do
    lf -remote "send $id toggle '$f'"
done
````

Also, I noticed some `app.ui.loadFile(app.nav)` that don't seem necessary to me (none of those `callExpr` moves the selection so there is no need for
`app.ui.loadFile(app.nav)` or 
`app.ui.loadFileInfo(app.nav)`

P.S. @gokcehan I will try to modify the previous PR (#407) to only deal with the issue with the `shell-async`(#408) as soon as I figure out how to push to a second branch or whatever it is that I am currently not doing properly.