### PR TITLE
added pre-cd command

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1256,6 +1256,9 @@ You can add an extra call to make it run on startup as well:
 
 Note that all shell commands are possible but `%` and `&` are usually more appropriate as `$` and `!` causes flickers and pauses respectively.
 
+There is also a 'pre-cd' command, that works like 'on-cd', but is run before the directory is actually changed.
+It is generally a bad idea, to put movement commands (like 'up' / 'top' etc.) here.
+
 Colors
 
 lf tries to automatically adapt its colors to the environment.

--- a/docstring.go
+++ b/docstring.go
@@ -1407,6 +1407,10 @@ add an extra call to make it run on startup as well:
 Note that all shell commands are possible but '%' and '&' are usually more
 appropriate as '$' and '!' causes flickers and pauses respectively.
 
+There is also a 'pre-cd' command, that works like 'on-cd', but is run before
+the directory is actually changed. It is generally a bad idea, to put
+movement commands (like 'up' / 'top' etc.) here.
+
 
 Colors
 

--- a/lf.1
+++ b/lf.1
@@ -1399,6 +1399,8 @@ This command runs whenever you change directory but not on startup. You can add 
 .EE
 .PP
 Note that all shell commands are possible but `%` and `&` are usually more appropriate as `$` and `!` causes flickers and pauses respectively.
+.PP
+There is also a 'pre-cd' command, that works like 'on-cd', but is run before the directory is actually changed. It is generally a bad idea, to put movement commands (like 'up' / 'top' etc.) here.
 .SH COLORS
 lf tries to automatically adapt its colors to the environment. It starts with a default colorscheme and updates colors using values of existing environment variables possibly by overwriting its previous values. Colors are set in the following order:
 .PP


### PR DESCRIPTION
I added a `pre-cd` command, that works very simmilar to the `on-cd` command, but is called before the cd actually happens. This means all commands are executed in the old directory.
There is one very small caveat however: since we call `pre-cd` before we do the cd, we don't actually know, if the cd will run sucessfully and without errors. This means, unlike `on-cd`, `pre-cd` is run, even when the cd fails.
(Another thing to be aware of, is that movement commands naturally change the selected file. This means that any movement commands in `pre-cd` will cause the selection to change and actually cd into another directory.)