### PR TITLE
Add check for truncatechar

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -315,7 +315,7 @@ func (e *setExpr) eval(app *app, args []string) {
 	case "timefmt":
 		gOpts.timefmt = e.val
 	case "truncatechar":
-		if len(e.val) > 1 {
+		if runeSliceWidth([]rune(e.val)) > 1 {
 			app.ui.echoerr("truncatechar: value should be 1 character long")
 			return
 		}

--- a/eval.go
+++ b/eval.go
@@ -315,6 +315,11 @@ func (e *setExpr) eval(app *app, args []string) {
 	case "timefmt":
 		gOpts.timefmt = e.val
 	case "truncatechar":
+		if len(e.val) > 1 {
+			app.ui.echoerr("truncatechar: value should be 1 character long")
+			return
+		}
+
 		gOpts.truncatechar = e.val
 	default:
 		app.ui.echoerrf("unknown option: %s", e.opt)


### PR DESCRIPTION
Addition to #417 

# Summary
When setting `truncatechar` option, it throws an error when value is longer than 1 character

