### PR TITLE
Added Ability to change window title

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -133,6 +133,7 @@ var (
 		"previewer",
 		"cleaner",
 		"promptfmt",
+		"titlefmt",
 		"ratios",
 		"shell",
 		"shellopts",

--- a/eval.go
+++ b/eval.go
@@ -267,6 +267,8 @@ func (e *setExpr) eval(app *app, args []string) {
 		gOpts.cleaner = replaceTilde(e.val)
 	case "promptfmt":
 		gOpts.promptfmt = e.val
+	case "titlefmt":
+		gOpts.titlefmt = e.val
 	case "ratios":
 		toks := strings.Split(e.val, ":")
 		var rats []int

--- a/opts.go
+++ b/opts.go
@@ -53,6 +53,7 @@ var gOpts struct {
 	previewer      string
 	cleaner        string
 	promptfmt      string
+	titlefmt       string
 	shell          string
 	timefmt        string
 	truncatechar   string
@@ -92,6 +93,7 @@ func init() {
 	gOpts.previewer = ""
 	gOpts.cleaner = ""
 	gOpts.promptfmt = "\033[32;1m%u@%h\033[0m:\033[34;1m%w\033[0m\033[1m%f\033[0m"
+	gOpts.titlefmt = ""
 	gOpts.shell = gDefaultShell
 	gOpts.timefmt = time.ANSIC
 	gOpts.truncatechar = "~"

--- a/ui.go
+++ b/ui.go
@@ -693,6 +693,34 @@ func (ui *ui) drawPromptLine(nav *nav) {
 	ui.promptWin.print(ui.screen, 0, 0, st, prompt)
 }
 
+func setWinTitle(nav *nav) {
+	pwd := nav.currDir().path
+
+	if strings.HasPrefix(pwd, gUser.HomeDir) {
+		pwd = filepath.Join("~", strings.TrimPrefix(pwd, gUser.HomeDir))
+	}
+
+	sep := string(filepath.Separator)
+
+	if !strings.HasSuffix(pwd, sep) {
+		pwd += sep
+	}
+
+	var fname string
+	curr, err := nav.currFile()
+	if err == nil {
+		fname = filepath.Base(curr.path)
+	}
+
+	var title string
+	title = strings.Replace(gOpts.titlefmt, "%u", gUser.Username, -1)
+	title = strings.Replace(title, "%h", gHostname, -1)
+	title = strings.Replace(title, "%f", fname, -1)
+	title = strings.Replace(title, "%w", pwd, -1)
+
+	fmt.Printf("\033]2;%s\a", title)
+}
+
 func (ui *ui) drawStatLine(nav *nav) {
 	st := tcell.StyleDefault
 
@@ -766,6 +794,9 @@ func (ui *ui) draw(nav *nav) {
 	}
 
 	ui.drawPromptLine(nav)
+	if gOpts.titlefmt != "" {
+		setWinTitle(nav)
+	}
 
 	length := min(len(ui.wins), len(nav.dirs))
 	woff := len(ui.wins) - length


### PR DESCRIPTION
I added the ability to change the title of the terminal window, that `lf` is running in.
The title can be changed using the `titlefmt` option. The syntax is the same as in `promptfmt`.
The title is also only updated, if the `titlefmt` option is non empty, so it isn't updated by default.
I don't know how / if the updating of the title works on window, so I only implemented a Linux solution.