### PR TITLE
fixes 'numbers are bold when the filename is bold'

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -375,7 +375,7 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]in
 				}
 			}
 
-			win.print(screen, 0, i, (st.Normal()).Foreground(tcell.ColorOlive), ln)
+			win.print(screen, 0, i, tcell.StyleDefault.Foreground(tcell.ColorOlive), ln)
 		}
 
 		path := filepath.Join(dir.path, f.Name())

--- a/ui.go
+++ b/ui.go
@@ -375,7 +375,7 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]in
 				}
 			}
 
-			win.print(screen, 0, i, st.Foreground(tcell.ColorOlive), ln)
+			win.print(screen, 0, i, (st.Normal()).Foreground(tcell.ColorOlive), ln)
 		}
 
 		path := filepath.Join(dir.path, f.Name())


### PR DESCRIPTION
It fixes a very small regression I noticed almost immediately after I tried to see how `lf` looks like using `tcell`.

Something that bothered me is that the numbers are bold when the filename is supposed to be in bold text.
This patch works for me, but it is too small not to share.