### PR TITLE
Stop distinguishing between up/low-case file ext for custom icons

### DIFF
--- a/icons.go
+++ b/icons.go
@@ -156,7 +156,7 @@ func (im iconMap) get(f *file) string {
 		return val
 	}
 
-	if val, ok := im["*"+f.ext]; ok {
+	if val, ok := im["*"+strings.ToLower(f.ext)]; ok {
 		return val
 	}
 


### PR DESCRIPTION
For custom icons (set in the `LF_ICONS` env), does it make sense to distinguish the lowercase from the uppercase file extensions? I mean if someone sets the icon eg. for `*.png` files, it would be nice to show it also for the `*.PNG`.

Before:

![2022-04-07_08-34](https://user-images.githubusercontent.com/8074556/162135700-5ba90848-7f27-4d84-bb5e-cc8a0f37693f.png)

After the change from the PR:

![2022-04-07_08-33](https://user-images.githubusercontent.com/8074556/162135719-0639f69a-9925-478c-8747-5cb3e094c0c3.png)

