### PR TITLE
make sortby ext work as expected

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -200,7 +200,7 @@ func (dir *dir) sort() {
 
 			// in order to also have natural sorting with the filenames
 			// combine the name with the ext but have the ext at the front
-			return (ext1 + name1) < (ext2 + name2)
+			return ext1 < ext2 || ext1 == ext2 && name1 < name2
 		})
 	}
 


### PR DESCRIPTION
When sorting by extension, name and extension of the compared files will get mixed up and produce wrong results. The following files will be sorted exactly as shown
```
a.b
a.ba
b.b
```