### PR TITLE
Preserve special ' bookmark on sync

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -1010,7 +1010,13 @@ func (nav *nav) sync() error {
 		nav.saves[f] = cp
 	}
 
-	return nav.readMarks()
+	path, ok := nav.marks["'"]
+	err = nav.readMarks()
+	if ok {
+		nav.marks["'"] = path
+	}
+
+	return err
 }
 
 func (nav *nav) cd(wd string) error {


### PR DESCRIPTION
When `sync` is called bookmarks are reloaded from disc and the special `'` bookmark is lost. This results in an error if there is no `'` in the bookmarks file, more likely it will take you to whatever directory was saved previously (always the home directory for me). This makes it impossible to jump back and forth between directories with `''` to copy/paste files, since `sync` is called when the file selection changes.

I hope the error handling makes sense. `'` can still be preserved even if reading the bookmark file fails.