### PR TITLE
Cmap fixes

### DIFF
--- a/app.go
+++ b/app.go
@@ -524,6 +524,7 @@ func (app *app) runShell(s string, args []string, prefix string) {
 
 	switch prefix {
 	case "%":
+		normal(app)
 		app.cmd = cmd
 		app.cmdOutBuf = nil
 		app.ui.msg = ""

--- a/app.go
+++ b/app.go
@@ -495,6 +495,9 @@ func (app *app) runShell(s string, args []string, prefix string) {
 
 		err = cmd.Run()
 	case "%":
+		if app.ui.cmdPrefix == ">" {
+			return
+		}
 		stdin, err := cmd.StdinPipe()
 		if err != nil {
 			log.Printf("writing stdin: %s", err)

--- a/eval.go
+++ b/eval.go
@@ -532,6 +532,19 @@ func update(app *app) {
 	}
 }
 
+func restartIncCmd(app *app) {
+	if gOpts.incsearch && (app.ui.cmdPrefix == "/" || app.ui.cmdPrefix == "?") {
+		dir := app.nav.currDir()
+		app.nav.searchInd = dir.ind
+		app.nav.searchPos = dir.pos
+		update(app)
+	} else if gOpts.incfilter && app.ui.cmdPrefix == "filter: " {
+		dir := app.nav.currDir()
+		app.nav.prevFilter = dir.filter
+		update(app)
+	}
+}
+
 func resetIncCmd(app *app)  {
 	if gOpts.incsearch && (app.ui.cmdPrefix == "/" || app.ui.cmdPrefix == "?") {
 		dir := app.nav.currDir()
@@ -726,6 +739,7 @@ func insert(app *app, arg string) {
 		}
 
 		if wd != path {
+			resetIncCmd(app)
 			preChdir(app)
 		}
 
@@ -738,6 +752,7 @@ func insert(app *app, arg string) {
 
 		if wd != path {
 			app.nav.marks["'"] = wd
+			restartIncCmd(app)
 			onChdir(app)
 		}
 	case app.ui.cmdPrefix == "mark-remove: ":
@@ -818,6 +833,7 @@ func (e *callExpr) eval(app *app, args []string) {
 		if app.ui.cmdPrefix != "" && app.ui.cmdPrefix != ">" {
 			normal(app)
 		}
+		resetIncCmd(app)
 		preChdir(app)
 		for i := 0; i < e.count; i++ {
 			if err := app.nav.updir(); err != nil {
@@ -827,6 +843,7 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 		app.ui.loadFile(app.nav, true)
 		app.ui.loadFileInfo(app.nav)
+		restartIncCmd(app)
 		onChdir(app)
 	case "open":
 		if app.ui.cmdPrefix != "" && app.ui.cmdPrefix != ">" {
@@ -839,6 +856,7 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 
 		if curr.IsDir() {
+			resetIncCmd(app)
 			preChdir(app)
 			err := app.nav.open()
 			if err != nil {
@@ -847,6 +865,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			}
 			app.ui.loadFile(app.nav, true)
 			app.ui.loadFileInfo(app.nav)
+			restartIncCmd(app)
 			onChdir(app)
 			return
 		}
@@ -1261,6 +1280,7 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 
 		if wd != path {
+			resetIncCmd(app)
 			preChdir(app)
 		}
 
@@ -1274,6 +1294,7 @@ func (e *callExpr) eval(app *app, args []string) {
 
 		if wd != path {
 			app.nav.marks["'"] = wd
+			restartIncCmd(app)
 			onChdir(app)
 		}
 	case "select":
@@ -1295,6 +1316,7 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 
 		if wd != path {
+			resetIncCmd(app)
 			preChdir(app)
 		}
 
@@ -1308,6 +1330,7 @@ func (e *callExpr) eval(app *app, args []string) {
 
 		if wd != path {
 			app.nav.marks["'"] = wd
+			restartIncCmd(app)
 			onChdir(app)
 		}
 	case "glob-select":
@@ -1658,12 +1681,9 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 		cmd := app.cmdHistory[len(app.cmdHistory)-app.cmdHistoryInd]
+		normal(app)
 		app.ui.cmdPrefix = cmd.prefix
 		app.ui.cmdAccLeft = []rune(cmd.value)
-		app.ui.cmdAccRight = nil
-		app.ui.cmdTmp = nil
-		app.ui.menuBuf = nil
-		app.ui.menuSelected = -2
 	case "cmd-history-prev":
 		if app.ui.cmdPrefix == ">" {
 			return
@@ -1676,12 +1696,9 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 		app.cmdHistoryInd++
 		cmd := app.cmdHistory[len(app.cmdHistory)-app.cmdHistoryInd]
+		normal(app)
 		app.ui.cmdPrefix = cmd.prefix
 		app.ui.cmdAccLeft = []rune(cmd.value)
-		app.ui.cmdAccRight = nil
-		app.ui.cmdTmp = nil
-		app.ui.menuBuf = nil
-		app.ui.menuSelected = -2
 	case "cmd-delete":
 		if len(app.ui.cmdAccRight) == 0 {
 			return

--- a/eval.go
+++ b/eval.go
@@ -782,57 +782,36 @@ func insert(app *app, arg string) {
 func (e *callExpr) eval(app *app, args []string) {
 	switch e.name {
 	case "up":
-		if app.ui.cmdPrefix != "" && app.ui.cmdPrefix != ">" {
-			normal(app)
-		}
 		if app.nav.up(e.count) {
 			app.ui.loadFile(app.nav, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "half-up":
-		if app.ui.cmdPrefix != "" && app.ui.cmdPrefix != ">" {
-			normal(app)
-		}
 		if app.nav.up(e.count * app.nav.height / 2) {
 			app.ui.loadFile(app.nav, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "page-up":
-		if app.ui.cmdPrefix != "" && app.ui.cmdPrefix != ">" {
-			normal(app)
-		}
 		if app.nav.up(e.count * app.nav.height) {
 			app.ui.loadFile(app.nav, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "down":
-		if app.ui.cmdPrefix != "" && app.ui.cmdPrefix != ">" {
-			normal(app)
-		}
 		if app.nav.down(e.count) {
 			app.ui.loadFile(app.nav, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "half-down":
-		if app.ui.cmdPrefix != "" && app.ui.cmdPrefix != ">" {
-			normal(app)
-		}
 		if app.nav.down(e.count * app.nav.height / 2) {
 			app.ui.loadFile(app.nav, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "page-down":
-		if app.ui.cmdPrefix != "" && app.ui.cmdPrefix != ">" {
-			normal(app)
-		}
 		if app.nav.down(e.count * app.nav.height) {
 			app.ui.loadFile(app.nav, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "updir":
-		if app.ui.cmdPrefix != "" && app.ui.cmdPrefix != ">" {
-			normal(app)
-		}
 		resetIncCmd(app)
 		preChdir(app)
 		for i := 0; i < e.count; i++ {
@@ -846,9 +825,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		restartIncCmd(app)
 		onChdir(app)
 	case "open":
-		if app.ui.cmdPrefix != "" && app.ui.cmdPrefix != ">" {
-			normal(app)
-		}
 		curr, err := app.nav.currFile()
 		if err != nil {
 			app.ui.echoerrf("opening: %s", err)
@@ -901,17 +877,11 @@ func (e *callExpr) eval(app *app, args []string) {
 	case "quit":
 		app.quitChan <- struct{}{}
 	case "top":
-		if app.ui.cmdPrefix != "" && app.ui.cmdPrefix != ">" {
-			normal(app)
-		}
 		if app.nav.top() {
 			app.ui.loadFile(app.nav, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "bottom":
-		if app.ui.cmdPrefix != "" && app.ui.cmdPrefix != ">" {
-			normal(app)
-		}
 		if app.nav.bottom() {
 			app.ui.loadFile(app.nav, true)
 			app.ui.loadFileInfo(app.nav)

--- a/eval.go
+++ b/eval.go
@@ -1028,31 +1028,52 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.ui.loadFile(app.nav, true)
 		app.ui.loadFileInfo(app.nav)
 	case "read":
+		if app.ui.cmdPrefix == ">" {
+			return
+		}
 		normal(app)
 		app.ui.cmdPrefix = ":"
 		app.ui.loadFileInfo(app.nav)
 	case "shell":
+		if app.ui.cmdPrefix == ">" {
+			return
+		}
 		normal(app)
 		app.ui.cmdPrefix = "$"
 		app.ui.loadFileInfo(app.nav)
 	case "shell-pipe":
+		if app.ui.cmdPrefix == ">" {
+			return
+		}
 		normal(app)
 		app.ui.cmdPrefix = "%"
 		app.ui.loadFileInfo(app.nav)
 	case "shell-wait":
+		if app.ui.cmdPrefix == ">" {
+			return
+		}
 		normal(app)
 		app.ui.cmdPrefix = "!"
 		app.ui.loadFileInfo(app.nav)
 	case "shell-async":
+		if app.ui.cmdPrefix == ">" {
+			return
+		}
 		normal(app)
 		app.ui.cmdPrefix = "&"
 		app.ui.loadFileInfo(app.nav)
 	case "find":
+		if app.ui.cmdPrefix == ">" {
+			return
+		}
 		normal(app)
 		app.ui.cmdPrefix = "find: "
 		app.nav.findBack = false
 		app.ui.loadFileInfo(app.nav)
 	case "find-back":
+		if app.ui.cmdPrefix == ">" {
+			return
+		}
 		normal(app)
 		app.ui.cmdPrefix = "find-back: "
 		app.nav.findBack = true
@@ -1086,6 +1107,9 @@ func (e *callExpr) eval(app *app, args []string) {
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "search":
+		if app.ui.cmdPrefix == ">" {
+			return
+		}
 		normal(app)
 		app.ui.cmdPrefix = "/"
 		dir := app.nav.currDir()
@@ -1094,6 +1118,9 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.nav.searchBack = false
 		app.ui.loadFileInfo(app.nav)
 	case "search-back":
+		if app.ui.cmdPrefix == ">" {
+			return
+		}
 		normal(app)
 		app.ui.cmdPrefix = "?"
 		dir := app.nav.currDir()
@@ -1138,6 +1165,9 @@ func (e *callExpr) eval(app *app, args []string) {
 			}
 		}
 	case "filter":
+		if app.ui.cmdPrefix == ">" {
+			return
+		}
 		normal(app)
 		app.ui.cmdPrefix = "filter: "
 		dir := app.nav.currDir()
@@ -1156,13 +1186,22 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.ui.loadFile(app.nav, true)
 		app.ui.loadFileInfo(app.nav)
 	case "mark-save":
+		if app.ui.cmdPrefix == ">" {
+			return
+		}
 		normal(app)
 		app.ui.cmdPrefix = "mark-save: "
 	case "mark-load":
+		if app.ui.cmdPrefix == ">" {
+			return
+		}
 		normal(app)
 		app.ui.menuBuf = listMarks(app.nav.marks)
 		app.ui.cmdPrefix = "mark-load: "
 	case "mark-remove":
+		if app.ui.cmdPrefix == ">" {
+			return
+		}
 		normal(app)
 		app.ui.menuBuf = listMarks(app.nav.marks)
 		app.ui.cmdPrefix = "mark-remove: "
@@ -1182,6 +1221,9 @@ func (e *callExpr) eval(app *app, args []string) {
 			curr, err := app.nav.currFile()
 			if err != nil {
 				app.ui.echoerrf("rename: %s:", err)
+				return
+			}
+			if app.ui.cmdPrefix == ">" {
 				return
 			}
 			normal(app)

--- a/eval.go
+++ b/eval.go
@@ -532,7 +532,29 @@ func update(app *app) {
 	}
 }
 
+func resetIncCmd(app *app)  {
+	if gOpts.incsearch && (app.ui.cmdPrefix == "/" || app.ui.cmdPrefix == "?") {
+		dir := app.nav.currDir()
+		dir.pos = app.nav.searchPos
+		if dir.ind != app.nav.searchInd {
+			dir.ind = app.nav.searchInd
+			app.ui.loadFile(app.nav, true)
+			app.ui.loadFileInfo(app.nav)
+		}
+	} else if gOpts.incfilter && app.ui.cmdPrefix == "filter: " {
+		dir := app.nav.currDir()
+		old := dir.ind
+		app.nav.setFilter(app.nav.prevFilter)
+		if old != dir.ind {
+			app.ui.loadFile(app.nav, true)
+			app.ui.loadFileInfo(app.nav)
+		}
+	}
+}
+
 func normal(app *app) {
+	resetIncCmd(app)
+
 	app.ui.menuBuf = nil
 	app.ui.menuSelected = -2
 
@@ -1296,24 +1318,6 @@ func (e *callExpr) eval(app *app, args []string) {
 	case "cmd-escape":
 		if app.ui.cmdPrefix == ">" {
 			return
-		}
-		if gOpts.incsearch && (app.ui.cmdPrefix == "/" || app.ui.cmdPrefix == "?") {
-			dir := app.nav.currDir()
-			dir.pos = app.nav.searchPos
-			if dir.ind != app.nav.searchInd {
-				dir.ind = app.nav.searchInd
-				app.ui.loadFile(app.nav, true)
-				app.ui.loadFileInfo(app.nav)
-			}
-		}
-		if gOpts.incfilter && app.ui.cmdPrefix == "filter: " {
-			dir := app.nav.currDir()
-			old := dir.ind
-			app.nav.setFilter(app.nav.prevFilter)
-			if old != dir.ind {
-				app.ui.loadFile(app.nav, true)
-				app.ui.loadFileInfo(app.nav)
-			}
 		}
 		normal(app)
 	case "cmd-complete":

--- a/eval.go
+++ b/eval.go
@@ -972,6 +972,9 @@ func (e *callExpr) eval(app *app, args []string) {
 				return
 			}
 
+			if app.ui.cmdPrefix == ">" {
+				return
+			}
 			normal(app)
 			if len(list) == 1 {
 				app.ui.cmdPrefix = "delete '" + list[0] + "' ? [y/N] "

--- a/eval.go
+++ b/eval.go
@@ -961,6 +961,7 @@ func (e *callExpr) eval(app *app, args []string) {
 				return
 			}
 
+			normal(app)
 			if len(list) == 1 {
 				app.ui.cmdPrefix = "delete '" + list[0] + "' ? [y/N] "
 			} else {
@@ -1005,25 +1006,32 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.ui.loadFile(app.nav, true)
 		app.ui.loadFileInfo(app.nav)
 	case "read":
+		normal(app)
 		app.ui.cmdPrefix = ":"
 		app.ui.loadFileInfo(app.nav)
 	case "shell":
+		normal(app)
 		app.ui.cmdPrefix = "$"
 		app.ui.loadFileInfo(app.nav)
 	case "shell-pipe":
+		normal(app)
 		app.ui.cmdPrefix = "%"
 		app.ui.loadFileInfo(app.nav)
 	case "shell-wait":
+		normal(app)
 		app.ui.cmdPrefix = "!"
 		app.ui.loadFileInfo(app.nav)
 	case "shell-async":
+		normal(app)
 		app.ui.cmdPrefix = "&"
 		app.ui.loadFileInfo(app.nav)
 	case "find":
+		normal(app)
 		app.ui.cmdPrefix = "find: "
 		app.nav.findBack = false
 		app.ui.loadFileInfo(app.nav)
 	case "find-back":
+		normal(app)
 		app.ui.cmdPrefix = "find-back: "
 		app.nav.findBack = true
 		app.ui.loadFileInfo(app.nav)
@@ -1056,6 +1064,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "search":
+		normal(app)
 		app.ui.cmdPrefix = "/"
 		dir := app.nav.currDir()
 		app.nav.searchInd = dir.ind
@@ -1063,6 +1072,7 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.nav.searchBack = false
 		app.ui.loadFileInfo(app.nav)
 	case "search-back":
+		normal(app)
 		app.ui.cmdPrefix = "?"
 		dir := app.nav.currDir()
 		app.nav.searchInd = dir.ind
@@ -1106,6 +1116,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			}
 		}
 	case "filter":
+		normal(app)
 		app.ui.cmdPrefix = "filter: "
 		dir := app.nav.currDir()
 		app.nav.prevFilter = dir.filter
@@ -1123,11 +1134,14 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.ui.loadFile(app.nav, true)
 		app.ui.loadFileInfo(app.nav)
 	case "mark-save":
+		normal(app)
 		app.ui.cmdPrefix = "mark-save: "
 	case "mark-load":
+		normal(app)
 		app.ui.menuBuf = listMarks(app.nav.marks)
 		app.ui.cmdPrefix = "mark-load: "
 	case "mark-remove":
+		normal(app)
 		app.ui.menuBuf = listMarks(app.nav.marks)
 		app.ui.cmdPrefix = "mark-remove: "
 	case "rename":
@@ -1148,6 +1162,7 @@ func (e *callExpr) eval(app *app, args []string) {
 				app.ui.echoerrf("rename: %s:", err)
 				return
 			}
+			normal(app)
 			app.ui.cmdPrefix = "rename: "
 			app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(curr.Name())...)
 		}


### PR DESCRIPTION
I fixed some bugs with the new `cmap` command.
The following fixes were applied:
- Both the bugs I mentioned in #686 are now fixed (the prompt, as well as the search and filter, are reset when switching commands)
- when changing directory or navigating through the command history, the old pre-filter/search status is restored and the filter and search are correctly restartet in the new directory
- Shell-Pipe commands are not interrupted by other commands that use the prompt
- Movement commands now don't stop prompt anymore