### PR TITLE
Keep copy selections after paste

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1098,9 +1098,9 @@ You can use the following example as a starting point:
             cp -R $list .
         elif [ $mode = 'move' ]; then
             mv $list .
+            rm ~/.local/share/lf/files
+            lf -remote 'send clear'
         fi
-        rm ~/.local/share/lf/files
-        lf -remote 'send clear'
     }}
 
 Some useful things to be considered are to use the backup ('--backup') and/or preserve attributes ('-a') options with 'cp' and 'mv' commands if they support it (i.e. GNU implementation), change the command type to asynchronous, or use 'rsync' command with progress bar option for copying and feed the progress to the client periodically with remote 'echo' calls.

--- a/docstring.go
+++ b/docstring.go
@@ -1215,9 +1215,9 @@ point:
             cp -R $list .
         elif [ $mode = 'move' ]; then
             mv $list .
+            rm ~/.local/share/lf/files
+            lf -remote 'send clear'
         fi
-        rm ~/.local/share/lf/files
-        lf -remote 'send clear'
     }}
 
 Some useful things to be considered are to use the backup ('--backup')

--- a/lf.1
+++ b/lf.1
@@ -1272,9 +1272,9 @@ You can customize copy and move operations by defining a 'paste' command. This i
             cp -R $list .
         elif [ $mode = 'move' ]; then
             mv $list .
+            rm ~/.local/share/lf/files
+            lf -remote 'send clear'
         fi
-        rm ~/.local/share/lf/files
-        lf -remote 'send clear'
     }}
 .EE
 .PP

--- a/nav.go
+++ b/nav.go
@@ -1043,19 +1043,18 @@ func (nav *nav) paste(ui *ui) error {
 		go nav.copyAsync(ui, srcs, dstDir)
 	} else {
 		go nav.moveAsync(ui, srcs, dstDir)
-	}
-
-	if err := saveFiles(nil, false); err != nil {
-		return fmt.Errorf("clearing copy/cut buffer: %s", err)
-	}
-
-	if gSingleMode {
-		if err := nav.sync(); err != nil {
-			return fmt.Errorf("paste: %s", err)
+		if err := saveFiles(nil, false); err != nil {
+			return fmt.Errorf("clearing copy/cut buffer: %s", err)
 		}
-	} else {
-		if err := remote("send sync"); err != nil {
-			return fmt.Errorf("paste: %s", err)
+
+		if gSingleMode {
+			if err := nav.sync(); err != nil {
+				return fmt.Errorf("paste: %s", err)
+			}
+		} else {
+			if err := remote("send sync"); err != nil {
+				return fmt.Errorf("paste: %s", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR changes paste so that the copy selection is not cleared and you can paste the same files again.

I find this useful for example when updating template files in unrelated projects.

The selection is still cleared for cut and paste of course.