### PR TITLE
Added ability to use a custom config file

### DIFF
--- a/app.go
+++ b/app.go
@@ -174,9 +174,17 @@ func (app *app) loop() {
 		}()
 	}
 
-	for _, path := range gConfigPaths {
-		if _, err := os.Stat(path); !os.IsNotExist(err) {
-			app.readFile(path)
+	if gCustomConfig != "" {
+		if _, err := os.Stat(gCustomConfig); !os.IsNotExist(err) {
+			app.readFile(gCustomConfig)
+		} else {
+			log.Printf("Config file does not exist: %s", err)
+		}
+	} else {
+		for _, path := range gConfigPaths {
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				app.readFile(path)
+			}
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ var (
 	gLogPath       string
 	gServerLogPath string
 	gSelect        string
+	gCustomConfig  string
 	gCommands      arrayFlag
 	gVersion       string
 )
@@ -216,6 +217,11 @@ func main() {
 		"selection-path",
 		"",
 		"path to the file to write selected files on open (to use as open file dialog)")
+
+	flag.StringVar(&gCustomConfig,
+		"config",
+		"",
+		"path to a custom config file to be used, instead of normal lfrc file")
 
 	flag.Var(&gCommands,
 		"command",


### PR DESCRIPTION
I added the ability to load a custom config file, by starting lf with the `-config` option.
This is very usefull, when someone wants different mappings for different use cases.
If one specifies a custom config file, the normal `lfrc` file is not loaded, in order to avoid conflicts. (But if someone wanted, the file could still be loaded manually with the `source` command.)
If the file does not exist, it will log an error and load nothing. Therefor this is also an easy way, to load lf with no custom config.