### PR TITLE
Added new Promptfmt Option to remove trailing separator

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -673,7 +673,7 @@ func (ui *ui) drawPromptLine(nav *nav) {
 	prompt = strings.Replace(prompt, "%h", gHostname, -1)
 	prompt = strings.Replace(prompt, "%f", fname, -1)
 
-	if printLength(strings.Replace(prompt, "%w", pwd, -1)) > ui.promptWin.w {
+	if printLength(strings.Replace(prompt, "%w", pwd, -1)) > ui.promptWin.w || printLength(strings.Replace(prompt, "%W", pwd, -1)) > ui.promptWin.w {
 		names := strings.Split(pwd, sep)
 		for i := range names {
 			if names[i] == "" {
@@ -681,7 +681,7 @@ func (ui *ui) drawPromptLine(nav *nav) {
 			}
 			r, _ := utf8.DecodeRuneInString(names[i])
 			names[i] = string(r)
-			if printLength(strings.Replace(prompt, "%w", strings.Join(names, sep), -1)) <= ui.promptWin.w {
+			if printLength(strings.Replace(prompt, "%w", strings.Join(names, sep), -1)) <= ui.promptWin.w || printLength(strings.Replace(prompt, "%W", strings.Join(names, sep), -1)) <= ui.promptWin.w {
 				break
 			}
 		}
@@ -689,6 +689,11 @@ func (ui *ui) drawPromptLine(nav *nav) {
 	}
 
 	prompt = strings.Replace(prompt, "%w", pwd, -1)
+	if pwd != "/" {
+		// Don't remove root folder
+		pwd = strings.TrimSuffix(pwd, sep)
+	}
+	prompt = strings.Replace(prompt, "%W", pwd, -1)
 
 	ui.promptWin.print(ui.screen, 0, 0, st, prompt)
 }

--- a/ui.go
+++ b/ui.go
@@ -689,8 +689,7 @@ func (ui *ui) drawPromptLine(nav *nav) {
 	}
 
 	prompt = strings.Replace(prompt, "%w", pwd, -1)
-	if pwd != "/" {
-		// Don't remove root folder
+	if pwd != sep { // Don't remove root folder
 		pwd = strings.TrimSuffix(pwd, sep)
 	}
 	prompt = strings.Replace(prompt, "%W", pwd, -1)

--- a/ui.go
+++ b/ui.go
@@ -657,10 +657,6 @@ func (ui *ui) drawPromptLine(nav *nav) {
 
 	sep := string(filepath.Separator)
 
-	if !strings.HasSuffix(pwd, sep) {
-		pwd += sep
-	}
-
 	var fname string
 	curr, err := nav.currFile()
 	if err == nil {
@@ -673,7 +669,7 @@ func (ui *ui) drawPromptLine(nav *nav) {
 	prompt = strings.Replace(prompt, "%h", gHostname, -1)
 	prompt = strings.Replace(prompt, "%f", fname, -1)
 
-	if printLength(strings.Replace(prompt, "%w", pwd, -1)) > ui.promptWin.w || printLength(strings.Replace(prompt, "%W", pwd, -1)) > ui.promptWin.w {
+	if printLength(strings.Replace(strings.Replace(prompt, "%w", pwd, -1), "%d", pwd, -1)) > ui.promptWin.w {
 		names := strings.Split(pwd, sep)
 		for i := range names {
 			if names[i] == "" {
@@ -681,7 +677,7 @@ func (ui *ui) drawPromptLine(nav *nav) {
 			}
 			r, _ := utf8.DecodeRuneInString(names[i])
 			names[i] = string(r)
-			if printLength(strings.Replace(prompt, "%w", strings.Join(names, sep), -1)) <= ui.promptWin.w || printLength(strings.Replace(prompt, "%W", strings.Join(names, sep), -1)) <= ui.promptWin.w {
+			if printLength(strings.Replace(strings.Replace(prompt, "%w", strings.Join(names, sep), -1), "%d", strings.Join(names, sep), -1)) <= ui.promptWin.w {
 				break
 			}
 		}
@@ -689,10 +685,10 @@ func (ui *ui) drawPromptLine(nav *nav) {
 	}
 
 	prompt = strings.Replace(prompt, "%w", pwd, -1)
-	if pwd != sep { // Don't remove root folder
-		pwd = strings.TrimSuffix(pwd, sep)
+	if !strings.HasSuffix(pwd, sep) {
+		pwd += sep
 	}
-	prompt = strings.Replace(prompt, "%W", pwd, -1)
+	prompt = strings.Replace(prompt, "%d", pwd, -1)
 
 	ui.promptWin.print(ui.screen, 0, 0, st, prompt)
 }


### PR DESCRIPTION
I added a new format option for `promptfmt`.
The new option is named `%W` and behaves exactly like `%w`, but doesn't append a trailing separator.
I made sure it also works correctly in the root folder (`/`).
This fixes #528.