### PR TITLE
Exhaust queued entries in previewChan prior to calling preview script

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -460,18 +460,14 @@ func (nav *nav) position() {
 }
 
 func (nav *nav) previewLoop(ui *ui) {
-	var path string
-	for {
-		p, ok := <-nav.previewChan
-		if !ok {
-			return
-		}
-		if len(p) != 0 {
+	var prev string
+	for path := range nav.previewChan {
+		if len(path) != 0 {
 			win := ui.wins[len(ui.wins)-1]
-			nav.preview(p, win)
-			path = p
+			nav.preview(path, win)
+			prev = path
 		} else if len(gOpts.previewer) != 0 && len(gOpts.cleaner) != 0 && nav.volatilePreview {
-			cmd := exec.Command(gOpts.cleaner, path)
+			cmd := exec.Command(gOpts.cleaner, prev)
 			if err := cmd.Run(); err != nil {
 				log.Printf("cleaning preview: %s", err)
 			}


### PR DESCRIPTION
I've noticed that ever since #546 when rapidly moving between a large amount of files, the `previewLoop` thread can take a while to catch up to the currently selected file. It will try to clear and preview every file. It becomes especially apparent when previewing files over the network. This PR fixes that by avoiding redundant calls to the preview script. I've added logic to consume all available values in `previewChan` before a call to either the previewer or cleaner is made. Also, if `""` is sent over the channel immediately before a valid path, `previewLoop` will still call the cleaner script and then the previewer script, just like before.