### PR TITLE
Fix previewer for PowerShell

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -630,7 +630,7 @@ func (nav *nav) preview(path string, win *win) {
 	if len(gOpts.previewer) != 0 {
 		nav.exportFiles()
 		exportOpts()
-		cmd := exec.Command(gOpts.previewer, path,
+		cmd := exec.Command(gOpts.shell, gOpts.shellflag, gOpts.previewer, path,
 			strconv.Itoa(win.w),
 			strconv.Itoa(win.h),
 			strconv.Itoa(win.x),


### PR DESCRIPTION
PowerShell scripts (ps1 files) are not executable by default. This means setting a .ps1 file as the previewer causes errors like this: `fork/exec C:\Users\USERNAME\Invoke-LfPreview.ps1: %1 is not a valid Win32 application.`

This change makes it so the shell and shellflag are the first and second parameters that are passed in before the previewer script.

I tested this on PowerShell Core, Command Prompt and WSL2. On Command Prompt and WSL2, I tested with the default configuration where the only thing in my lfrc was the `set previewer` line.

While this patch seems to work, I am not completely happy with it. Every time I preview a file, it spawns a new shell. This is not a problem on bash or command prompt because they start up so quick, but PowerShell and PowerShell Core take forever to start. Here is the time it takes to start PowerShell Core on my (admittedly old and slow) laptop. 

*Note: The output below is for PowerShell Core. The Windows version of PowerShell takes about twice as long to start.*

```powershell
PS > Measure-Command { pwsh -Command exit }

...
TotalSeconds      : 0.6552842
TotalMilliseconds : 655.2842                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        


PS > Measure-Command { pwsh -noprofile -Command exit }

...
TotalSeconds      : 0.3040729
TotalMilliseconds : 304.0729   
```

This means, I have to wait 0.3 or 0.6 seconds for PowerShell to start before the highlight or pdftotext programs execute. It might seem small but this wait is every time I switch files.

Is there a better way to fix this problem without needing to spawn a new PowerShell? 

If not, perhaps a better fix would be for me to write a small go program to use as a previewer instead of the .ps1 script. In that case, we wouldn't need to merge this PR.

There is a third option, we could add this capability into `lf` itself. We could somehow add a section to lfrc where you put in the file extension and the application you want to run as the previewer. Then `lf` could launch that program directly without relying on a previewer script.

Any thoughts or feedback are welcome!