### PR TITLE
A more robust server starting mechanism

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,7 +64,6 @@ func exportEnvVars() {
 
 func startServer() {
 	cmd := detachedCommand(os.Args[0], "-server")
-	cmd.Dir = gUser.HomeDir
 	if err := cmd.Start(); err != nil {
 		log.Printf("starting server: %s", err)
 	}
@@ -157,6 +156,7 @@ func main() {
 			log.Fatalf("remote command: %s", err)
 		}
 	case *serverMode:
+		os.Chdir(gUser.HomeDir)
 		gServerLogPath = filepath.Join(os.TempDir(), fmt.Sprintf("lf.%s.server.log", gUser.Username))
 		serve()
 	default:


### PR DESCRIPTION
Now lf will start the server in the current directory (which will then Chdir to the user's home directory) to ensure it is always starting as the user intended.

This fixes the issue where the server would fail to start if lf was started with a relative path (and fixes the chance of starting the wrong program i.e. if `~/lf` and `/path/to/curr/dir/lf` both exist).

EDIT: a much better method completely slipped by the first time