### PR TITLE
go get is deprecated, instead use go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,24 +42,38 @@ See [releases](https://github.com/gokcehan/lf/releases) for pre-built binaries.
 If you like to build from the source on unix:
 
 ```bash
-# For go version < 1.7
+# For go version < 1.17
 env CGO_ENABLED=0 GO111MODULE=on go get -u -ldflags="-s -w" github.com/gokcehan/lf
 
-# For go version >= 1.7
+# For go version >= 1.17
 env CGO_ENABLED=0 go install -ldflags="-s -w" github.com/gokcehan/lf@latest
 ```
 
 On windows `cmd`:
 
-    set CGO_ENABLED=0
-    set GO111MODULE=on
-    go get -u -ldflags="-s -w" github.com/gokcehan/lf
+```cmd
+REM For go version < 1.17
+set CGO_ENABLED=0
+set GO111MODULE=on
+go get -u -ldflags="-s -w" github.com/gokcehan/lf
+
+REM For go version >= 1.17
+set CGO_ENABLED=0
+go install -ldflags="-s -w" github.com/gokcehan/lf@latest
+```
 
 On windows `powershell`:
 
-    $env:CGO_ENABLED = '0'
-    $env:GO111MODULE = 'on'
-    go get -u -ldflags="-s -w" github.com/gokcehan/lf
+```powershell
+# For go version < 1.17
+$env:CGO_ENABLED = '0'
+$env:GO111MODULE = 'on'
+go get -u -ldflags="-s -w" github.com/gokcehan/lf
+
+# For go version >= 1.17
+$env:CGO_ENABLED = '0'
+go install -ldflags="-s -w" github.com/gokcehan/lf@latest
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See [releases](https://github.com/gokcehan/lf/releases) for pre-built binaries.
 
 If you like to build from the source on unix:
 
-    env CGO_ENABLED=0 GO111MODULE=on go get -u -ldflags="-s -w" github.com/gokcehan/lf
+    env CGO_ENABLED=0 GO111MODULE=on go install -ldflags="-s -w" github.com/gokcehan/lf@latest
 
 On windows `cmd`:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,13 @@ See [releases](https://github.com/gokcehan/lf/releases) for pre-built binaries.
 
 If you like to build from the source on unix:
 
-    env CGO_ENABLED=0 GO111MODULE=on go install -ldflags="-s -w" github.com/gokcehan/lf@latest
+```bash
+# For go version < 1.7
+env CGO_ENABLED=0 GO111MODULE=on go get -u -ldflags="-s -w" github.com/gokcehan/lf
+
+# For go version >= 1.7
+env CGO_ENABLED=0 go install -ldflags="-s -w" github.com/gokcehan/lf@latest
+```
 
 On windows `cmd`:
 


### PR DESCRIPTION
It seems `go get` is deprecated. Instead I change it to `go install` as suggested.

<img width="716" alt="image" src="https://user-images.githubusercontent.com/11582667/141596029-fa545a73-7ea6-4b02-919d-db7750ff7b08.png">
