### PR TITLE
760 - Add opener example to lfrc for powershell

### DIFF
--- a/etc/lfrc.ps1.example
+++ b/etc/lfrc.ps1.example
@@ -17,6 +17,9 @@ set shell powershell
 # editor keybinding accordingly.
 map e $vim $Env:f
 
+# change the open command to work in PowerShell
+cmd open &start $Env:f
+
 # change the pager used in default pager keybinding
 # The standard pager used in Windows is 'more' which is not a very capable
 # pager. You may instead install a pager of your choice and replace the default


### PR DESCRIPTION
Added the opener mentioned in #760 to the PowerShell lfrc example.

Closes #760 

----

Next I'd like to work on a PowerShell example for previewer.

I have a PS1 script that I can run like this:
```powershell
C:\Users\USERNAME\Invoke-LfPreview.ps1 C:\Users\USERNAME\Downloads\pdftxt.txt
```
and it prints the output correctly.

However, I added this to my lfrc:
`set previewer C:\\Users\\USERNAME\\Invoke-LfPreview.ps1`

Then I get this error:
```
2022/02/19 17:50:11 previewing file: fork/exec C:\Users\USERNAME\Invoke-LfPreview.ps1: %1 is not a valid Win32 application.
```