### PR TITLE
Add ability to use image previewers

### DIFF
--- a/app.go
+++ b/app.go
@@ -310,7 +310,9 @@ func (app *app) loop() {
 
 			app.ui.draw(app.nav)
 		case r := <-app.nav.regChan:
-			app.nav.checkReg(r)
+			if app.nav.checkReg(r) {
+				go app.nav.preview(r.path)
+			}
 
 			app.nav.regCache[r.path] = r
 

--- a/app.go
+++ b/app.go
@@ -213,6 +213,8 @@ func (app *app) loop() {
 				continue
 			}
 
+			go app.nav.previewClear()
+
 			log.Print("bye!")
 
 			if err := app.writeHistory(); err != nil {
@@ -405,6 +407,7 @@ func (app *app) runShell(s string, args []string, prefix string) {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 
+		go app.nav.previewClear()
 		app.ui.pause()
 		defer app.ui.resume()
 		defer app.nav.renew()

--- a/app.go
+++ b/app.go
@@ -311,7 +311,8 @@ func (app *app) loop() {
 			app.ui.draw(app.nav)
 		case r := <-app.nav.regChan:
 			if app.nav.checkReg(r) {
-				go app.nav.preview(r.path)
+				win := app.ui.wins[len(app.ui.wins)-1]
+				go app.nav.preview(r.path, win)
 			}
 
 			app.nav.regCache[r.path] = r

--- a/complete.go
+++ b/complete.go
@@ -131,6 +131,7 @@ var (
 		"ifs",
 		"info",
 		"previewer",
+		"cleaner",
 		"promptfmt",
 		"ratios",
 		"shell",

--- a/doc.go
+++ b/doc.go
@@ -118,6 +118,7 @@ The following options can be used to customize the behavior of lf:
     period         int       (default 0)
     preview        bool      (default on)
     previewer      string    (default '')
+    cleaner        string    (default '')
     promptfmt      string    (default "\033[32;1m%u@%h\033[0m:\033[34;1m%w\033[0m\033[1m%f\033[0m")
     ratios         []int     (default '1:2:3')
     relativenumber bool      (default off)
@@ -595,6 +596,12 @@ Five arguments are passed to the file, first is the current file name; the secon
 SIGPIPE signal is sent when enough lines are read.
 If the previewer returns a non-zero exit code, then the preview cache for the given file is disabled. This means that if the file is selected in the future, the previewer is called once again.
 Preview filtering is disabled and files are displayed as they are when the value of this option is left empty.
+
+    cleaner        string    (default '') (not called if empty)
+
+Set the path of a cleaner file. This file will be called if previewing is enabled, the previewer is set, and the previously selected file had its preview cache disabled.
+The file should be executable.
+Preview clearing is disabled when the value of this option is left empty.
 
     promptfmt      string    (default "\033[32;1m%u@%h\033[0m:\033[34;1m%w/\033[0m\033[1m%f\033[0m")
 

--- a/doc.go
+++ b/doc.go
@@ -591,8 +591,9 @@ Files containing the null character (U+0000) in the read portion are considered 
 
 Set the path of a previewer file to filter the content of regular files for previewing.
 The file should be executable.
-Two arguments are passed to the file, first is the current file name, and second is the height of preview pane.
+Five arguments are passed to the file, first is the current file name; the second, third, fourth, and fifth are height, width, horizontal position, and vertical position of preview pane respectively.
 SIGPIPE signal is sent when enough lines are read.
+If the previewer returns a non-zero exit code, then the preview cache for the given file is disabled. This means that if the file is selected in the future, the previewer is called once again.
 Preview filtering is disabled and files are displayed as they are when the value of this option is left empty.
 
     promptfmt      string    (default "\033[32;1m%u@%h\033[0m:\033[34;1m%w/\033[0m\033[1m%f\033[0m")

--- a/docstring.go
+++ b/docstring.go
@@ -121,6 +121,7 @@ The following options can be used to customize the behavior of lf:
     period         int       (default 0)
     preview        bool      (default on)
     previewer      string    (default '')
+    cleaner        string    (default '')
     promptfmt      string    (default "\033[32;1m%u@%h\033[0m:\033[34;1m%w\033[0m\033[1m%f\033[0m")
     ratios         []int     (default '1:2:3')
     relativenumber bool      (default off)
@@ -632,6 +633,13 @@ previewer returns a non-zero exit code, then the preview cache for the given
 file is disabled. This means that if the file is selected in the future, the
 previewer is called once again. Preview filtering is disabled and files are
 displayed as they are when the value of this option is left empty.
+
+    cleaner        string    (default '') (not called if empty)
+
+Set the path of a cleaner file. This file will be called if previewing is
+enabled, the previewer is set, and the previously selected file had its
+preview cache disabled. The file should be executable. Preview clearing is
+disabled when the value of this option is left empty.
 
     promptfmt      string    (default "\033[32;1m%u@%h\033[0m:\033[34;1m%w/\033[0m\033[1m%f\033[0m")
 

--- a/docstring.go
+++ b/docstring.go
@@ -624,11 +624,14 @@ binary files and displayed as 'binary'.
     previewer      string    (default '') (not filtered if empty)
 
 Set the path of a previewer file to filter the content of regular files for
-previewing. The file should be executable. Two arguments are passed to the
-file, first is the current file name, and second is the height of preview
-pane. SIGPIPE signal is sent when enough lines are read. Preview filtering
-is disabled and files are displayed as they are when the value of this
-option is left empty.
+previewing. The file should be executable. Five arguments are passed to the
+file, first is the current file name; the second, third, fourth, and fifth
+are height, width, horizontal position, and vertical position of preview
+pane respectively. SIGPIPE signal is sent when enough lines are read. If the
+previewer returns a non-zero exit code, then the preview cache for the given
+file is disabled. This means that if the file is selected in the future, the
+previewer is called once again. Preview filtering is disabled and files are
+displayed as they are when the value of this option is left empty.
 
     promptfmt      string    (default "\033[32;1m%u@%h\033[0m:\033[34;1m%w/\033[0m\033[1m%f\033[0m")
 

--- a/eval.go
+++ b/eval.go
@@ -263,6 +263,8 @@ func (e *setExpr) eval(app *app, args []string) {
 		gOpts.info = toks
 	case "previewer":
 		gOpts.previewer = replaceTilde(e.val)
+	case "cleaner":
+		gOpts.cleaner = replaceTilde(e.val)
 	case "promptfmt":
 		gOpts.promptfmt = e.val
 	case "ratios":

--- a/lf.1
+++ b/lf.1
@@ -712,7 +712,7 @@ Show previews of files and directories at the right most pane. If the file has m
     previewer      string    (default '') (not filtered if empty)
 .EE
 .PP
-Set the path of a previewer file to filter the content of regular files for previewing. The file should be executable. Two arguments are passed to the file, first is the current file name, and second is the height of preview pane. SIGPIPE signal is sent when enough lines are read. Preview filtering is disabled and files are displayed as they are when the value of this option is left empty.
+Set the path of a previewer file to filter the content of regular files for previewing. The file should be executable. Five arguments are passed to the file, first is the current file name; the second, third, fourth, and fifth are height, width, horizontal position, and vertical position of preview pane respectively. SIGPIPE signal is sent when enough lines are read. If the previewer returns a non-zero exit code, then the preview cache for the given file is disabled. This means that if the file is selected in the future, the previewer is called once again. Preview filtering is disabled and files are displayed as they are when the value of this option is left empty.
 .PP
 .EX
     promptfmt      string    (default "\e033[32;1m%u@%h\e033[0m:\e033[34;1m%w/\e033[0m\e033[1m%f\e033[0m")

--- a/lf.1
+++ b/lf.1
@@ -132,6 +132,7 @@ The following options can be used to customize the behavior of lf:
     period         int       (default 0)
     preview        bool      (default on)
     previewer      string    (default '')
+    cleaner        string    (default '')
     promptfmt      string    (default "\e033[32;1m%u@%h\e033[0m:\e033[34;1m%w\e033[0m\e033[1m%f\e033[0m")
     ratios         []int     (default '1:2:3')
     relativenumber bool      (default off)
@@ -713,6 +714,12 @@ Show previews of files and directories at the right most pane. If the file has m
 .EE
 .PP
 Set the path of a previewer file to filter the content of regular files for previewing. The file should be executable. Five arguments are passed to the file, first is the current file name; the second, third, fourth, and fifth are height, width, horizontal position, and vertical position of preview pane respectively. SIGPIPE signal is sent when enough lines are read. If the previewer returns a non-zero exit code, then the preview cache for the given file is disabled. This means that if the file is selected in the future, the previewer is called once again. Preview filtering is disabled and files are displayed as they are when the value of this option is left empty.
+.PP
+.EX
+    cleaner        string    (default '') (not called if empty)
+.EE
+.PP
+Set the path of a cleaner file. This file will be called if previewing is enabled, the previewer is set, and the previously selected file had its preview cache disabled. The file should be executable. Preview clearing is disabled when the value of this option is left empty.
 .PP
 .EX
     promptfmt      string    (default "\e033[32;1m%u@%h\e033[0m:\e033[34;1m%w/\e033[0m\e033[1m%f\e033[0m")

--- a/nav.go
+++ b/nav.go
@@ -302,6 +302,7 @@ type nav struct {
 	searchBack      bool
 	searchInd       int
 	searchPos       int
+	volatilePreview bool
 }
 
 func (nav *nav) loadDir(path string) *dir {
@@ -486,6 +487,7 @@ func (nav *nav) preview(path string, win *win) {
 			if err := cmd.Wait(); err != nil {
 				if e, ok := err.(*exec.ExitError); ok {
 					if e.ExitCode() != 0 {
+						nav.volatilePreview = true
 						reg.volatile = true
 					}
 				} else {
@@ -520,6 +522,17 @@ func (nav *nav) preview(path string, win *win) {
 
 	if buf.Err() != nil {
 		log.Printf("loading file: %s", buf.Err())
+	}
+}
+
+func (nav *nav) previewClear() {
+	if len(gOpts.cleaner) != 0 && nav.volatilePreview {
+		nav.volatilePreview = false
+
+		cmd := exec.Command(gOpts.cleaner)
+		if err := cmd.Run(); err != nil {
+			log.Printf("cleaning preview: %s", err)
+		}
 	}
 }
 

--- a/nav.go
+++ b/nav.go
@@ -518,15 +518,17 @@ func (nav *nav) loadReg(path string) *reg {
 		return r
 	}
 
-	nav.checkReg(r)
+	if nav.checkReg(r) {
+		go nav.preview(path)
+	}
 
 	return r
 }
 
-func (nav *nav) checkReg(reg *reg) {
+func (nav *nav) checkReg(reg *reg) bool {
 	s, err := os.Stat(reg.path)
 	if err != nil {
-		return
+		return false
 	}
 
 	now := time.Now()
@@ -534,13 +536,15 @@ func (nav *nav) checkReg(reg *reg) {
 	// XXX: Linux builtin exFAT drivers are able to predict modifications in the future
 	// https://bugs.launchpad.net/ubuntu/+source/ubuntu-meta/+bug/1872504
 	if s.ModTime().After(now) {
-		return
+		return false
 	}
 
 	if s.ModTime().After(reg.loadTime) {
 		reg.loadTime = now
-		go nav.preview(reg.path)
+		return true
 	}
+
+	return false
 }
 
 func (nav *nav) sort() {

--- a/opts.go
+++ b/opts.go
@@ -51,6 +51,7 @@ var gOpts struct {
 	filesep        string
 	ifs            string
 	previewer      string
+	cleaner        string
 	promptfmt      string
 	shell          string
 	timefmt        string
@@ -89,6 +90,7 @@ func init() {
 	gOpts.filesep = "\n"
 	gOpts.ifs = ""
 	gOpts.previewer = ""
+	gOpts.cleaner = ""
 	gOpts.promptfmt = "\033[32;1m%u@%h\033[0m:\033[34;1m%w\033[0m\033[1m%f\033[0m"
 	gOpts.shell = gDefaultShell
 	gOpts.timefmt = time.ANSIC

--- a/ui.go
+++ b/ui.go
@@ -627,7 +627,8 @@ func (ui *ui) loadFile(nav *nav) {
 	if curr.IsDir() {
 		ui.dirPrev = nav.loadDir(curr.path)
 	} else if curr.Mode().IsRegular() {
-		ui.regPrev = nav.loadReg(curr.path)
+		win := ui.wins[len(ui.wins)-1]
+		ui.regPrev = nav.loadReg(curr.path, win)
 	}
 }
 

--- a/ui.go
+++ b/ui.go
@@ -625,6 +625,7 @@ func (ui *ui) loadFile(nav *nav) {
 		return
 	}
 
+	go nav.previewClear()
 	if curr.IsDir() {
 		ui.dirPrev = nav.loadDir(curr.path)
 	} else if curr.Mode().IsRegular() {

--- a/ui.go
+++ b/ui.go
@@ -609,6 +609,7 @@ func (ui *ui) echoerrf(format string, a ...interface{}) {
 
 type reg struct {
 	loading  bool
+	volatile bool
 	loadTime time.Time
 	path     string
 	lines    []string


### PR DESCRIPTION
This is intended as a follow-up to #304 
I've taken the code up at https://gitlab.com/Provessor/lfp, diffed it against master, and re-implemented portions of it while minimizing code changes, and organizing each logical change in its own commit (for ease of review).

Features added by this PR:
* The previewer script is passed width, height, x, y from the last pane (in that order)
* If the previewer script returns a non-zero exit code the preview is assumed to be volatile, and the next time that file is selected a new preview will be generated
* A cleaner script option has been added. This will be called upon the file selection changing, if the previous file had a volatile preview.
* Documentation has been changed for the previewer option, and added for the cleaner option.

Differences with lfp:
* The `preview` and `previewClear` methods have been left in nav.go. For `preview`, the caller is responsible for passing in a `win` struct
* `previewClear` is called in a new thread
* `gClientID` is not passed to the cleaner.
* The cleaner is called upon any file selection change (for both regular files and directories). With lfp, I was running into an issue where if I select a text file (whose preview would be non-volatile), then select an image file, then select the previous text file once again, the preview would remain on screen. This change fixes that.
* In `preview` setting `reg.volatile` is guaranteed to occur prior to `reg` being sent over `regChan`

@Provessor Your input is welcome as well.

I've also added the scripts I use with this at https://github.com/neeshy/lfimg in case they are needed for testing.