### PR TITLE
Avoid redundantly loading previews for search/find

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -455,9 +455,9 @@ func insert(app *app, arg string) {
 				return
 			}
 
-			if !app.nav.findNext() {
+			if moved, found := app.nav.findNext(); !found {
 				app.ui.echoerrf("find: pattern not found: %s", app.nav.find)
-			} else {
+			} else if moved {
 				app.ui.loadFile(app.nav, true)
 				app.ui.loadFileInfo(app.nav)
 			}
@@ -484,9 +484,9 @@ func insert(app *app, arg string) {
 				return
 			}
 
-			if !app.nav.findPrev() {
+			if moved, found := app.nav.findPrev(); !found {
 				app.ui.echoerrf("find-back: pattern not found: %s", app.nav.find)
-			} else {
+			} else if moved {
 				app.ui.loadFile(app.nav, true)
 				app.ui.loadFileInfo(app.nav)
 			}
@@ -854,6 +854,8 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.nav.findBack = true
 		app.ui.loadFileInfo(app.nav)
 	case "find-next":
+		dir := app.nav.currDir()
+		old := dir.ind
 		for i := 0; i < e.count; i++ {
 			if app.nav.findBack {
 				app.nav.findPrev()
@@ -861,9 +863,13 @@ func (e *callExpr) eval(app *app, args []string) {
 				app.nav.findNext()
 			}
 		}
-		app.ui.loadFile(app.nav, true)
-		app.ui.loadFileInfo(app.nav)
+		if old != dir.ind {
+			app.ui.loadFile(app.nav, true)
+			app.ui.loadFileInfo(app.nav)
+		}
 	case "find-prev":
+		dir := app.nav.currDir()
+		old := dir.ind
 		for i := 0; i < e.count; i++ {
 			if app.nav.findBack {
 				app.nav.findNext()
@@ -871,8 +877,10 @@ func (e *callExpr) eval(app *app, args []string) {
 				app.nav.findPrev()
 			}
 		}
-		app.ui.loadFile(app.nav, true)
-		app.ui.loadFileInfo(app.nav)
+		if old != dir.ind {
+			app.ui.loadFile(app.nav, true)
+			app.ui.loadFileInfo(app.nav)
+		}
 	case "search":
 		app.ui.cmdPrefix = "/"
 		dir := app.nav.currDir()

--- a/nav.go
+++ b/nav.go
@@ -1123,42 +1123,38 @@ func (nav *nav) findSingle() int {
 	return count
 }
 
-func (nav *nav) findNext() bool {
+func (nav *nav) findNext() (bool, bool) {
 	dir := nav.currDir()
 	for i := dir.ind + 1; i < len(dir.files); i++ {
 		if findMatch(dir.files[i].Name(), nav.find) {
-			nav.down(i - dir.ind)
-			return true
+			return nav.down(i - dir.ind), true
 		}
 	}
 	if gOpts.wrapscan {
 		for i := 0; i < dir.ind; i++ {
 			if findMatch(dir.files[i].Name(), nav.find) {
-				nav.up(dir.ind - i)
-				return true
+				return nav.up(dir.ind - i), true
 			}
 		}
 	}
-	return false
+	return false, false
 }
 
-func (nav *nav) findPrev() bool {
+func (nav *nav) findPrev() (bool, bool) {
 	dir := nav.currDir()
 	for i := dir.ind - 1; i >= 0; i-- {
 		if findMatch(dir.files[i].Name(), nav.find) {
-			nav.up(dir.ind - i)
-			return true
+			return nav.up(dir.ind - i), true
 		}
 	}
 	if gOpts.wrapscan {
 		for i := len(dir.files) - 1; i > dir.ind; i-- {
 			if findMatch(dir.files[i].Name(), nav.find) {
-				nav.down(i - dir.ind)
-				return true
+				return nav.down(i - dir.ind), true
 			}
 		}
 	}
-	return false
+	return false, false
 }
 
 func searchMatch(name, pattern string) (matched bool, err error) {

--- a/nav.go
+++ b/nav.go
@@ -1178,58 +1178,46 @@ func searchMatch(name, pattern string) (matched bool, err error) {
 	return strings.Contains(name, pattern), nil
 }
 
-func (nav *nav) searchNext() error {
+func (nav *nav) searchNext() (bool, error) {
 	dir := nav.currDir()
 	for i := dir.ind + 1; i < len(dir.files); i++ {
-		matched, err := searchMatch(dir.files[i].Name(), nav.search)
-		if err != nil {
-			return err
-		}
-		if matched {
-			nav.down(i - dir.ind)
-			return nil
+		if matched, err := searchMatch(dir.files[i].Name(), nav.search); err != nil {
+			return false, err
+		} else if matched {
+			return nav.down(i - dir.ind), nil
 		}
 	}
 	if gOpts.wrapscan {
 		for i := 0; i < dir.ind; i++ {
-			matched, err := searchMatch(dir.files[i].Name(), nav.search)
-			if err != nil {
-				return err
-			}
-			if matched {
-				nav.up(dir.ind - i)
-				return nil
+			if matched, err := searchMatch(dir.files[i].Name(), nav.search); err != nil {
+				return false, err
+			} else if matched {
+				return nav.up(dir.ind - i), nil
 			}
 		}
 	}
-	return nil
+	return false, nil
 }
 
-func (nav *nav) searchPrev() error {
+func (nav *nav) searchPrev() (bool, error) {
 	dir := nav.currDir()
 	for i := dir.ind - 1; i >= 0; i-- {
-		matched, err := searchMatch(dir.files[i].Name(), nav.search)
-		if err != nil {
-			return err
-		}
-		if matched {
-			nav.up(dir.ind - i)
-			return nil
+		if matched, err := searchMatch(dir.files[i].Name(), nav.search); err != nil {
+			return false, err
+		} else if matched {
+			return nav.up(dir.ind - i), nil
 		}
 	}
 	if gOpts.wrapscan {
 		for i := len(dir.files) - 1; i > dir.ind; i-- {
-			matched, err := searchMatch(dir.files[i].Name(), nav.search)
-			if err != nil {
-				return err
-			}
-			if matched {
-				nav.down(i - dir.ind)
-				return nil
+			if matched, err := searchMatch(dir.files[i].Name(), nav.search); err != nil {
+				return false, err
+			} else if matched {
+				return nav.down(i - dir.ind), nil
 			}
 		}
 	}
-	return nil
+	return false, nil
 }
 
 func (nav *nav) removeMark(mark string) error {


### PR DESCRIPTION
This is a followup to https://github.com/gokcehan/lf/pull/562#issuecomment-762547551
This PR avoids redundantly invoking the previewer script upon using find or searching (both normal and incremental). Find and search methods now return the result of `nav.up`/`nav.down`, and in `eval.go` I've inserted checks corresponding checks. In some locations I had to manually check if the current `dir.ind` differs from its previous value.