### PR TITLE
Don't use the absolute path when saving bookmarks

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -605,12 +605,7 @@ func insert(app *app, arg string) {
 	case app.ui.cmdPrefix == "mark-save: ":
 		normal(app)
 
-		wd, err := os.Getwd()
-		if err != nil {
-			log.Printf("getting current directory: %s", err)
-			return
-		}
-		app.nav.marks[arg] = wd
+		app.nav.marks[arg] = app.nav.currDir().path
 		if err := app.nav.writeMarks(); err != nil {
 			app.ui.echoerrf("mark-save: %s", err)
 		}


### PR DESCRIPTION
The absolute path of symlinks were getting saved, so bookmarking a symlink
directory would cause the absolute path to be saved and loaded instead.
What's saved now is the current path string as understood by lf instead, so
path to symlinks can be saved too and they won't get dereferenced when
loading.

I hope this doesn't cause any problems. It works perfectly fine for me on Linux.