### PR TITLE
(feature): more flexible icons

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -86,6 +86,7 @@ var (
 		"nohidden",
 		"hidden!",
 		"icons",
+		"iconsdir",
 		"noicons",
 		"icons!",
 		"ignorecase",

--- a/eval.go
+++ b/eval.go
@@ -82,6 +82,8 @@ func (e *setExpr) eval(app *app, args []string) {
 		app.ui.loadFile(app.nav)
 	case "icons":
 		gOpts.icons = true
+	case "iconsdir":
+		gOpts.iconsdir = true
 	case "noicons":
 		gOpts.icons = false
 	case "icons!":

--- a/icons.go
+++ b/icons.go
@@ -60,11 +60,18 @@ var iconKeyGenerators []iconKeyGenerator = []iconKeyGenerator{
 		if strings.HasPrefix(path, home) {
 			path = "~" + path[len(home):]
 		}
+		if gOpts.iconsdir && f.IsDir() {
+			path += string(os.PathSeparator)
+		}
 		return path, true
 	},
 	// The exact basename of the file.
 	func(f *file) (string, bool) {
-		return filepath.Base(f.Name()), true
+		base := filepath.Base(f.Name())
+		if gOpts.iconsdir && f.IsDir() {
+			base += string(os.PathSeparator)
+		}
+		return base, true
 	},
 	// The basename of the file excluding the extension
 	func(f *file) (string, bool) {

--- a/icons.go
+++ b/icons.go
@@ -45,46 +45,85 @@ func parseIconsEnv(env string) iconMap {
 	return icons
 }
 
+// Maps a file to a possible key in the iconMap.
+type iconKeyGenerator func(f *file) (string, bool)
+
+// Slice of transformation functions, each of which tries to convert
+// an input file to a key in iconMap. The first key that's found AND
+// exists in the iconMap is used to set the icon for the current
+// file.
+var iconKeyGenerators []iconKeyGenerator = []iconKeyGenerator{
+	// Firstly try to match the complete path (without tilde expansion).
+	func(f *file) (string, bool) {
+		path := f.path
+		home := gUser.HomeDir
+		if strings.HasPrefix(path, home) {
+			path = "~" + path[len(home):]
+		}
+		return path, true
+	},
+	// The exact basename of the file.
+	func(f *file) (string, bool) {
+		return filepath.Base(f.Name()), true
+	},
+	// The basename of the file excluding the extension
+	func(f *file) (string, bool) {
+		return filepath.Base(f.Name()) + ".*", true
+	},
+	// The file extension
+	func(f *file) (string, bool) {
+		return "*" + filepath.Ext(f.Name()), true
+	},
+	// The filetype classification
+	func(f *file) (string, bool) {
+		var key string
+
+		switch {
+		case f.IsDir() && f.Mode()&os.ModeSticky != 0 && f.Mode()&0002 != 0:
+			key = "tw"
+		case f.IsDir() && f.Mode()&os.ModeSticky != 0:
+			key = "st"
+		case f.IsDir() && f.Mode()&0002 != 0:
+			key = "ow"
+		case f.IsDir():
+			key = "di"
+		case f.linkState == working:
+			key = "ln"
+		case f.linkState == broken:
+			key = "or"
+		case f.Mode()&os.ModeNamedPipe != 0:
+			key = "pi"
+		case f.Mode()&os.ModeSocket != 0:
+			key = "so"
+		case f.Mode()&os.ModeCharDevice != 0:
+			key = "cd"
+		case f.Mode()&os.ModeDevice != 0:
+			key = "bd"
+		case f.Mode()&os.ModeSetuid != 0:
+			key = "su"
+		case f.Mode()&os.ModeSetgid != 0:
+			key = "sg"
+		case f.Mode().IsRegular() && f.Mode()&0111 != 0:
+			key = "ex"
+		default:
+			return "", false
+		}
+
+		return key, true
+	},
+	// If all else fails, everything is a file
+	func(f *file) (string, bool) {
+		return "fi", true
+	},
+}
+
 func (im iconMap) get(f *file) string {
-	var key string
-
-	switch {
-	case f.IsDir() && f.Mode()&os.ModeSticky != 0 && f.Mode()&0002 != 0:
-		key = "tw"
-	case f.IsDir() && f.Mode()&os.ModeSticky != 0:
-		key = "st"
-	case f.IsDir() && f.Mode()&0002 != 0:
-		key = "ow"
-	case f.IsDir():
-		key = "di"
-	case f.linkState == working:
-		key = "ln"
-	case f.linkState == broken:
-		key = "or"
-	case f.Mode()&os.ModeNamedPipe != 0:
-		key = "pi"
-	case f.Mode()&os.ModeSocket != 0:
-		key = "so"
-	case f.Mode()&os.ModeCharDevice != 0:
-		key = "cd"
-	case f.Mode()&os.ModeDevice != 0:
-		key = "bd"
-	case f.Mode()&os.ModeSetuid != 0:
-		key = "su"
-	case f.Mode()&os.ModeSetgid != 0:
-		key = "sg"
-	case f.Mode().IsRegular() && f.Mode()&0111 != 0:
-		key = "ex"
-	default:
-		key = "*" + filepath.Ext(f.Name())
-	}
-
-	if val, ok := im[key]; ok {
-		return val
-	}
-
-	if val, ok := im["fi"]; ok {
-		return val
+	for _, gen := range iconKeyGenerators {
+		if key, ok := gen(f); ok {
+			if val, ok := im[key]; ok {
+				return val
+			}
+		}
 	}
 
 	return " "

--- a/opts.go
+++ b/opts.go
@@ -33,6 +33,7 @@ var gOpts struct {
 	drawbox        bool
 	globsearch     bool
 	icons          bool
+	iconsdir       bool
 	ignorecase     bool
 	ignoredia      bool
 	incsearch      bool
@@ -71,6 +72,7 @@ func init() {
 	gOpts.drawbox = false
 	gOpts.globsearch = false
 	gOpts.icons = false
+	gOpts.iconsdir = false
 	gOpts.ignorecase = true
 	gOpts.ignoredia = true
 	gOpts.incsearch = false


### PR DESCRIPTION
See #198 

This patch gives lf the ability to:
- Apply icons for folders the same way as it does for files
- Specify icons with none-extension based globs (Eg. `README=foo`, `*webpack*=bar`).

It also enforces a few new considerations:
1. LF_ICONS prioritises earlier matches over later ones. `*.txt=foo:*.txt=bar` will
   always return foo, never bar.
2. LF_ICONS prioritises globs over types. `tw=foo:*.txt=bar` will consider `*.txt`
   before `tw` even though it appears earlier in LF_ICONS.

Aside from that I've tried to maintain backwards compatibility with the existing
implementation, crucially in regards to performance. If you only ever use the
extension-globs and type-patterns than this implementation should be just as
performant as the existing implementation.

For every none-extension based glob you use an extra regex check will be performed,
but only on those patterns that exist before a matching extension. For example: If
LF_ICONS is:
- `*.txt=foo`
- `*t*=bar`

Any .txt icon lookups will never check the pattern `*t*` because `*.txt` takes
precedence (due to occurring earlier in LF_ICONS). Conversely if LF_ICONS is:
- `*f*=bar`
- `*b*=bar`
- `*txt*=baz`
- `*.txt=bag`

We'll be checking all 3 of the patterns `*f*`, `*b*`, `*txt*` until either a match is
found or we've reached the position of `*.txt` (in which case bag is used as the
icon).

Lastly if no glob lookup resolves to an icon, we compare file-types (see fileIconTypes)
or return " ".