### PR TITLE
Make ratios behave like ratios

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -499,7 +499,7 @@ func getWidths(wtot int) []int {
 
 	wsum := 0
 	for i := 0; i < wlen-1; i++ {
-		widths[i] = gOpts.ratios[i] * (wtot / rsum)
+		widths[i] = gOpts.ratios[i] * wtot / rsum
 		wsum += widths[i]
 	}
 	widths[wlen-1] = wtot - wsum


### PR DESCRIPTION
Integer division causes miscalculation of pane widths. With `set ratios 100:200:300` the first two panes have width 0, the third pane will take up all space (unless you happen to have a huge terminal). I noticed this when fine tuning ratios, e.g. going from `1:2:3` to something like `10:21:30`.