### PR TITLE
handle empty answer in delete

### DIFF
--- a/etc/lfrc.example
+++ b/etc/lfrc.example
@@ -60,7 +60,7 @@ cmd trash %set -f; mv $fx ~/.trash
 #     printf "$fx\n"
 #     printf "delete?[y/n]"
 #     read ans
-#     [ $ans = "y" ] && rm -rf $fx
+#     [ -n "$ans" ] && [ "$ans" = "y" ] && rm -rf $fx
 # }}
 
 # use '<delete>' key for either 'trash' or 'delete' command

--- a/etc/lfrc.example
+++ b/etc/lfrc.example
@@ -60,7 +60,7 @@ cmd trash %set -f; mv $fx ~/.trash
 #     printf "$fx\n"
 #     printf "delete?[y/n]"
 #     read ans
-#     [ -n "$ans" ] && [ "$ans" = "y" ] && rm -rf $fx
+#     [ "$ans" = "y" ] && rm -rf $fx
 # }}
 
 # use '<delete>' key for either 'trash' or 'delete' command


### PR DESCRIPTION
Fixes an error message that occurs in the delete command from lfrc.example. If the user enters an empty answer, the test for "y" is syntactically wrong. 