### PR TITLE
make cmap behave more like map

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -436,10 +436,10 @@ func (e *mapExpr) eval(app *app, args []string) {
 }
 
 func (e *cmapExpr) eval(app *app, args []string) {
-	if e.cmd == "" {
+	if e.expr == nil {
 		delete(gOpts.cmdkeys, e.key)
 	} else {
-		gOpts.cmdkeys[e.key] = &callExpr{e.cmd, nil, 1}
+		gOpts.cmdkeys[e.key] = e.expr
 	}
 	app.ui.loadFileInfo(app.nav)
 }

--- a/eval_test.go
+++ b/eval_test.go
@@ -218,7 +218,7 @@ var gEvalTests = []struct {
 	{
 		"cmap <c-g> cmd-escape",
 		[]string{"cmap", "<c-g>", "cmd-escape", "\n"},
-		[]expr{&cmapExpr{"<c-g>", "cmd-escape"}},
+		[]expr{&cmapExpr{"<c-g>", &callExpr{"cmd-escape", nil, 1}}},
 	},
 
 	{

--- a/parse.go
+++ b/parse.go
@@ -14,7 +14,7 @@ package main
 //
 // MapExpr  = 'map' <keys> Expr
 //
-// CMapExpr = 'cmap' <key> <cmd> ';'
+// CMapExpr = 'cmap' <key> Expr
 //
 // CmdExpr  = 'cmd' <name> Expr
 //
@@ -58,11 +58,11 @@ type mapExpr struct {
 func (e *mapExpr) String() string { return fmt.Sprintf("map %s %s", e.keys, e.expr) }
 
 type cmapExpr struct {
-	key string
-	cmd string
+	key  string
+	expr expr
 }
 
-func (e *cmapExpr) String() string { return fmt.Sprintf("cmap %s %s", e.key, e.cmd) }
+func (e *cmapExpr) String() string { return fmt.Sprintf("cmap %s %s", e.key, e.expr) }
 
 type cmdExpr struct {
 	name string
@@ -191,23 +191,19 @@ func (p *parser) parseExpr() expr {
 
 			result = &mapExpr{keys, expr}
 		case "cmap":
-			var cmd string
+			var expr expr
 
 			s.scan()
 			key := s.tok
 
 			s.scan()
 			if s.typ != tokenSemicolon {
-				if s.typ != tokenIdent {
-					p.err = fmt.Errorf("expected command: %s", s.tok)
-				}
-				cmd = s.tok
+				expr = p.parseExpr()
+			} else {
 				s.scan()
 			}
 
-			s.scan()
-
-			result = &cmapExpr{key, cmd}
+			result = &cmapExpr{key, expr}
 		case "cmd":
 			var expr expr
 


### PR DESCRIPTION
I was a bit bothered by the fact, that `cmap` can only ever execute one command, unlike `map`, which can accept multiline commands and custom commands. I noticed that the current logic already supports all types of expressions for `cmap` (because `map` already does, and they use the same evaluation code), the only thing preventing us from doing so is the parser. So I changed the parser, so that `map` and `cmap` now use the same parser code.

There is only one problem: What happens when a command, that has nothing to do with editing the prompt (like `toggle` for example), is called during a prompt.
As far as I can tell, there are three possible solutions to this problem:
1. Execute the command while keeping the prompt open (the solution I think is best): this has the advantage of beeing the easiest to implement and most flexible solution. Accepting or cancelling the prompt would then only happen manually, if `cmd-enter` or `cmd-escape` are called. This is the current solution for non-movement commands.
2. Accept the prompt und execute the command afterwards (unless the command explicitly starts with `cmd-escape`): this is (kinda) the current solution when using the searching / filtering with `incsearch` / `incfilter` option on and movement commands are used.
3. Cancel the prompt and execute the command (unless the command explicitly starts with `cmd-enter`): this is the current solution when the `incsearch` / `incfilter` options are off or we don't use searching / filtering and movement commands are used.

So yeah, at the moment all 3 solutions are used in various different places which I think is extremely inconsistent and should probably be cleaned up, before we merge this. I'm fine with implement either solution, but I think the first one is the best, since it allows every user to decide for himself which approach he wants and it also allows to have commands run during a prompt.