### PR TITLE
Add history-back and history-forward commands

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -250,6 +250,14 @@ A custom 'open' command can be defined to override this default.
 
 (See also 'OPENER' variable and 'Opening Files' section)
 
+    jump-prev                (default '[')
+
+Change the current working directory to the previous jumplist item.
+
+    jump-next                (default ']')
+
+Change the current working directory to the next jumplist item.
+
     top                      (default 'gg' and '<home>')
     bottom                   (default 'G' and '<end>')
 

--- a/docstring.go
+++ b/docstring.go
@@ -260,6 +260,14 @@ default.
 
 (See also 'OPENER' variable and 'Opening Files' section)
 
+    jump-prev                (default '[')
+
+Change the current working directory to the previous jumplist item.
+
+    jump-next                (default ']')
+
+Change the current working directory to the next jumplist item.
+
     top                      (default 'gg' and '<home>')
     bottom                   (default 'G' and '<end>')
 

--- a/eval.go
+++ b/eval.go
@@ -470,6 +470,7 @@ func preChdir(app *app) {
 }
 
 func onChdir(app *app) {
+	app.nav.addJumpList()
 	if cmd, ok := gOpts.cmds["on-cd"]; ok {
 		cmd.eval(app, nil)
 	}
@@ -884,6 +885,26 @@ func (e *callExpr) eval(app *app, args []string) {
 		if cmd, ok := gOpts.cmds["open"]; ok {
 			cmd.eval(app, e.args)
 		}
+	case "jump-prev":
+		resetIncCmd(app)
+		preChdir(app)
+		for i := 0; i < e.count; i++ {
+			app.nav.cdJumpListPrev()
+		}
+		app.ui.loadFile(app.nav, true)
+		app.ui.loadFileInfo(app.nav)
+		restartIncCmd(app)
+		onChdir(app)
+	case "jump-next":
+		resetIncCmd(app)
+		preChdir(app)
+		for i := 0; i < e.count; i++ {
+			app.nav.cdJumpListNext()
+		}
+		app.ui.loadFile(app.nav, true)
+		app.ui.loadFileInfo(app.nav)
+		restartIncCmd(app)
+		onChdir(app)
 	case "quit":
 		app.quitChan <- struct{}{}
 	case "top":

--- a/lf.1
+++ b/lf.1
@@ -287,6 +287,18 @@ If the current file is a directory, then change the current directory to it, oth
 (See also 'OPENER' variable and 'Opening Files' section)
 .PP
 .EX
+    jump-prev                (default '[')
+.EE
+.PP
+Change the current working directory to the previous jumplist item.
+.PP
+.EX
+    jump-next                (default ']')
+.EE
+.PP
+Change the current working directory to the next jumplist item.
+.PP
+.EX
     top                      (default 'gg' and '<home>')
     bottom                   (default 'G' and '<end>')
 .EE

--- a/nav.go
+++ b/nav.go
@@ -364,6 +364,8 @@ type nav struct {
 	searchPos       int
 	prevFilter      []string
 	volatilePreview bool
+	jumpList        []string
+	jumpListInd     int
 }
 
 func (nav *nav) loadDirInternal(path string) *dir {
@@ -480,11 +482,44 @@ func newNav(height int) *nav {
 		selections:      make(map[string]int),
 		selectionInd:    0,
 		height:          height,
+		jumpList:        make([]string, 0),
+		jumpListInd:     -1,
 	}
 
 	nav.getDirs(wd)
+	nav.addJumpList()
 
 	return nav
+}
+
+func (nav *nav) addJumpList() {
+	currPath := nav.currDir().path
+	if nav.jumpListInd >= 0 && nav.jumpListInd < len(nav.jumpList)-1 {
+		if nav.jumpList[nav.jumpListInd] == currPath {
+			// walking the jumpList
+			return
+		}
+		nav.jumpList = nav.jumpList[:nav.jumpListInd+1]
+	}
+	if len(nav.jumpList) == 0 || nav.jumpList[len(nav.jumpList)-1] != currPath {
+		nav.jumpList = append(nav.jumpList, currPath)
+	}
+	nav.jumpListInd = len(nav.jumpList) - 1
+}
+
+func (nav *nav) cdJumpListPrev() {
+	// currPath := nav.currDir().path
+	if nav.jumpListInd > 0 {
+		nav.jumpListInd -= 1
+		nav.cd(nav.jumpList[nav.jumpListInd])
+	}
+}
+
+func (nav *nav) cdJumpListNext() {
+	if nav.jumpListInd < len(nav.jumpList)-1 {
+		nav.jumpListInd += 1
+		nav.cd(nav.jumpList[nav.jumpListInd])
+	}
 }
 
 func (nav *nav) renew() {
@@ -1171,7 +1206,7 @@ func (nav *nav) cd(wd string) error {
 	}
 
 	nav.getDirs(wd)
-
+	nav.addJumpList()
 	return nil
 }
 

--- a/opts.go
+++ b/opts.go
@@ -142,6 +142,8 @@ func init() {
 	gOpts.keys["<home>"] = &callExpr{"top", nil, 1}
 	gOpts.keys["G"] = &callExpr{"bottom", nil, 1}
 	gOpts.keys["<end>"] = &callExpr{"bottom", nil, 1}
+	gOpts.keys["["] = &callExpr{"jump-prev", nil, 1}
+	gOpts.keys["]"] = &callExpr{"jump-next", nil, 1}
 	gOpts.keys["<space>"] = &listExpr{[]expr{&callExpr{"toggle", nil, 1}, &callExpr{"down", nil, 1}}, 1}
 	gOpts.keys["v"] = &callExpr{"invert", nil, 1}
 	gOpts.keys["u"] = &callExpr{"unselect", nil, 1}


### PR DESCRIPTION
This PR implements a history that works similar to a browser. It allows you to travel back and forward on the directories you visited. Each client has its own history.

It also implements two default keybindings `[` and `]` but I can remove them if you prefer to keep this optional.

This is also, if I understood correctly, what was requested in #212, where it was called a jump list.

And sorry if I am overwhelming you with PRs. It's just that I really like lf after having been on ranger for too long ;)