### PR TITLE
always export lf_options before previewing

### DIFF
--- a/app.go
+++ b/app.go
@@ -9,8 +9,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"reflect"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -364,85 +362,6 @@ func (app *app) exportFiles() {
 	exportFiles(currFile, currSelections)
 }
 
-func fieldToString(field reflect.Value) string {
-	kind := field.Kind()
-	var value string
-
-	switch kind {
-	case reflect.Int:
-		value = strconv.Itoa(int(field.Int()))
-	case reflect.Bool:
-		value = strconv.FormatBool(field.Bool())
-	case reflect.Slice:
-		for i := 0; i < field.Len(); i++ {
-			element := field.Index(i)
-
-			if i == 0 {
-				value = fieldToString(element)
-			} else {
-				value += ":" + fieldToString(element)
-			}
-		}
-	default:
-		value = field.String()
-	}
-
-	return value
-}
-
-func (app *app) exportOpts() {
-	e := reflect.ValueOf(&gOpts).Elem()
-
-	for i := 0; i < e.NumField(); i++ {
-		// Get name and prefix it with lf_
-		name := e.Type().Field(i).Name
-		name = fmt.Sprintf("lf_%s", name)
-
-		// Skip maps
-		if name == "lf_keys" || name == "lf_cmdkeys" || name == "lf_cmds" {
-			continue
-		}
-
-		// Get string representation of the value
-		if name == "lf_sortType" {
-			var sortby string
-
-			switch gOpts.sortType.method {
-			case naturalSort:
-				sortby = "natural"
-			case nameSort:
-				sortby = "name"
-			case sizeSort:
-				sortby = "size"
-			case timeSort:
-				sortby = "time"
-			case ctimeSort:
-				sortby = "ctime"
-			case atimeSort:
-				sortby = "atime"
-			case extSort:
-				sortby = "ext"
-			}
-
-			os.Setenv("lf_sortby", sortby)
-
-			reverse := strconv.FormatBool(gOpts.sortType.option&reverseSort != 0)
-			os.Setenv("lf_reverse", reverse)
-
-			hidden := strconv.FormatBool(gOpts.sortType.option&hiddenSort != 0)
-			os.Setenv("lf_hidden", hidden)
-
-			dirfirst := strconv.FormatBool(gOpts.sortType.option&dirfirstSort != 0)
-			os.Setenv("lf_dirfirst", dirfirst)
-		} else {
-			field := e.Field(i)
-			value := fieldToString(field)
-
-			os.Setenv(name, value)
-		}
-	}
-}
-
 func waitKey() error {
 	cmd := pauseCommand()
 
@@ -466,7 +385,7 @@ func waitKey() error {
 //     &       No    Yes    No     No      No      Do nothing
 func (app *app) runShell(s string, args []string, prefix string) {
 	app.exportFiles()
-	app.exportOpts()
+	exportOpts()
 
 	cmd := shellCommand(s, args)
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"runtime/pprof"
 	"strconv"
@@ -60,6 +61,86 @@ func exportEnvVars() {
 	level++
 
 	os.Setenv("LF_LEVEL", strconv.Itoa(level))
+}
+
+// used by exportOpts below
+func fieldToString(field reflect.Value) string {
+	kind := field.Kind()
+	var value string
+
+	switch kind {
+	case reflect.Int:
+		value = strconv.Itoa(int(field.Int()))
+	case reflect.Bool:
+		value = strconv.FormatBool(field.Bool())
+	case reflect.Slice:
+		for i := 0; i < field.Len(); i++ {
+			element := field.Index(i)
+
+			if i == 0 {
+				value = fieldToString(element)
+			} else {
+				value += ":" + fieldToString(element)
+			}
+		}
+	default:
+		value = field.String()
+	}
+
+	return value
+}
+
+func exportOpts() {
+	e := reflect.ValueOf(&gOpts).Elem()
+
+	for i := 0; i < e.NumField(); i++ {
+		// Get name and prefix it with lf_
+		name := e.Type().Field(i).Name
+		name = fmt.Sprintf("lf_%s", name)
+
+		// Skip maps
+		if name == "lf_keys" || name == "lf_cmdkeys" || name == "lf_cmds" {
+			continue
+		}
+
+		// Get string representation of the value
+		if name == "lf_sortType" {
+			var sortby string
+
+			switch gOpts.sortType.method {
+			case naturalSort:
+				sortby = "natural"
+			case nameSort:
+				sortby = "name"
+			case sizeSort:
+				sortby = "size"
+			case timeSort:
+				sortby = "time"
+			case ctimeSort:
+				sortby = "ctime"
+			case atimeSort:
+				sortby = "atime"
+			case extSort:
+				sortby = "ext"
+			}
+
+			os.Setenv("lf_sortby", sortby)
+
+			reverse := strconv.FormatBool(gOpts.sortType.option&reverseSort != 0)
+			os.Setenv("lf_reverse", reverse)
+
+			hidden := strconv.FormatBool(gOpts.sortType.option&hiddenSort != 0)
+			os.Setenv("lf_hidden", hidden)
+
+			dirfirst := strconv.FormatBool(gOpts.sortType.option&dirfirstSort != 0)
+			os.Setenv("lf_dirfirst", dirfirst)
+		} else {
+			field := e.Field(i)
+			value := fieldToString(field)
+
+			os.Setenv(name, value)
+		}
+	}
 }
 
 func startServer() {

--- a/nav.go
+++ b/nav.go
@@ -427,6 +427,7 @@ func (nav *nav) preview() {
 	var reader io.Reader
 
 	if len(gOpts.previewer) != 0 {
+		exportOpts()
 		cmd := exec.Command(gOpts.previewer, curr.path, strconv.Itoa(nav.height))
 
 		out, err := cmd.StdoutPipe()

--- a/os.go
+++ b/os.go
@@ -9,8 +9,6 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
-	"reflect"
-	"strconv"
 	"runtime"
 	"strings"
 	"syscall"
@@ -180,84 +178,5 @@ func exportFiles(f string, fs []string) {
 		os.Setenv("fx", envFile)
 	} else {
 		os.Setenv("fx", envFiles)
-	}
-}
-
-func fieldToString(field reflect.Value) string {
-	kind := field.Kind()
-	var value string
-
-	switch kind {
-	case reflect.Int:
-		value = strconv.Itoa(int(field.Int()))
-	case reflect.Bool:
-		value = strconv.FormatBool(field.Bool())
-	case reflect.Slice:
-		for i := 0; i < field.Len(); i++ {
-			element := field.Index(i)
-
-			if i == 0 {
-				value = fieldToString(element)
-			} else {
-				value += ":" + fieldToString(element)
-			}
-		}
-	default:
-		value = field.String()
-	}
-
-	return value
-}
-
-func exportOpts() {
-	e := reflect.ValueOf(&gOpts).Elem()
-
-	for i := 0; i < e.NumField(); i++ {
-		// Get name and prefix it with lf_
-		name := e.Type().Field(i).Name
-		name = fmt.Sprintf("lf_%s", name)
-
-		// Skip maps
-		if name == "lf_keys" || name == "lf_cmdkeys" || name == "lf_cmds" {
-			continue
-		}
-
-		// Get string representation of the value
-		if name == "lf_sortType" {
-			var sortby string
-
-			switch gOpts.sortType.method {
-			case naturalSort:
-				sortby = "natural"
-			case nameSort:
-				sortby = "name"
-			case sizeSort:
-				sortby = "size"
-			case timeSort:
-				sortby = "time"
-			case ctimeSort:
-				sortby = "ctime"
-			case atimeSort:
-				sortby = "atime"
-			case extSort:
-				sortby = "ext"
-			}
-
-			os.Setenv("lf_sortby", sortby)
-
-			reverse := strconv.FormatBool(gOpts.sortType.option&reverseSort != 0)
-			os.Setenv("lf_reverse", reverse)
-
-			hidden := strconv.FormatBool(gOpts.sortType.option&hiddenSort != 0)
-			os.Setenv("lf_hidden", hidden)
-
-			dirfirst := strconv.FormatBool(gOpts.sortType.option&dirfirstSort != 0)
-			os.Setenv("lf_dirfirst", dirfirst)
-		} else {
-			field := e.Field(i)
-			value := fieldToString(field)
-
-			os.Setenv(name, value)
-		}
 	}
 }

--- a/os.go
+++ b/os.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"reflect"
+	"strconv"
 	"runtime"
 	"strings"
 	"syscall"
@@ -178,5 +180,84 @@ func exportFiles(f string, fs []string) {
 		os.Setenv("fx", envFile)
 	} else {
 		os.Setenv("fx", envFiles)
+	}
+}
+
+func fieldToString(field reflect.Value) string {
+	kind := field.Kind()
+	var value string
+
+	switch kind {
+	case reflect.Int:
+		value = strconv.Itoa(int(field.Int()))
+	case reflect.Bool:
+		value = strconv.FormatBool(field.Bool())
+	case reflect.Slice:
+		for i := 0; i < field.Len(); i++ {
+			element := field.Index(i)
+
+			if i == 0 {
+				value = fieldToString(element)
+			} else {
+				value += ":" + fieldToString(element)
+			}
+		}
+	default:
+		value = field.String()
+	}
+
+	return value
+}
+
+func exportOpts() {
+	e := reflect.ValueOf(&gOpts).Elem()
+
+	for i := 0; i < e.NumField(); i++ {
+		// Get name and prefix it with lf_
+		name := e.Type().Field(i).Name
+		name = fmt.Sprintf("lf_%s", name)
+
+		// Skip maps
+		if name == "lf_keys" || name == "lf_cmdkeys" || name == "lf_cmds" {
+			continue
+		}
+
+		// Get string representation of the value
+		if name == "lf_sortType" {
+			var sortby string
+
+			switch gOpts.sortType.method {
+			case naturalSort:
+				sortby = "natural"
+			case nameSort:
+				sortby = "name"
+			case sizeSort:
+				sortby = "size"
+			case timeSort:
+				sortby = "time"
+			case ctimeSort:
+				sortby = "ctime"
+			case atimeSort:
+				sortby = "atime"
+			case extSort:
+				sortby = "ext"
+			}
+
+			os.Setenv("lf_sortby", sortby)
+
+			reverse := strconv.FormatBool(gOpts.sortType.option&reverseSort != 0)
+			os.Setenv("lf_reverse", reverse)
+
+			hidden := strconv.FormatBool(gOpts.sortType.option&hiddenSort != 0)
+			os.Setenv("lf_hidden", hidden)
+
+			dirfirst := strconv.FormatBool(gOpts.sortType.option&dirfirstSort != 0)
+			os.Setenv("lf_dirfirst", dirfirst)
+		} else {
+			field := e.Field(i)
+			value := fieldToString(field)
+
+			os.Setenv(name, value)
+		}
 	}
 }


### PR DESCRIPTION
related functions were moved to `os.go`
and now exportOpts isn't called through
an app, so it can be called independently

I use the `lf_ratios` variable from the enviroment to determine
the columns of the preview panel inside my previwer script, and
it is annoying to have to run an command (`$`, `!` or `&`) to
properly export the variable. This patch is my solution to this
problem. I would be happy to improve it to better fit the overall
style.
