### PR TITLE
Allow to configure time format in the info column

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -157,6 +157,8 @@ var (
 		"shellopts",
 		"sortby",
 		"timefmt",
+		"timefmtthisy",
+		"timefmtothery",
 		"truncatechar",
 	}
 )

--- a/doc.go
+++ b/doc.go
@@ -138,6 +138,8 @@ The following options can be used to customize the behavior of lf:
     sortby         string    (default 'natural')
     tabstop        int       (default 8)
     timefmt        string    (default 'Mon Jan _2 15:04:05 2006')
+    timefmtthisy   string    (default 'Jan _2 15:04')
+    timefmtothery  string    (default 'Jan _2  2006')
     truncatechar   string    (default '~')
     waitmsg        string    (default 'Press any key to continue')
     wrapscan       bool      (default on)
@@ -711,6 +713,14 @@ Number of space characters to show for horizontal tabulation (U+0009) character.
     timefmt        string    (default 'Mon Jan _2 15:04:05 2006')
 
 Format string of the file modification time shown in the bottom line.
+
+    timefmtthisy   string    (default 'Jan _2 15:04')
+
+Format string of the file time shown in the info column when it matches this year.
+
+    timefmtothery  string    (default 'Jan _2  2006')
+
+Format string of the file time shown in the info column when it doesn't match this year.
 
     truncatechar   string    (default '~')
 

--- a/docstring.go
+++ b/docstring.go
@@ -142,6 +142,8 @@ The following options can be used to customize the behavior of lf:
     sortby         string    (default 'natural')
     tabstop        int       (default 8)
     timefmt        string    (default 'Mon Jan _2 15:04:05 2006')
+    timefmtthisy   string    (default 'Jan _2 15:04')
+    timefmtothery  string    (default 'Jan _2  2006')
     truncatechar   string    (default '~')
     waitmsg        string    (default 'Press any key to continue')
     wrapscan       bool      (default on)
@@ -759,6 +761,16 @@ character.
     timefmt        string    (default 'Mon Jan _2 15:04:05 2006')
 
 Format string of the file modification time shown in the bottom line.
+
+    timefmtthisy   string    (default 'Jan _2 15:04')
+
+Format string of the file time shown in the info column when it matches this
+year.
+
+    timefmtothery  string    (default 'Jan _2  2006')
+
+Format string of the file time shown in the info column when it doesn't
+match this year.
 
     truncatechar   string    (default '~')
 

--- a/eval.go
+++ b/eval.go
@@ -412,6 +412,10 @@ func (e *setExpr) eval(app *app, args []string) {
 		app.ui.sort()
 	case "timefmt":
 		gOpts.timefmt = e.val
+	case "timefmtthisy":
+		gOpts.timefmtthisy = e.val
+	case "timefmtothery":
+		gOpts.timefmtothery = e.val
 	case "truncatechar":
 		if runeSliceWidth([]rune(e.val)) != 1 {
 			app.ui.echoerr("truncatechar: value should be a single character")

--- a/lf.1
+++ b/lf.1
@@ -157,6 +157,8 @@ The following options can be used to customize the behavior of lf:
     sortby         string    (default 'natural')
     tabstop        int       (default 8)
     timefmt        string    (default 'Mon Jan _2 15:04:05 2006')
+    timefmtthisy   string    (default 'Jan _2 15:04')
+    timefmtothery  string    (default 'Jan _2  2006')
     truncatechar   string    (default '~')
     waitmsg        string    (default 'Press any key to continue')
     wrapscan       bool      (default on)
@@ -859,6 +861,18 @@ Number of space characters to show for horizontal tabulation (U+0009) character.
 .EE
 .PP
 Format string of the file modification time shown in the bottom line.
+.PP
+.EX
+    timefmtthisy   string    (default 'Jan _2 15:04')
+.EE
+.PP
+Format string of the file time shown in the info column when it matches this year.
+.PP
+.EX
+    timefmtothery  string    (default 'Jan _2  2006')
+.EE
+.PP
+Format string of the file time shown in the info column when it doesn't match this year.
 .PP
 .EX
     truncatechar   string    (default '~')

--- a/opts.go
+++ b/opts.go
@@ -62,6 +62,8 @@ var gOpts struct {
 	shell          string
 	shellflag      string
 	timefmt        string
+	timefmtthisy   string
+	timefmtothery  string
 	truncatechar   string
 	ratios         []int
 	hiddenfiles    []string
@@ -108,6 +110,8 @@ func init() {
 	gOpts.shell = gDefaultShell
 	gOpts.shellflag = gDefaultShellFlag
 	gOpts.timefmt = time.ANSIC
+	gOpts.timefmtthisy = "Jan _2 15:04"
+	gOpts.timefmtothery = "Jan _2  2006"
 	gOpts.truncatechar = "~"
 	gOpts.ratios = []int{1, 2, 3}
 	gOpts.hiddenfiles = []string{".*"}

--- a/ui.go
+++ b/ui.go
@@ -279,9 +279,9 @@ var gThisYear = time.Now().Year()
 
 func infotimefmt(t time.Time) string {
 	if t.Year() == gThisYear {
-		return t.Format("Jan _2 15:04")
+		return t.Format(gOpts.timefmtthisy)
 	}
-	return t.Format("Jan _2  2006")
+	return t.Format(gOpts.timefmtothery)
 }
 
 func fileInfo(f *file, d *dir) string {


### PR DESCRIPTION
I was looking for a config option for the time format in the info colum. I've found out that the formats were hardcoded.

I'm extracting the formats into the config. Maybe more user would find this useful (I'm not convinced about the naming though, but I couldn't come up with anything else).