### PR TITLE
Ability to customize filename truncating

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -140,6 +140,7 @@ var (
 		"shellopts",
 		"sortby",
 		"timefmt",
+		"truncatechar",
 	}
 )
 

--- a/doc.go
+++ b/doc.go
@@ -136,6 +136,7 @@ The following options can be used to customize the behavior of lf:
     shellopts       string   (default '')
     sortby          string   (default 'natural')
     timefmt         string   (default 'Mon Jan _2 15:04:05 2006')
+    truncatechar    string   (default '~')
 
 The following variables are exported for shell commands:
 

--- a/docstring.go
+++ b/docstring.go
@@ -139,6 +139,7 @@ The following options can be used to customize the behavior of lf:
     shellopts       string   (default '')
     sortby          string   (default 'natural')
     timefmt         string   (default 'Mon Jan _2 15:04:05 2006')
+    truncatechar    string   (default '~')
 
 The following variables are exported for shell commands:
 

--- a/eval.go
+++ b/eval.go
@@ -314,6 +314,8 @@ func (e *setExpr) eval(app *app, args []string) {
 		app.ui.sort()
 	case "timefmt":
 		gOpts.timefmt = e.val
+	case "truncatechar":
+		gOpts.truncatechar = e.val
 	default:
 		app.ui.echoerrf("unknown option: %s", e.opt)
 		return

--- a/opts.go
+++ b/opts.go
@@ -55,6 +55,7 @@ var gOpts struct {
 	promptfmt      string
 	shell          string
 	timefmt        string
+	truncatechar   string
 	ratios         []int
 	hiddenfiles    []string
 	info           []string
@@ -93,6 +94,7 @@ func init() {
 	gOpts.promptfmt = "\033[32;1m%u@%h\033[0m:\033[34;1m%w/\033[0m\033[1m%f\033[0m"
 	gOpts.shell = gDefaultShell
 	gOpts.timefmt = time.ANSIC
+	gOpts.truncatechar = "~"
 	gOpts.ratios = []int{1, 2, 3}
 	gOpts.hiddenfiles = []string{".*"}
 	gOpts.info = nil

--- a/ui.go
+++ b/ui.go
@@ -345,7 +345,7 @@ func (win *win) printDir(dir *dir, selections map[string]int, saves map[string]b
 
 		if w > win.w-3 {
 			s = runeSliceWidthRange(s, 0, win.w-4)
-			s = append(s, '~')
+			s = append(s, []rune(gOpts.truncatechar)...)
 		} else {
 			for i := 0; i < win.w-3-w; i++ {
 				s = append(s, ' ')
@@ -359,7 +359,7 @@ func (win *win) printDir(dir *dir, selections map[string]int, saves map[string]b
 				s = runeSliceWidthRange(s, 0, win.w-3-len(info)-lnwidth)
 			} else {
 				s = runeSliceWidthRange(s, 0, win.w-4-len(info)-lnwidth)
-				s = append(s, '~')
+				s = append(s, []rune(gOpts.truncatechar)...)
 			}
 			for _, r := range info {
 				s = append(s, r)


### PR DESCRIPTION
This PR adds `truncatechar` option that allows to customize how `lf` handles filename truncating. For example,
```
set truncatechar …
```
will be equal to Ranger's `unicode_ellipsis`

Closes #413 