### PR TITLE
added: `*filename` as a color sequence to match against

### DIFF
--- a/colors.go
+++ b/colors.go
@@ -276,6 +276,10 @@ func (sm styleMap) get(f *file) tcell.Style {
 		return val
 	}
 
+	if val, ok := sm["*"+f.Name()]; ok {
+		return val
+	}
+
 	if val, ok := sm[filepath.Base(f.Name())+".*"]; ok {
 		return val
 	}


### PR DESCRIPTION
I added the pattern `*filename` as a sequence to match against when coloring files.

For instance, all the following are valid sequences and work just fine on `zsh` at least. I would assume that `bash` is the same if all of the other sequences work with it as well.

```sh
*Makefile=1;38;2;255;88;19
*setup.py=0;38;2;255;88;19
*justfile=1;38;2;255;88;19
*Doxyfile=0;38;2;255;88;19
*Dockerfile=1;38;2;255;149;0
*CONTRIBUTORS=0;38;2;160;100;105
*LICENSE-MIT=0;38;2;126;178;177
```
Since these file names do all not contain an extension, they are not colored with the sequences that are in place. `setup.py` is the only one in this example with an extension, and is not colored based on its individual color, but instead whatever (if any) all of the are Python files are colored.