### PR TITLE
add select-path to -help

### DIFF
--- a/gen/man.sh
+++ b/gen/man.sh
@@ -35,7 +35,7 @@ lf \- terminal file manager
 .OP \-single
 .OP \-version
 .OP \-help
-.RI [ directory ]
+.RI [ select-path ]
 .YS
 .SH DESCRIPTION
 END

--- a/lf.1
+++ b/lf.1
@@ -16,7 +16,7 @@ lf \- terminal file manager
 .OP \-single
 .OP \-version
 .OP \-help
-.RI [ directory ]
+.RI [ select-path ]
 .YS
 .SH DESCRIPTION
 lf is a terminal file manager.

--- a/main.go
+++ b/main.go
@@ -185,6 +185,18 @@ func checkServer() {
 }
 
 func main() {
+	flag.Usage = func() {
+		f := flag.CommandLine.Output()
+		fmt.Fprintln(f, "lf - Terminal file manager")
+		fmt.Fprintln(f, "")
+		fmt.Fprintf(f, "Usage:  %s [options] [select-path]\n\n", os.Args[0])
+		fmt.Fprintln(f, "  select-path")
+		fmt.Fprintln(f, "        set the initial file selection to the given argument")
+		fmt.Fprintln(f, "")
+		fmt.Fprintln(f, "Options:")
+		flag.PrintDefaults()
+	}
+
 	showDoc := flag.Bool(
 		"doc",
 		false,


### PR DESCRIPTION
I saw that lf allows you to select a path via the first argument. This is not documented AFAIK.

This PR just adds the following usage information:
```
lf - Terminal file manager (version r26-17-g511c060)

Usage:  lf [options] [select-path]

  select-path
        set the initial file selection to the given argument

Options:
  -command value
```