### PR TITLE
now mark-save can take an argument

### DIFF
--- a/app.go
+++ b/app.go
@@ -549,3 +549,19 @@ func (app *app) runShell(s string, args []string, prefix string) {
 		}()
 	}
 }
+
+func (app *app) markSave(s string) {
+	// assuming s is only one char long
+	wd, err := os.Getwd()
+	if err != nil {
+		log.Printf("getting current directory: %s", err)
+		return
+	}
+	app.nav.marks[s] = wd
+	if err := app.nav.writeMarks(); err != nil {
+		app.ui.echoerrf("mark-save: %s", err)
+	}
+	if err := remote("send sync"); err != nil {
+		app.ui.echoerrf("mark-save: %s", err)
+	}
+}

--- a/eval.go
+++ b/eval.go
@@ -526,19 +526,7 @@ func insert(app *app, arg string) {
 		}
 	case app.ui.cmdPrefix == "mark-save: ":
 		normal(app)
-
-		wd, err := os.Getwd()
-		if err != nil {
-			log.Printf("getting current directory: %s", err)
-			return
-		}
-		app.nav.marks[arg] = wd
-		if err := app.nav.writeMarks(); err != nil {
-			app.ui.echoerrf("mark-save: %s", err)
-		}
-		if err := remote("send sync"); err != nil {
-			app.ui.echoerrf("mark-save: %s", err)
-		}
+		app.markSave(arg)
 	case app.ui.cmdPrefix == "mark-load: ":
 		normal(app)
 
@@ -887,7 +875,14 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.ui.loadFile(app.nav)
 		app.ui.loadFileInfo(app.nav)
 	case "mark-save":
-		app.ui.cmdPrefix = "mark-save: "
+		switch {
+		case len(e.args) == 0:
+			app.ui.cmdPrefix = "mark-save: "
+		case len(e.args[0]) == 1:
+			app.markSave(e.args[0])
+		default:
+			app.ui.echoerr("mark-save: argument should be a single character")
+		}
 	case "mark-load":
 		app.ui.menuBuf = listMarks(app.nav.marks)
 		app.ui.cmdPrefix = "mark-load: "


### PR DESCRIPTION
(argument should be a single character)

Related #212.
I use mapping with `g` as a preffix, e.g.:
````sh
map gr cd /
````
though I would like to jump where I was before the jump, so instead
one could use something like
````shell
cmd UpdateLastMark :push m'
#'
map gr :UpdateLastMark; cd /
````
though I didn't get it to work, but even if it did, 
I think then there is a problem with concurrency so the following
wouldn't work anyway:
`map q :UpdateLastMark; quit`

I can confirm that this works with this patch.

Note that the similar commands (`mark-load`, `mark-remove`) aren't changed
mostly because it hasn't seemed useful (for me at least) so far. They could
be implemented similarly, though I am unsure if it is desirable or if it 
should be implemented in a different way.

EDIT: something wasn't displayed well with the code highlight.