### PR TITLE
Add get-dirsize command

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -60,6 +60,7 @@ var (
 		"echomsg",
 		"echoerr",
 		"cd",
+		"get-dirsize",
 		"select",
 		"glob-select",
 		"glob-unselect",

--- a/doc.go
+++ b/doc.go
@@ -31,6 +31,7 @@ The following commands are provided by lf:
     unselect                 (default 'u')
     glob-select
     glob-unselect
+    get-dirsize
     copy                     (default 'y')
     cut                      (default 'd')
     paste                    (default 'p')
@@ -273,6 +274,10 @@ Select files that match the given glob.
     glob-unselect
 
 Unselect files that match the given glob.
+
+    get-dirsize
+
+Get the total size for each of the selected directories.
 
     copy                     (default 'y')
 

--- a/docstring.go
+++ b/docstring.go
@@ -35,6 +35,7 @@ The following commands are provided by lf:
     unselect                 (default 'u')
     glob-select
     glob-unselect
+    get-dirsize
     copy                     (default 'y')
     cut                      (default 'd')
     paste                    (default 'p')
@@ -285,6 +286,10 @@ Select files that match the given glob.
     glob-unselect
 
 Unselect files that match the given glob.
+
+    get-dirsize
+
+Get the total size for each of the selected directories.
 
     copy                     (default 'y')
 

--- a/eval.go
+++ b/eval.go
@@ -913,6 +913,15 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.nav.invert()
 	case "unselect":
 		app.nav.unselect()
+	case "get-dirsize":
+		err := app.nav.getDirSize()
+		if err != nil {
+			app.ui.echoerrf("get-dirsize: %s", err)
+			return
+		}
+		app.ui.loadFileInfo(app.nav)
+		app.nav.sort()
+		app.ui.sort()
 	case "copy":
 		if err := app.nav.save(true); err != nil {
 			app.ui.echoerrf("copy: %s", err)

--- a/lf.1
+++ b/lf.1
@@ -46,6 +46,7 @@ The following commands are provided by lf:
     unselect                 (default 'u')
     glob-select
     glob-unselect
+    get-dirsize
     copy                     (default 'y')
     cut                      (default 'd')
     paste                    (default 'p')
@@ -318,6 +319,12 @@ Select files that match the given glob.
 .EE
 .PP
 Unselect files that match the given glob.
+.PP
+.EX
+    get-dirsize
+.EE
+.PP
+Get the total size for each of the selected directories.
 .PP
 .EX
     copy                     (default 'y')

--- a/ui.go
+++ b/ui.go
@@ -292,8 +292,14 @@ func fileInfo(f *file, d *dir) string {
 	for _, s := range gOpts.info {
 		switch s {
 		case "size":
-			if !(gOpts.dircounts && f.IsDir()) {
-				info = fmt.Sprintf("%s %4s", info, humanize(f.Size()))
+			if !(f.IsDir() && gOpts.dircounts) {
+				var sz string
+				if f.IsDir() && f.dirSize < 0 {
+					sz = "-"
+				} else {
+					sz = humanize(f.TotalSize())
+				}
+				info = fmt.Sprintf("%s %4s", info, sz)
 				continue
 			}
 


### PR DESCRIPTION
This is a take on #152 

It adds a `calcdir` command that calculates the total size of the currently selected directories and displays it in the status and in the info column. Anything not a directory is ignored. Sorting is supported as well.

Since this is an expensive operation it is only executed when called manually.

Also the sizes for directories as reported by the OS are not very useful IMO. Can they be removed so a directory does not show a size (or 0) until it is calculated by this command?