### PR TITLE
Allow multiple -command flags

### DIFF
--- a/app.go
+++ b/app.go
@@ -183,8 +183,8 @@ func (app *app) loop() {
 		}
 	}
 
-	if gCommand != "" {
-		p := newParser(strings.NewReader(gCommand))
+	for _, cmd := range gCommands {
+		p := newParser(strings.NewReader(cmd))
 
 		for p.parse() {
 			p.expr.eval(app, nil)

--- a/main.go
+++ b/main.go
@@ -11,12 +11,15 @@ import (
 	"runtime"
 	"runtime/pprof"
 	"strconv"
+	"strings"
 )
 
 var (
 	envPath  = os.Getenv("PATH")
 	envLevel = os.Getenv("LF_LEVEL")
 )
+
+type arrayFlag []string
 
 var (
 	gClientID      int
@@ -28,9 +31,18 @@ var (
 	gLogPath       string
 	gServerLogPath string
 	gSelect        string
-	gCommand       string
+	gCommands      arrayFlag
 	gVersion       string
 )
+
+func (a *arrayFlag) Set(v string) error {
+	*a = append(*a, v)
+	return nil
+}
+
+func (a *arrayFlag) String() string {
+	return strings.Join(*a, ", ")
+}
 
 func init() {
 	h, err := os.Hostname()
@@ -205,9 +217,8 @@ func main() {
 		"",
 		"path to the file to write selected files on open (to use as open file dialog)")
 
-	flag.StringVar(&gCommand,
+	flag.Var(&gCommands,
 		"command",
-		"",
 		"command to execute on client initialization")
 
 	flag.Parse()


### PR DESCRIPTION
Implements #551
I did not change the flag description because I feel like allowing multiple instances is a natural default for a flag like this.