### PR TITLE
Ability to map <esc>

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -941,7 +941,7 @@ func (ui *ui) readNormalEvent(ev tcell.Event) expr {
 			}
 		} else {
 			val := gKeyVal[tev.Key()]
-			if val == "<esc>" {
+			if val == "<esc>" && string(ui.keyAcc) != "" {
 				ui.keyAcc = nil
 				ui.keyCount = nil
 				ui.menuBuf = nil


### PR DESCRIPTION
Since d2414f758090f70b2c220320ee4f8f3025e89c1d <kbd>&lt;esc&gt;</kbd> resets key buffer but this feature prevents binding it to anything.