### PR TITLE
Guarantee preview/previewClear ordering

### DIFF
--- a/app.go
+++ b/app.go
@@ -312,10 +312,7 @@ func (app *app) loop() {
 
 			app.ui.draw(app.nav)
 		case r := <-app.nav.regChan:
-			if app.nav.checkReg(r) {
-				win := app.ui.wins[len(app.ui.wins)-1]
-				go app.nav.preview(r.path, win)
-			}
+			app.nav.checkReg(r)
 
 			app.nav.regCache[r.path] = r
 

--- a/app.go
+++ b/app.go
@@ -25,7 +25,7 @@ type app struct {
 	ui            *ui
 	nav           *nav
 	ticker        *time.Ticker
-	quitChan      chan bool
+	quitChan      chan struct{}
 	cmd           *exec.Cmd
 	cmdIn         io.WriteCloser
 	cmdOutBuf     []byte
@@ -38,7 +38,7 @@ func newApp(screen tcell.Screen) *app {
 	ui := newUI(screen)
 	nav := newNav(ui.wins[0].h)
 
-	quitChan := make(chan bool, 1)
+	quitChan := make(chan struct{}, 1)
 
 	app := &app{
 		ui:       ui,

--- a/app.go
+++ b/app.go
@@ -213,7 +213,7 @@ func (app *app) loop() {
 				continue
 			}
 
-			go app.nav.previewClear()
+			app.nav.previewChan <- ""
 
 			log.Print("bye!")
 
@@ -404,7 +404,7 @@ func (app *app) runShell(s string, args []string, prefix string) {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 
-		go app.nav.previewClear()
+		app.nav.previewChan <- ""
 		app.ui.pause()
 		defer app.ui.resume()
 		defer app.nav.renew()

--- a/client.go
+++ b/client.go
@@ -42,6 +42,7 @@ func run() {
 		app.ui.echoerrf("reading history file: %s", err)
 	}
 
+	go app.nav.previewLoop(app.ui)
 	app.loop()
 	app.ui.screen.Fini()
 }

--- a/doc.go
+++ b/doc.go
@@ -601,6 +601,7 @@ Preview filtering is disabled and files are displayed as they are when the value
 
 Set the path of a cleaner file. This file will be called if previewing is enabled, the previewer is set, and the previously selected file had its preview cache disabled.
 The file should be executable.
+One argument is passed to the file; the path to the file whose preview should be cleaned.
 Preview clearing is disabled when the value of this option is left empty.
 
     promptfmt      string    (default "\033[32;1m%u@%h\033[0m:\033[34;1m%w/\033[0m\033[1m%f\033[0m")

--- a/docstring.go
+++ b/docstring.go
@@ -638,8 +638,9 @@ displayed as they are when the value of this option is left empty.
 
 Set the path of a cleaner file. This file will be called if previewing is
 enabled, the previewer is set, and the previously selected file had its
-preview cache disabled. The file should be executable. Preview clearing is
-disabled when the value of this option is left empty.
+preview cache disabled. The file should be executable. One argument is
+passed to the file; the path to the file whose preview should be cleaned.
+Preview clearing is disabled when the value of this option is left empty.
 
     promptfmt      string    (default "\033[32;1m%u@%h\033[0m:\033[34;1m%w/\033[0m\033[1m%f\033[0m")
 

--- a/eval.go
+++ b/eval.go
@@ -699,7 +699,7 @@ func (e *callExpr) eval(app *app, args []string) {
 				log.Printf("writing selection file: %s", err)
 			}
 
-			app.quitChan <- true
+			app.quitChan <- struct{}{}
 
 			return
 		}
@@ -708,7 +708,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			cmd.eval(app, e.args)
 		}
 	case "quit":
-		app.quitChan <- true
+		app.quitChan <- struct{}{}
 	case "top":
 		app.nav.top()
 		app.ui.loadFile(app.nav)

--- a/lf.1
+++ b/lf.1
@@ -719,7 +719,7 @@ Set the path of a previewer file to filter the content of regular files for prev
     cleaner        string    (default '') (not called if empty)
 .EE
 .PP
-Set the path of a cleaner file. This file will be called if previewing is enabled, the previewer is set, and the previously selected file had its preview cache disabled. The file should be executable. Preview clearing is disabled when the value of this option is left empty.
+Set the path of a cleaner file. This file will be called if previewing is enabled, the previewer is set, and the previously selected file had its preview cache disabled. The file should be executable. One argument is passed to the file; the path to the file whose preview should be cleaned. Preview clearing is disabled when the value of this option is left empty.
 .PP
 .EX
     promptfmt      string    (default "\e033[32;1m%u@%h\e033[0m:\e033[34;1m%w/\e033[0m\e033[1m%f\e033[0m")

--- a/nav.go
+++ b/nav.go
@@ -471,7 +471,7 @@ func (nav *nav) previewLoop(ui *ui) {
 			nav.preview(p, win)
 			path = p
 		} else if len(gOpts.previewer) != 0 && len(gOpts.cleaner) != 0 && nav.volatilePreview {
-			cmd := exec.Command(gOpts.cleaner)
+			cmd := exec.Command(gOpts.cleaner, path)
 			if err := cmd.Run(); err != nil {
 				log.Printf("cleaning preview: %s", err)
 			}

--- a/nav.go
+++ b/nav.go
@@ -545,17 +545,15 @@ func (nav *nav) loadReg(path string, win *win) *reg {
 		return r
 	}
 
-	if nav.checkReg(r) {
-		go nav.preview(path, win)
-	}
+	nav.checkReg(r)
 
 	return r
 }
 
-func (nav *nav) checkReg(reg *reg) bool {
+func (nav *nav) checkReg(reg *reg) {
 	s, err := os.Stat(reg.path)
 	if err != nil {
-		return false
+		return
 	}
 
 	now := time.Now()
@@ -563,15 +561,13 @@ func (nav *nav) checkReg(reg *reg) bool {
 	// XXX: Linux builtin exFAT drivers are able to predict modifications in the future
 	// https://bugs.launchpad.net/ubuntu/+source/ubuntu-meta/+bug/1872504
 	if s.ModTime().After(now) {
-		return false
+		return
 	}
 
 	if s.ModTime().After(reg.loadTime) {
 		reg.loadTime = now
-		return true
+		go nav.preview(reg.path)
 	}
-
-	return false
 }
 
 func (nav *nav) sort() {

--- a/nav.go
+++ b/nav.go
@@ -285,6 +285,7 @@ type nav struct {
 	moveTotalChan   chan int
 	deleteCountChan chan int
 	deleteTotalChan chan int
+	previewChan     chan string
 	dirChan         chan *dir
 	regChan         chan *reg
 	dirCache        map[string]*dir
@@ -398,6 +399,7 @@ func newNav(height int) *nav {
 		moveTotalChan:   make(chan int, 1024),
 		deleteCountChan: make(chan int, 1024),
 		deleteTotalChan: make(chan int, 1024),
+		previewChan:     make(chan string, 1024),
 		dirChan:         make(chan *dir),
 		regChan:         make(chan *reg),
 		dirCache:        make(map[string]*dir),
@@ -457,6 +459,27 @@ func (nav *nav) position() {
 	}
 }
 
+func (nav *nav) previewLoop(ui *ui) {
+	var path string
+	for {
+		p, ok := <-nav.previewChan
+		if !ok {
+			return
+		}
+		if len(p) != 0 {
+			win := ui.wins[len(ui.wins)-1]
+			nav.preview(p, win)
+			path = p
+		} else if len(gOpts.previewer) != 0 && len(gOpts.cleaner) != 0 && nav.volatilePreview {
+			cmd := exec.Command(gOpts.cleaner)
+			if err := cmd.Run(); err != nil {
+				log.Printf("cleaning preview: %s", err)
+			}
+			nav.volatilePreview = false
+		}
+	}
+}
+
 func (nav *nav) preview(path string, win *win) {
 	reg := &reg{loadTime: time.Now(), path: path}
 	defer func() { nav.regChan <- reg }()
@@ -487,8 +510,8 @@ func (nav *nav) preview(path string, win *win) {
 			if err := cmd.Wait(); err != nil {
 				if e, ok := err.(*exec.ExitError); ok {
 					if e.ExitCode() != 0 {
-						nav.volatilePreview = true
 						reg.volatile = true
+						nav.volatilePreview = true
 					}
 				} else {
 					log.Printf("loading file: %s", err)
@@ -525,23 +548,12 @@ func (nav *nav) preview(path string, win *win) {
 	}
 }
 
-func (nav *nav) previewClear() {
-	if len(gOpts.cleaner) != 0 && nav.volatilePreview {
-		nav.volatilePreview = false
-
-		cmd := exec.Command(gOpts.cleaner)
-		if err := cmd.Run(); err != nil {
-			log.Printf("cleaning preview: %s", err)
-		}
-	}
-}
-
-func (nav *nav) loadReg(path string, win *win) *reg {
+func (nav *nav) loadReg(path string) *reg {
 	r, ok := nav.regCache[path]
 	if !ok || r.volatile {
 		r := &reg{loading: true, loadTime: time.Now(), path: path, volatile: true}
 		nav.regCache[path] = r
-		go nav.preview(path, win)
+		nav.previewChan <- path
 		return r
 	}
 
@@ -566,7 +578,7 @@ func (nav *nav) checkReg(reg *reg) {
 
 	if s.ModTime().After(reg.loadTime) {
 		reg.loadTime = now
-		go nav.preview(reg.path)
+		nav.previewChan <- reg.path
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -13,7 +13,7 @@ var (
 	gCopyFile bool
 	gFileList []string
 	gConnList = make(map[int]net.Conn)
-	gQuitChan = make(chan bool, 1)
+	gQuitChan = make(chan struct{}, 1)
 	gListener net.Listener
 )
 
@@ -115,7 +115,7 @@ Loop:
 				}
 			}
 		case "quit":
-			gQuitChan <- true
+			gQuitChan <- struct{}{}
 			for _, c := range gConnList {
 				fmt.Fprintln(c, "echo server is quitting...")
 				c.Close()

--- a/ui.go
+++ b/ui.go
@@ -625,12 +625,11 @@ func (ui *ui) loadFile(nav *nav) {
 		return
 	}
 
-	go nav.previewClear()
+	nav.previewChan <- ""
 	if curr.IsDir() {
 		ui.dirPrev = nav.loadDir(curr.path)
 	} else if curr.Mode().IsRegular() {
-		win := ui.wins[len(ui.wins)-1]
-		ui.regPrev = nav.loadReg(curr.path, win)
+		ui.regPrev = nav.loadReg(curr.path)
 	}
 }
 


### PR DESCRIPTION
This is a followup to the discussion in https://github.com/gokcehan/lf/pull/531 (see: https://github.com/gokcehan/lf/pull/531#issuecomment-751147416)

I have successfully been able to produce a good ordering on calls to the preview and cleaner scripts. No matter how much delay I add to either script, the order always looks like this in my testing:
```
begin pv <first_path> <w> <h> <x> <y>
end pv <first_path> <w> <h> <x> <y>
begin cls <first_path>
end cls <first_path>
begin pv <second_path> <w> <h> <x> <y>
end pv <second_path> <w> <h> <x> <y>
...
```

This solution also only blocks threads responsible for waiting on the previewer script and executing the cleaner script, so these changes don't block the UI itself.

I've also included a commit which passes the file path to the cleaner script.