### PR TITLE
Fix typo

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -21,11 +21,11 @@ func (e *setExpr) eval(app *app, args []string) {
 	case "anchorfind!":
 		gOpts.anchorfind = !gOpts.anchorfind
 	case "color256":
-		app.ui.echoerr("option color256 is depreciated")
+		app.ui.echoerr("option color256 is deprecated")
 	case "nocolor256":
-		app.ui.echoerr("option nocolor256 is depreciated")
+		app.ui.echoerr("option nocolor256 is deprecated")
 	case "color256!":
-		app.ui.echoerr("option color256! is depreciated")
+		app.ui.echoerr("option color256! is deprecated")
 	case "dircounts":
 		gOpts.dircounts = true
 	case "nodircounts":


### PR DESCRIPTION
[depreciated](https://www.merriam-webster.com/dictionary/depreciated) -> [deprecated](https://www.merriam-webster.com/dictionary/deprecated)

`deprecated` is commonly used in this context, `depreciated` is an odd choice.