### PR TITLE
Add tags

### DIFF
--- a/client.go
+++ b/client.go
@@ -51,6 +51,10 @@ func run() {
 		app.ui.echoerrf("reading marks file: %s", err)
 	}
 
+	if err := app.nav.readTags(); err != nil {
+		app.ui.echoerrf("reading tags file: %s", err)
+	}
+
 	if err := app.readHistory(); err != nil {
 		app.ui.echoerrf("reading history file: %s", err)
 	}

--- a/complete.go
+++ b/complete.go
@@ -69,6 +69,7 @@ var (
 		"source",
 		"push",
 		"delete",
+		"tag",
 	}
 
 	gOptWords = []string{

--- a/complete.go
+++ b/complete.go
@@ -70,6 +70,7 @@ var (
 		"push",
 		"delete",
 		"tag",
+		"tag-toggle",
 	}
 
 	gOptWords = []string{

--- a/doc.go
+++ b/doc.go
@@ -71,6 +71,8 @@ The following commands are provided by lf:
     mark-save      (modal)   (default 'm')
     mark-load      (modal)   (default "'")
     mark-remove    (modal)   (default `"`)
+	tag-toggle               (default t)
+	tag
 
 The following command line commands are provided by lf:
 
@@ -149,6 +151,7 @@ The following options can be used to customize the behavior of lf:
     waitmsg        string    (default 'Press any key to continue')
     wrapscan       bool      (default on)
     wrapscroll     bool      (default off)
+	tagfmt         string    (default "\033[31m%s\033[0m")
 
 The following environment variables are exported for shell commands:
 
@@ -232,6 +235,11 @@ History file should be located at:
 
     unix     ~/.local/share/lf/history
     windows  C:\Users\<user>\AppData\Local\lf\history
+
+Tags file should be located at:
+
+    unix     ~/.local/share/lf/tags
+    windows  C:\Users\<user>\AppData\Local\lf\tags
 
 You can configure the default values of following variables to change these
 locations:
@@ -457,13 +465,13 @@ A special bookmark "'" holds the previous directory after a 'mark-load', 'cd', o
 
 Remove a bookmark assigned to the given key.
 
-    tag            (modal)   (default 'T')
+    tag
 
-Tag a file with the given key.
+Tag a file with a single width character given in the argument.
 
     tag-toggle     (modal)   (default 't')
 
-Tag a file with "*" if the file is untagged, otherwise remove the tag.
+Tag a file with a single width character given in the argument if the file is untagged, otherwise remove the tag.
 
 Command Line Commands
 
@@ -789,6 +797,10 @@ Searching can wrap around the file list.
     wrapscroll     bool      (default off)
 
 Scrolling can wrap around the file list.
+
+    tagfmt         string    (default "\033[31m%s\033[0m")
+
+Format string of the tags.
 
 Environment Variables
 

--- a/doc.go
+++ b/doc.go
@@ -457,6 +457,14 @@ A special bookmark "'" holds the previous directory after a 'mark-load', 'cd', o
 
 Remove a bookmark assigned to the given key.
 
+    tag            (modal)   (default 'T')
+
+Tag a file with the given key.
+
+    tag-toggle     (modal)   (default 't')
+
+Tag a file with "*" if the file is untagged, otherwise remove the tag.
+
 Command Line Commands
 
 This section shows information about command line commands.

--- a/docstring.go
+++ b/docstring.go
@@ -482,6 +482,14 @@ or 'select' command.
 
 Remove a bookmark assigned to the given key.
 
+    tag            (modal)   (default 'T')
+
+Tag a file with the given key.
+
+    tag-toggle     (modal)   (default 't')
+
+Tag a file with "*" if the file is untagged, otherwise remove the tag.
+
 
 Command Line Commands
 

--- a/docstring.go
+++ b/docstring.go
@@ -21,61 +21,63 @@ Quick Reference
 
 The following commands are provided by lf:
 
-    quit                     (default 'q')
-    up                       (default 'k' and '<up>')
-    half-up                  (default '<c-u>')
-    page-up                  (default '<c-b>' and '<pgup>')
-    scrollup                 (default '<c-y>')
-    down                     (default 'j' and '<down>')
-    half-down                (default '<c-d>')
-    page-down                (default '<c-f>' and '<pgdn>')
-    scrolldown               (default '<c-e>')
-    updir                    (default 'h' and '<left>')
-    open                     (default 'l' and '<right>')
-    top                      (default 'gg' and '<home>')
-    bottom                   (default 'G' and '<end>')
-    toggle
-    invert                   (default 'v')
-    unselect                 (default 'u')
-    glob-select
-    glob-unselect
-    calcdirsize
-    copy                     (default 'y')
-    cut                      (default 'd')
-    paste                    (default 'p')
-    clear                    (default 'c')
-    sync
-    draw
-    redraw                   (default '<c-l>')
-    load
-    reload                   (default '<c-r>')
-    echo
-    echomsg
-    echoerr
-    cd
-    select
-    delete         (modal)
-    rename         (modal)   (default 'r')
-    source
-    push
-    read           (modal)   (default ':')
-    shell          (modal)   (default '$')
-    shell-pipe     (modal)   (default '%')
-    shell-wait     (modal)   (default '!')
-    shell-async    (modal)   (default '&')
-    find           (modal)   (default 'f')
-    find-back      (modal)   (default 'F')
-    find-next                (default ';')
-    find-prev                (default ',')
-    search         (modal)   (default '/')
-    search-back    (modal)   (default '?')
-    search-next              (default 'n')
-    search-prev              (default 'N')
-    filter         (modal)
-    setfilter
-    mark-save      (modal)   (default 'm')
-    mark-load      (modal)   (default "'")
-    mark-remove    (modal)   (default '"')
+        quit                     (default 'q')
+        up                       (default 'k' and '<up>')
+        half-up                  (default '<c-u>')
+        page-up                  (default '<c-b>' and '<pgup>')
+        scrollup                 (default '<c-y>')
+        down                     (default 'j' and '<down>')
+        half-down                (default '<c-d>')
+        page-down                (default '<c-f>' and '<pgdn>')
+        scrolldown               (default '<c-e>')
+        updir                    (default 'h' and '<left>')
+        open                     (default 'l' and '<right>')
+        top                      (default 'gg' and '<home>')
+        bottom                   (default 'G' and '<end>')
+        toggle
+        invert                   (default 'v')
+        unselect                 (default 'u')
+        glob-select
+        glob-unselect
+        calcdirsize
+        copy                     (default 'y')
+        cut                      (default 'd')
+        paste                    (default 'p')
+        clear                    (default 'c')
+        sync
+        draw
+        redraw                   (default '<c-l>')
+        load
+        reload                   (default '<c-r>')
+        echo
+        echomsg
+        echoerr
+        cd
+        select
+        delete         (modal)
+        rename         (modal)   (default 'r')
+        source
+        push
+        read           (modal)   (default ':')
+        shell          (modal)   (default '$')
+        shell-pipe     (modal)   (default '%')
+        shell-wait     (modal)   (default '!')
+        shell-async    (modal)   (default '&')
+        find           (modal)   (default 'f')
+        find-back      (modal)   (default 'F')
+        find-next                (default ';')
+        find-prev                (default ',')
+        search         (modal)   (default '/')
+        search-back    (modal)   (default '?')
+        search-next              (default 'n')
+        search-prev              (default 'N')
+        filter         (modal)
+        setfilter
+        mark-save      (modal)   (default 'm')
+        mark-load      (modal)   (default "'")
+        mark-remove    (modal)   (default '"')
+    	tag-toggle               (default t)
+    	tag
 
 The following command line commands are provided by lf:
 
@@ -108,52 +110,53 @@ The following command line commands are provided by lf:
 
 The following options can be used to customize the behavior of lf:
 
-    anchorfind     bool      (default on)
-    autoquit       bool      (default off)
-    dircache       bool      (default on)
-    dircounts      bool      (default off)
-    dirfirst       bool      (default on)
-    dironly        bool      (default off)
-    drawbox        bool      (default off)
-    errorfmt       string    (default "\033[7;31;47m%s\033[0m")
-    filesep        string    (default "\n")
-    findlen        int       (default 1)
-    globsearch     bool      (default off)
-    hidden         bool      (default off)
-    hiddenfiles    []string  (default '.*')
-    icons          bool      (default off)
-    ifs            string    (default '')
-    ignorecase     bool      (default on)
-    ignoredia      bool      (default on)
-    incfilter      bool      (default off)
-    incsearch      bool      (default off)
-    info           []string  (default '')
-    mouse          bool      (default off)
-    number         bool      (default off)
-    period         int       (default 0)
-    preview        bool      (default on)
-    previewer      string    (default '')
-    cleaner        string    (default '')
-    promptfmt      string    (default "\033[32;1m%u@%h\033[0m:\033[34;1m%d\033[0m\033[1m%f\033[0m")
-    ratios         []int     (default '1:2:3')
-    relativenumber bool      (default off)
-    reverse        bool      (default off)
-    scrolloff      int       (default 0)
-    shell          string    (default 'sh' for unix and 'cmd' for windows)
-    shellflag      string    (default '-c' for unix and '/c' for windows)
-    shellopts      []string  (default '')
-    smartcase      bool      (default on)
-    smartdia       bool      (default off)
-    sortby         string    (default 'natural')
-    tabstop        int       (default 8)
-    tempmarks      string    (default '')
-    timefmt        string    (default 'Mon Jan _2 15:04:05 2006')
-    infotimefmtnew string    (default 'Jan _2 15:04')
-    infotimefmtold string    (default 'Jan _2  2006')
-    truncatechar   string    (default '~')
-    waitmsg        string    (default 'Press any key to continue')
-    wrapscan       bool      (default on)
-    wrapscroll     bool      (default off)
+        anchorfind     bool      (default on)
+        autoquit       bool      (default off)
+        dircache       bool      (default on)
+        dircounts      bool      (default off)
+        dirfirst       bool      (default on)
+        dironly        bool      (default off)
+        drawbox        bool      (default off)
+        errorfmt       string    (default "\033[7;31;47m%s\033[0m")
+        filesep        string    (default "\n")
+        findlen        int       (default 1)
+        globsearch     bool      (default off)
+        hidden         bool      (default off)
+        hiddenfiles    []string  (default '.*')
+        icons          bool      (default off)
+        ifs            string    (default '')
+        ignorecase     bool      (default on)
+        ignoredia      bool      (default on)
+        incfilter      bool      (default off)
+        incsearch      bool      (default off)
+        info           []string  (default '')
+        mouse          bool      (default off)
+        number         bool      (default off)
+        period         int       (default 0)
+        preview        bool      (default on)
+        previewer      string    (default '')
+        cleaner        string    (default '')
+        promptfmt      string    (default "\033[32;1m%u@%h\033[0m:\033[34;1m%d\033[0m\033[1m%f\033[0m")
+        ratios         []int     (default '1:2:3')
+        relativenumber bool      (default off)
+        reverse        bool      (default off)
+        scrolloff      int       (default 0)
+        shell          string    (default 'sh' for unix and 'cmd' for windows)
+        shellflag      string    (default '-c' for unix and '/c' for windows)
+        shellopts      []string  (default '')
+        smartcase      bool      (default on)
+        smartdia       bool      (default off)
+        sortby         string    (default 'natural')
+        tabstop        int       (default 8)
+        tempmarks      string    (default '')
+        timefmt        string    (default 'Mon Jan _2 15:04:05 2006')
+        infotimefmtnew string    (default 'Jan _2 15:04')
+        infotimefmtold string    (default 'Jan _2  2006')
+        truncatechar   string    (default '~')
+        waitmsg        string    (default 'Press any key to continue')
+        wrapscan       bool      (default on)
+        wrapscroll     bool      (default off)
+    	tagfmt         string    (default "\033[31m%s\033[0m")
 
 The following environment variables are exported for shell commands:
 
@@ -239,6 +242,11 @@ History file should be located at:
 
     unix     ~/.local/share/lf/history
     windows  C:\Users\<user>\AppData\Local\lf\history
+
+Tags file should be located at:
+
+    unix     ~/.local/share/lf/tags
+    windows  C:\Users\<user>\AppData\Local\lf\tags
 
 You can configure the default values of following variables to change these
 locations:
@@ -482,13 +490,14 @@ or 'select' command.
 
 Remove a bookmark assigned to the given key.
 
-    tag            (modal)   (default 'T')
+    tag
 
-Tag a file with the given key.
+Tag a file with a single width character given in the argument.
 
     tag-toggle     (modal)   (default 't')
 
-Tag a file with "*" if the file is untagged, otherwise remove the tag.
+Tag a file with a single width character given in the argument if the file
+is untagged, otherwise remove the tag.
 
 
 Command Line Commands
@@ -846,6 +855,10 @@ Searching can wrap around the file list.
     wrapscroll     bool      (default off)
 
 Scrolling can wrap around the file list.
+
+    tagfmt         string    (default "\033[31m%s\033[0m")
+
+Format string of the tags.
 
 
 Environment Variables

--- a/eval.go
+++ b/eval.go
@@ -983,6 +983,31 @@ func (e *callExpr) eval(app *app, args []string) {
 				}
 			}
 		}
+	case "tag":
+		if !app.nav.init {
+			return
+		}
+		if len(e.args) == 0 {
+			app.nav.toggleTag()
+		} else if len(e.args[0]) == 1 {
+			app.nav.tag(e.args[0][0])
+		} else {
+			app.ui.echoerrf("tag: invalid argument")
+			return
+
+		}
+		if err := app.nav.writeTags(); err != nil {
+			app.ui.echoerrf("tag: %s", err)
+		}
+		if gSingleMode {
+			if err := app.nav.sync(); err != nil {
+				app.ui.echoerrf("tag: %s", err)
+			}
+		} else {
+			if err := remote("send sync"); err != nil {
+				app.ui.echoerrf("tag: %s", err)
+			}
+		}
 	case "invert":
 		if !app.nav.init {
 			return

--- a/eval.go
+++ b/eval.go
@@ -719,6 +719,22 @@ func insert(app *app, arg string) {
 			app.ui.loadFile(app.nav, true)
 			app.ui.loadFileInfo(app.nav)
 		}
+	case app.ui.cmdPrefix == "tag: ":
+		normal(app)
+
+		app.nav.tag(arg[0])
+		if err := app.nav.writeTags(); err != nil {
+			app.ui.echoerrf("tag: %s", err)
+		}
+		if gSingleMode {
+			if err := app.nav.sync(); err != nil {
+				app.ui.echoerrf("tag: %s", err)
+			}
+		} else {
+			if err := remote("send sync"); err != nil {
+				app.ui.echoerrf("tag: %s", err)
+			}
+		}
 	case app.ui.cmdPrefix == "mark-save: ":
 		normal(app)
 
@@ -983,19 +999,12 @@ func (e *callExpr) eval(app *app, args []string) {
 				}
 			}
 		}
-	case "tag":
+	case "tag-toggle":
 		if !app.nav.init {
 			return
 		}
-		if len(e.args) == 0 {
-			app.nav.toggleTag()
-		} else if len(e.args[0]) == 1 {
-			app.nav.tag(e.args[0][0])
-		} else {
-			app.ui.echoerrf("tag: invalid argument")
-			return
 
-		}
+		app.nav.toggleTag()
 		if err := app.nav.writeTags(); err != nil {
 			app.ui.echoerrf("tag: %s", err)
 		}
@@ -1008,6 +1017,12 @@ func (e *callExpr) eval(app *app, args []string) {
 				app.ui.echoerrf("tag: %s", err)
 			}
 		}
+	case "tag":
+		if app.ui.cmdPrefix == ">" {
+			return
+		}
+		normal(app)
+		app.ui.cmdPrefix = "tag: "
 	case "invert":
 		if !app.nav.init {
 			return

--- a/lf.1
+++ b/lf.1
@@ -31,61 +31,63 @@ You can run 'lf -help' to see descriptions of command line options.
 The following commands are provided by lf:
 .PP
 .EX
-    quit                     (default 'q')
-    up                       (default 'k' and '<up>')
-    half-up                  (default '<c-u>')
-    page-up                  (default '<c-b>' and '<pgup>')
-    scrollup                 (default '<c-y>')
-    down                     (default 'j' and '<down>')
-    half-down                (default '<c-d>')
-    page-down                (default '<c-f>' and '<pgdn>')
-    scrolldown               (default '<c-e>')
-    updir                    (default 'h' and '<left>')
-    open                     (default 'l' and '<right>')
-    top                      (default 'gg' and '<home>')
-    bottom                   (default 'G' and '<end>')
-    toggle
-    invert                   (default 'v')
-    unselect                 (default 'u')
-    glob-select
-    glob-unselect
-    calcdirsize
-    copy                     (default 'y')
-    cut                      (default 'd')
-    paste                    (default 'p')
-    clear                    (default 'c')
-    sync
-    draw
-    redraw                   (default '<c-l>')
-    load
-    reload                   (default '<c-r>')
-    echo
-    echomsg
-    echoerr
-    cd
-    select
-    delete         (modal)
-    rename         (modal)   (default 'r')
-    source
-    push
-    read           (modal)   (default ':')
-    shell          (modal)   (default '$')
-    shell-pipe     (modal)   (default '%')
-    shell-wait     (modal)   (default '!')
-    shell-async    (modal)   (default '&')
-    find           (modal)   (default 'f')
-    find-back      (modal)   (default 'F')
-    find-next                (default ';')
-    find-prev                (default ',')
-    search         (modal)   (default '/')
-    search-back    (modal)   (default '?')
-    search-next              (default 'n')
-    search-prev              (default 'N')
-    filter         (modal)
-    setfilter
-    mark-save      (modal)   (default 'm')
-    mark-load      (modal)   (default "'")
-    mark-remove    (modal)   (default `"`)
+        quit                     (default 'q')
+        up                       (default 'k' and '<up>')
+        half-up                  (default '<c-u>')
+        page-up                  (default '<c-b>' and '<pgup>')
+        scrollup                 (default '<c-y>')
+        down                     (default 'j' and '<down>')
+        half-down                (default '<c-d>')
+        page-down                (default '<c-f>' and '<pgdn>')
+        scrolldown               (default '<c-e>')
+        updir                    (default 'h' and '<left>')
+        open                     (default 'l' and '<right>')
+        top                      (default 'gg' and '<home>')
+        bottom                   (default 'G' and '<end>')
+        toggle
+        invert                   (default 'v')
+        unselect                 (default 'u')
+        glob-select
+        glob-unselect
+        calcdirsize
+        copy                     (default 'y')
+        cut                      (default 'd')
+        paste                    (default 'p')
+        clear                    (default 'c')
+        sync
+        draw
+        redraw                   (default '<c-l>')
+        load
+        reload                   (default '<c-r>')
+        echo
+        echomsg
+        echoerr
+        cd
+        select
+        delete         (modal)
+        rename         (modal)   (default 'r')
+        source
+        push
+        read           (modal)   (default ':')
+        shell          (modal)   (default '$')
+        shell-pipe     (modal)   (default '%')
+        shell-wait     (modal)   (default '!')
+        shell-async    (modal)   (default '&')
+        find           (modal)   (default 'f')
+        find-back      (modal)   (default 'F')
+        find-next                (default ';')
+        find-prev                (default ',')
+        search         (modal)   (default '/')
+        search-back    (modal)   (default '?')
+        search-next              (default 'n')
+        search-prev              (default 'N')
+        filter         (modal)
+        setfilter
+        mark-save      (modal)   (default 'm')
+        mark-load      (modal)   (default "'")
+        mark-remove    (modal)   (default `"`)
+    	tag-toggle               (default t)
+    	tag
 .EE
 .PP
 The following command line commands are provided by lf:
@@ -122,52 +124,53 @@ The following command line commands are provided by lf:
 The following options can be used to customize the behavior of lf:
 .PP
 .EX
-    anchorfind     bool      (default on)
-    autoquit       bool      (default off)
-    dircache       bool      (default on)
-    dircounts      bool      (default off)
-    dirfirst       bool      (default on)
-    dironly        bool      (default off)
-    drawbox        bool      (default off)
-    errorfmt       string    (default "\e033[7;31;47m%s\e033[0m")
-    filesep        string    (default "\en")
-    findlen        int       (default 1)
-    globsearch     bool      (default off)
-    hidden         bool      (default off)
-    hiddenfiles    []string  (default '.*')
-    icons          bool      (default off)
-    ifs            string    (default '')
-    ignorecase     bool      (default on)
-    ignoredia      bool      (default on)
-    incfilter      bool      (default off)
-    incsearch      bool      (default off)
-    info           []string  (default '')
-    mouse          bool      (default off)
-    number         bool      (default off)
-    period         int       (default 0)
-    preview        bool      (default on)
-    previewer      string    (default '')
-    cleaner        string    (default '')
-    promptfmt      string    (default "\e033[32;1m%u@%h\e033[0m:\e033[34;1m%d\e033[0m\e033[1m%f\e033[0m")
-    ratios         []int     (default '1:2:3')
-    relativenumber bool      (default off)
-    reverse        bool      (default off)
-    scrolloff      int       (default 0)
-    shell          string    (default 'sh' for unix and 'cmd' for windows)
-    shellflag      string    (default '-c' for unix and '/c' for windows)
-    shellopts      []string  (default '')
-    smartcase      bool      (default on)
-    smartdia       bool      (default off)
-    sortby         string    (default 'natural')
-    tabstop        int       (default 8)
-    tempmarks      string    (default '')
-    timefmt        string    (default 'Mon Jan _2 15:04:05 2006')
-    infotimefmtnew string    (default 'Jan _2 15:04')
-    infotimefmtold string    (default 'Jan _2  2006')
-    truncatechar   string    (default '~')
-    waitmsg        string    (default 'Press any key to continue')
-    wrapscan       bool      (default on)
-    wrapscroll     bool      (default off)
+        anchorfind     bool      (default on)
+        autoquit       bool      (default off)
+        dircache       bool      (default on)
+        dircounts      bool      (default off)
+        dirfirst       bool      (default on)
+        dironly        bool      (default off)
+        drawbox        bool      (default off)
+        errorfmt       string    (default "\e033[7;31;47m%s\e033[0m")
+        filesep        string    (default "\en")
+        findlen        int       (default 1)
+        globsearch     bool      (default off)
+        hidden         bool      (default off)
+        hiddenfiles    []string  (default '.*')
+        icons          bool      (default off)
+        ifs            string    (default '')
+        ignorecase     bool      (default on)
+        ignoredia      bool      (default on)
+        incfilter      bool      (default off)
+        incsearch      bool      (default off)
+        info           []string  (default '')
+        mouse          bool      (default off)
+        number         bool      (default off)
+        period         int       (default 0)
+        preview        bool      (default on)
+        previewer      string    (default '')
+        cleaner        string    (default '')
+        promptfmt      string    (default "\e033[32;1m%u@%h\e033[0m:\e033[34;1m%d\e033[0m\e033[1m%f\e033[0m")
+        ratios         []int     (default '1:2:3')
+        relativenumber bool      (default off)
+        reverse        bool      (default off)
+        scrolloff      int       (default 0)
+        shell          string    (default 'sh' for unix and 'cmd' for windows)
+        shellflag      string    (default '-c' for unix and '/c' for windows)
+        shellopts      []string  (default '')
+        smartcase      bool      (default on)
+        smartdia       bool      (default off)
+        sortby         string    (default 'natural')
+        tabstop        int       (default 8)
+        tempmarks      string    (default '')
+        timefmt        string    (default 'Mon Jan _2 15:04:05 2006')
+        infotimefmtnew string    (default 'Jan _2 15:04')
+        infotimefmtold string    (default 'Jan _2  2006')
+        truncatechar   string    (default '~')
+        waitmsg        string    (default 'Press any key to continue')
+        wrapscan       bool      (default on)
+        wrapscroll     bool      (default off)
+    	tagfmt         string    (default "\e033[31m%s\e033[0m")
 .EE
 .PP
 The following environment variables are exported for shell commands:
@@ -269,6 +272,13 @@ History file should be located at:
 .EX
     unix     ~/.local/share/lf/history
     windows  C:\eUsers\e<user>\eAppData\eLocal\elf\ehistory
+.EE
+.PP
+Tags file should be located at:
+.PP
+.EX
+    unix     ~/.local/share/lf/tags
+    windows  C:\eUsers\e<user>\eAppData\eLocal\elf\etags
 .EE
 .PP
 You can configure the default values of following variables to change these locations:
@@ -566,16 +576,16 @@ Change the current directory to the bookmark assigned to the given key. A specia
 Remove a bookmark assigned to the given key.
 .PP
 .EX
-    tag            (modal)   (default 'T')
+    tag
 .EE
 .PP
-Tag a file with the given key.
+Tag a file with a single width character given in the argument.
 .PP
 .EX
     tag-toggle     (modal)   (default 't')
 .EE
 .PP
-Tag a file with "*" if the file is untagged, otherwise remove the tag.
+Tag a file with a single width character given in the argument if the file is untagged, otherwise remove the tag.
 .SH COMMAND LINE COMMANDS
 This section shows information about command line commands. These should be mostly compatible with readline keybindings. A character refers to a unicode code point, a word consists of letters and digits, and a unix word consists of any non-blank characters.
 .PP
@@ -967,6 +977,12 @@ Searching can wrap around the file list.
 .EE
 .PP
 Scrolling can wrap around the file list.
+.PP
+.EX
+    tagfmt         string    (default "\e033[31m%s\e033[0m")
+.EE
+.PP
+Format string of the tags.
 .SH ENVIRONMENT VARIABLES
 The following variables are exported for shell commands: These are referred with a '$' prefix on POSIX shells (e.g. '$f'), between '%' characters on Windows cmd (e.g. '%f%'), and with a '$env:' prefix on Windows powershell (e.g. '$env:f').
 .PP

--- a/lf.1
+++ b/lf.1
@@ -564,6 +564,18 @@ Change the current directory to the bookmark assigned to the given key. A specia
 .EE
 .PP
 Remove a bookmark assigned to the given key.
+.PP
+.EX
+    tag            (modal)   (default 'T')
+.EE
+.PP
+Tag a file with the given key.
+.PP
+.EX
+    tag-toggle     (modal)   (default 't')
+.EE
+.PP
+Tag a file with "*" if the file is untagged, otherwise remove the tag.
 .SH COMMAND LINE COMMANDS
 This section shows information about command line commands. These should be mostly compatible with readline keybindings. A character refers to a unicode code point, a word consists of letters and digits, and a unix word consists of any non-blank characters.
 .PP

--- a/nav.go
+++ b/nav.go
@@ -61,6 +61,7 @@ func readdir(path string) ([]*file, error) {
 		fpath := filepath.Join(path, fname)
 
 		lstat, err := os.Lstat(fpath)
+
 		if os.IsNotExist(err) {
 			continue
 		}
@@ -373,6 +374,7 @@ type nav struct {
 	renameOldPath   string
 	renameNewPath   string
 	selections      map[string]int
+	tags            map[string]byte
 	selectionInd    int
 	height          int
 	find            string
@@ -495,6 +497,7 @@ func newNav(height int) *nav {
 		saves:           make(map[string]bool),
 		marks:           make(map[string]string),
 		selections:      make(map[string]int),
+		tags:            make(map[string]byte),
 		selectionInd:    0,
 		height:          height,
 		jumpList:        make([]string, 0),
@@ -961,6 +964,32 @@ func (nav *nav) toggle() {
 	nav.toggleSelection(curr.path)
 }
 
+func (nav *nav) toggleTagSelection(path string) {
+	if _, ok := nav.tags[path]; ok {
+		delete(nav.tags, path)
+	} else {
+		nav.tags[path] = '*'
+	}
+}
+
+func (nav *nav) toggleTag() {
+	curr, err := nav.currFile()
+	if err != nil {
+		return
+	}
+
+	nav.toggleTagSelection(curr.path)
+}
+
+func (nav *nav) tag(t byte) {
+	curr, err := nav.currFile()
+	if err != nil {
+		return
+	}
+
+	nav.tags[curr.path] = t
+}
+
 func (nav *nav) invert() {
 	dir := nav.currDir()
 	for _, f := range dir.files {
@@ -1268,6 +1297,7 @@ func (nav *nav) sync() error {
 			nav.marks[tmp] = v
 		}
 	}
+	err = nav.readTags()
 	return err
 }
 
@@ -1555,6 +1585,59 @@ func (nav *nav) writeMarks() error {
 		_, err = f.WriteString(fmt.Sprintf("%s:%s\n", k, nav.marks[k]))
 		if err != nil {
 			return fmt.Errorf("writing marks file: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func (nav *nav) readTags() error {
+	nav.tags = make(map[string]byte)
+	f, err := os.Open(gTagsPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("opening tags file: %s", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		toks := strings.SplitN(scanner.Text(), ":", 2)
+		if _, ok := nav.tags[toks[0]]; !ok {
+			nav.tags[toks[0]] = toks[1][0]
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("reading tags file: %s", err)
+	}
+
+	return nil
+}
+
+func (nav *nav) writeTags() error {
+	if err := os.MkdirAll(filepath.Dir(gTagsPath), os.ModePerm); err != nil {
+		return fmt.Errorf("creating data directory: %s", err)
+	}
+
+	f, err := os.Create(gTagsPath)
+	if err != nil {
+		return fmt.Errorf("creating tags file: %s", err)
+	}
+	defer f.Close()
+
+	var keys []string
+	for k := range nav.tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		_, err = f.WriteString(fmt.Sprintf("%s:%c\n", k, nav.tags[k]))
+		if err != nil {
+			return fmt.Errorf("writing tags file: %s", err)
 		}
 	}
 

--- a/opts.go
+++ b/opts.go
@@ -149,7 +149,8 @@ func init() {
 	gOpts.keys["["] = &callExpr{"jump-prev", nil, 1}
 	gOpts.keys["]"] = &callExpr{"jump-next", nil, 1}
 	gOpts.keys["<space>"] = &listExpr{[]expr{&callExpr{"toggle", nil, 1}, &callExpr{"down", nil, 1}}, 1}
-	gOpts.keys["t"] = &listExpr{[]expr{&callExpr{"tag", nil, 1}, &callExpr{"down", nil, 1}}, 1}
+	gOpts.keys["t"] = &listExpr{[]expr{&callExpr{"tag-toggle", nil, 1}, &callExpr{"down", nil, 1}}, 1}
+	gOpts.keys["T"] = &callExpr{"tag", nil, 1}
 	gOpts.keys["v"] = &callExpr{"invert", nil, 1}
 	gOpts.keys["u"] = &callExpr{"unselect", nil, 1}
 	gOpts.keys["y"] = &callExpr{"copy", nil, 1}

--- a/opts.go
+++ b/opts.go
@@ -74,6 +74,7 @@ var gOpts struct {
 	cmds           map[string]expr
 	sortType       sortType
 	tempmarks      string
+	tagcolor       string
 }
 
 func init() {
@@ -120,6 +121,7 @@ func init() {
 	gOpts.shellopts = nil
 	gOpts.sortType = sortType{naturalSort, dirfirstSort}
 	gOpts.tempmarks = "'"
+	gOpts.tagcolor = "0;31"
 
 	gOpts.keys = make(map[string]expr)
 
@@ -147,6 +149,7 @@ func init() {
 	gOpts.keys["["] = &callExpr{"jump-prev", nil, 1}
 	gOpts.keys["]"] = &callExpr{"jump-next", nil, 1}
 	gOpts.keys["<space>"] = &listExpr{[]expr{&callExpr{"toggle", nil, 1}, &callExpr{"down", nil, 1}}, 1}
+	gOpts.keys["t"] = &listExpr{[]expr{&callExpr{"tag", nil, 1}, &callExpr{"down", nil, 1}}, 1}
 	gOpts.keys["v"] = &callExpr{"invert", nil, 1}
 	gOpts.keys["u"] = &callExpr{"unselect", nil, 1}
 	gOpts.keys["y"] = &callExpr{"copy", nil, 1}

--- a/opts.go
+++ b/opts.go
@@ -74,7 +74,7 @@ var gOpts struct {
 	cmds           map[string]expr
 	sortType       sortType
 	tempmarks      string
-	tagcolor       string
+	tagfmt         string
 }
 
 func init() {
@@ -121,7 +121,7 @@ func init() {
 	gOpts.shellopts = nil
 	gOpts.sortType = sortType{naturalSort, dirfirstSort}
 	gOpts.tempmarks = "'"
-	gOpts.tagcolor = "0;31"
+	gOpts.tagfmt = "\033[31m%s\033[0m"
 
 	gOpts.keys = make(map[string]expr)
 
@@ -149,8 +149,7 @@ func init() {
 	gOpts.keys["["] = &callExpr{"jump-prev", nil, 1}
 	gOpts.keys["]"] = &callExpr{"jump-next", nil, 1}
 	gOpts.keys["<space>"] = &listExpr{[]expr{&callExpr{"toggle", nil, 1}, &callExpr{"down", nil, 1}}, 1}
-	gOpts.keys["t"] = &listExpr{[]expr{&callExpr{"tag-toggle", nil, 1}, &callExpr{"down", nil, 1}}, 1}
-	gOpts.keys["T"] = &callExpr{"tag", nil, 1}
+	gOpts.keys["t"] = &listExpr{[]expr{&callExpr{"tag-toggle", []string{"*"}, 1}, &callExpr{"down", nil, 1}}, 1}
 	gOpts.keys["v"] = &callExpr{"invert", nil, 1}
 	gOpts.keys["u"] = &callExpr{"unselect", nil, 1}
 	gOpts.keys["y"] = &callExpr{"copy", nil, 1}

--- a/os.go
+++ b/os.go
@@ -35,6 +35,7 @@ var (
 	gIconsPaths  []string
 	gFilesPath   string
 	gMarksPath   string
+	gTagsPath    string
 	gHistoryPath string
 )
 
@@ -98,6 +99,7 @@ func init() {
 
 	gFilesPath = filepath.Join(data, "lf", "files")
 	gMarksPath = filepath.Join(data, "lf", "marks")
+	gTagsPath = filepath.Join(data, "lf", "tags")
 	gHistoryPath = filepath.Join(data, "lf", "history")
 
 	runtime := os.Getenv("XDG_RUNTIME_DIR")

--- a/os_windows.go
+++ b/os_windows.go
@@ -33,6 +33,7 @@ var (
 	gColorsPaths []string
 	gIconsPaths  []string
 	gFilesPath   string
+	gTagsPath    string
 	gMarksPath   string
 	gHistoryPath string
 )
@@ -82,6 +83,7 @@ func init() {
 
 	gFilesPath = filepath.Join(data, "lf", "files")
 	gMarksPath = filepath.Join(data, "lf", "marks")
+	gTagsPath = filepath.Join(data, "lf", "tags")
 	gHistoryPath = filepath.Join(data, "lf", "history")
 }
 

--- a/ui.go
+++ b/ui.go
@@ -324,7 +324,7 @@ func fileInfo(f *file, d *dir) string {
 	return info
 }
 
-func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]int, saves map[string]bool, tags map[string]byte, colors styleMap, icons iconMap) {
+func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]int, saves map[string]bool, tags map[string]string, colors styleMap, icons iconMap) {
 	if win.w < 5 || dir == nil {
 		return
 	}
@@ -391,23 +391,14 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]in
 
 		path := filepath.Join(dir.path, f.Name())
 
-
-		st_tag := applyAnsiCodes(gOpts.tagcolor, st)
-		tag, ok := tags[path]
-		if !ok {
-			tag = ' '
-		}
-
 		if _, ok := selections[path]; ok {
-			win.print(screen, lnwidth, i, st_tag.Background(tcell.ColorPurple), string(tag))
+			win.print(screen, lnwidth, i, st.Background(tcell.ColorPurple), " ")
 		} else if cp, ok := saves[path]; ok {
 			if cp {
-				win.print(screen, lnwidth, i, st_tag.Background(tcell.ColorOlive), string(tag))
+				win.print(screen, lnwidth, i, st.Background(tcell.ColorOlive), " ")
 			} else {
-				win.print(screen, lnwidth, i, st_tag.Background(tcell.ColorMaroon), string(tag))
+				win.print(screen, lnwidth, i, st.Background(tcell.ColorMaroon), " ")
 			}
-		} else {
-			win.print(screen, lnwidth, i, st_tag, string(tag))
 		}
 
 		if i == dir.pos {
@@ -458,6 +449,18 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]in
 		s = append(s, ' ')
 
 		win.print(screen, lnwidth+1, i, st, string(s))
+
+		tag, ok := tags[path]
+		if ok {
+			st = st.Reverse(false)
+			fg, bg, _ := st.Decompose()
+
+			if i == dir.pos {
+				win.print(screen, lnwidth+1, i, st.Background(fg), fmt.Sprintf(gOpts.tagfmt, tag))
+			} else {
+				win.print(screen, lnwidth+1, i, st.Background(bg), fmt.Sprintf(gOpts.tagfmt, tag))
+			}
+		}
 	}
 }
 

--- a/ui.go
+++ b/ui.go
@@ -324,7 +324,7 @@ func fileInfo(f *file, d *dir) string {
 	return info
 }
 
-func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]int, saves map[string]bool, colors styleMap, icons iconMap) {
+func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]int, saves map[string]bool, tags map[string]byte, colors styleMap, icons iconMap) {
 	if win.w < 5 || dir == nil {
 		return
 	}
@@ -391,14 +391,23 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]in
 
 		path := filepath.Join(dir.path, f.Name())
 
+
+		st_tag := applyAnsiCodes(gOpts.tagcolor, st)
+		tag, ok := tags[path]
+		if !ok {
+			tag = ' '
+		}
+
 		if _, ok := selections[path]; ok {
-			win.print(screen, lnwidth, i, st.Background(tcell.ColorPurple), " ")
+			win.print(screen, lnwidth, i, st_tag.Background(tcell.ColorPurple), string(tag))
 		} else if cp, ok := saves[path]; ok {
 			if cp {
-				win.print(screen, lnwidth, i, st.Background(tcell.ColorOlive), " ")
+				win.print(screen, lnwidth, i, st_tag.Background(tcell.ColorOlive), string(tag))
 			} else {
-				win.print(screen, lnwidth, i, st.Background(tcell.ColorMaroon), " ")
+				win.print(screen, lnwidth, i, st_tag.Background(tcell.ColorMaroon), string(tag))
 			}
+		} else {
+			win.print(screen, lnwidth, i, st_tag, string(tag))
 		}
 
 		if i == dir.pos {
@@ -839,7 +848,7 @@ func (ui *ui) draw(nav *nav) {
 
 	doff := len(nav.dirs) - length
 	for i := 0; i < length; i++ {
-		ui.wins[woff+i].printDir(ui.screen, nav.dirs[doff+i], nav.selections, nav.saves, ui.styles, ui.icons)
+		ui.wins[woff+i].printDir(ui.screen, nav.dirs[doff+i], nav.selections, nav.saves, nav.tags, ui.styles, ui.icons)
 	}
 
 	switch ui.cmdPrefix {
@@ -873,7 +882,7 @@ func (ui *ui) draw(nav *nav) {
 			preview := ui.wins[len(ui.wins)-1]
 
 			if curr.IsDir() {
-				preview.printDir(ui.screen, ui.dirPrev, nav.selections, nav.saves, ui.styles, ui.icons)
+				preview.printDir(ui.screen, ui.dirPrev, nav.selections, nav.saves, nav.tags, ui.styles, ui.icons)
 			} else if curr.Mode().IsRegular() {
 				preview.printReg(ui.screen, ui.regPrev)
 			}


### PR DESCRIPTION
This addresses #400. It works similarly to ranger's tags. They default keymap is "t" to add the "*" tag or to remove the existing one but you can also use the :tag command followed by a single character to tag the file with that character.

I hope this is helpful, I really missed this feature when I switched from ranger to lf so I decided to implement it myself.

This is my first time writing anything in go, so any feedback is appreciated :)