### PR TITLE
`filter`: added support for `|` (OR) operator

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -1440,8 +1440,10 @@ func isFiltered(f os.FileInfo, filter []string) bool {
 
 			if strings.HasPrefix(pattern, "!") && matched {
 				subFiltered = true
+				break
 			} else if !strings.HasPrefix(pattern, "!") && !matched {
 				subFiltered = true
+				break
 			}
 		}
 

--- a/nav.go
+++ b/nav.go
@@ -1417,9 +1417,10 @@ func isFiltered(f os.FileInfo, filter []string) bool {
 	// cache
 	isMatched := make(map[string]bool)
 
-	var results []bool
+	subFilters := strings.Split(userPatt, "|")
 
-	for _, subFilter := range strings.Split(userPatt, "|") {
+	filtered := true
+	for _, subFilter := range subFilters {
 		subFiltered := false
 		subFilter = strings.TrimSpace(subFilter)
 
@@ -1447,17 +1448,15 @@ func isFiltered(f os.FileInfo, filter []string) bool {
 			}
 		}
 
-		results = append(results, subFiltered)
+		filtered = filtered && subFiltered
+		if !filtered {
+			break
+		}
 	}
 
-	if len(results) > 0 {
+	if len(subFilters) > 0 {
 		// if any of subfilters matched (r = false) - display
-		all := true
-		for _, r := range results {
-			all = all && r
-		}
-
-		return all
+		return filtered
 	}
 
 	return false

--- a/nav.go
+++ b/nav.go
@@ -1425,13 +1425,15 @@ func isFiltered(f os.FileInfo, filter []string) bool {
 		subFilter = strings.TrimSpace(subFilter)
 
 		for _, pattern := range strings.Split(subFilter, " ") {
+			excluded := strings.HasPrefix(pattern, "!")
+			pattern = strings.TrimPrefix(pattern, "!")
 
 			var matched bool
 			if v, ok := isMatched[pattern]; ok {
 				matched = v
 			} else {
 				var err error
-				matched, err = searchMatch(f.Name(), strings.TrimPrefix(pattern, "!"))
+				matched, err = searchMatch(f.Name(), pattern)
 				if err != nil {
 					log.Printf("Filter Error: %s", err)
 					return false
@@ -1439,10 +1441,7 @@ func isFiltered(f os.FileInfo, filter []string) bool {
 				isMatched[pattern] = matched
 			}
 
-			if strings.HasPrefix(pattern, "!") && matched {
-				subFiltered = true
-				break
-			} else if !strings.HasPrefix(pattern, "!") && !matched {
+			if (excluded && matched) || (!excluded && !matched) {
 				subFiltered = true
 				break
 			}

--- a/nav.go
+++ b/nav.go
@@ -1421,6 +1421,7 @@ func isFiltered(f os.FileInfo, filter []string) bool {
 
 	for _, subFilter := range strings.Split(userPatt, "|") {
 		subFiltered := false
+		subFilter = strings.TrimSpace(subFilter)
 
 		for _, pattern := range strings.Split(subFilter, " ") {
 


### PR DESCRIPTION
This should fix https://github.com/gokcehan/lf/issues/762

Before `isFiltered`, as described in the above issue, would filter out a file if any of the given sub patterns did NOT match.

So if you have e.g. `image.jpeg` and a bunch of other files and you want to match files with `.jpeg` and files with `.jpg` extensions (`filter: .jpeg .jpg`) - here is what's going to happen:

1. `.jpeg` is actually a match, but that doesn't matter because there is no explicit inclusion in current function, and EVERY pattern in processed. 
2. `.jpeg` will match (implicitly), but before that could happen, `.jpg` will return `true` and file will be filtered out, because `image.jpeg` doesn't match `.jpg`, only `.jpeg`
3. So the only way for `.jpeg` to get displayed is when there is nothing to overrule it (filter with just `.jpeg`)

Now `isFiltered` will work like this:
1. Exclusions (`!`) are processed, and if any matched - file is filtered
2. Then inclusions are processed, and if any matched - file will be
   displayed
3. If no inclusions found - file is filtered

Matches are only evaluated once, so there shouldn't be any meaningful difference in performance considering how simple everything else is.

A few examples:

```
/tmp/test ❯ ls
1A.txt  1B.txt  2.org  3.org  control  wtf.org.txt
```
(no `set globsearch`)

`filter: 1`

```
1A.txt
1B.txt
```

`filter: 1 !B`

```
1A.txt
```

`filter: 1 !B B` (`!B` takes priority)

```
1A.txt
```

`filter: .org .txt`

```
1A.txt
1B.txt
2.org
3.org
wtf.org.txt
```

`filter: .org .txt !.org.`

```
1A.txt
1B.txt
2.org
3.org
```

(I also tested with `set globsearch` and it works)

I think this is much more useful way of filtering things, ranger filtering actually works in similar way, but uses `|` for separator.