### PR TITLE
Add VIMs hi/mid/lo-screen commands

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -298,6 +298,12 @@ Change the current working directory to the next/previous jumplist item.
 
 Move the current file selection to the top/bottom of the directory.
 
+    hi-screen                (default 'H')
+    mid-screen               (default 'M')
+    lo-screen                (default 'L')
+
+Move the current file selection to the top/middle/bottom of the screen.
+
     toggle
 
 Toggle the selection of the current file or files given as arguments.

--- a/doc.go
+++ b/doc.go
@@ -31,6 +31,9 @@ The following commands are provided by lf:
     jump-prev                (default '[')
     top                      (default 'gg' and '<home>')
     bottom                   (default 'G' and '<end>')
+    hi-screen                (default 'H')
+    mid-screen               (default 'M')
+    lo-screen                (default 'L')
     toggle
     invert                   (default 'v')
     unselect                 (default 'u')

--- a/docstring.go
+++ b/docstring.go
@@ -310,6 +310,12 @@ Change the current working directory to the next/previous jumplist item.
 
 Move the current file selection to the top/bottom of the directory.
 
+    hi-screen                (default 'H')
+    mid-screen               (default 'M')
+    lo-screen                (default 'L')
+
+Move the current file selection to the top/middle/bottom of the screen.
+
     toggle
 
 Toggle the selection of the current file or files given as arguments.

--- a/docstring.go
+++ b/docstring.go
@@ -35,6 +35,9 @@ The following commands are provided by lf:
     jump-prev                (default '[')
     top                      (default 'gg' and '<home>')
     bottom                   (default 'G' and '<end>')
+    hi-screen                (default 'H')
+    mid-screen               (default 'M')
+    lo-screen                (default 'L')
     toggle
     invert                   (default 'v')
     unselect                 (default 'u')

--- a/eval.go
+++ b/eval.go
@@ -963,6 +963,30 @@ func (e *callExpr) eval(app *app, args []string) {
 			app.ui.loadFile(app.nav, true)
 			app.ui.loadFileInfo(app.nav)
 		}
+	case "hi-screen":
+		if !app.nav.init {
+			return
+		}
+		if app.nav.hiScreen() {
+			app.ui.loadFile(app.nav, true)
+			app.ui.loadFileInfo(app.nav)
+		}
+	case "mid-screen":
+		if !app.nav.init {
+			return
+		}
+		if app.nav.midScreen() {
+			app.ui.loadFile(app.nav, true)
+			app.ui.loadFileInfo(app.nav)
+		}
+	case "lo-screen":
+		if !app.nav.init {
+			return
+		}
+		if app.nav.loScreen() {
+			app.ui.loadFile(app.nav, true)
+			app.ui.loadFileInfo(app.nav)
+		}
 	case "toggle":
 		if !app.nav.init {
 			return

--- a/lf.1
+++ b/lf.1
@@ -347,6 +347,14 @@ Change the current working directory to the next/previous jumplist item.
 Move the current file selection to the top/bottom of the directory.
 .PP
 .EX
+    hi-screen                (default 'H')
+    mid-screen               (default 'M')
+    lo-screen                (default 'L')
+.EE
+.PP
+Move the current file selection to the top/middle/bottom of the screen.
+.PP
+.EX
     toggle
 .EE
 .PP

--- a/lf.1
+++ b/lf.1
@@ -46,6 +46,9 @@ The following commands are provided by lf:
     jump-prev                (default '[')
     top                      (default 'gg' and '<home>')
     bottom                   (default 'G' and '<end>')
+    hi-screen                (default 'H')
+    mid-screen               (default 'M')
+    lo-screen                (default 'L')
     toggle
     invert                   (default 'v')
     unselect                 (default 'u')

--- a/nav.go
+++ b/nav.go
@@ -943,6 +943,53 @@ func (nav *nav) bottom() bool {
 	return old != dir.ind
 }
 
+func (nav *nav) hiScreen() bool {
+	dir := nav.currDir()
+
+	old := dir.ind
+	beg := max(dir.ind-dir.pos, 0)
+	offs := gOpts.scrolloff
+	if beg == 0 {
+		offs = 0
+	}
+
+	dir.ind = beg + offs
+	dir.pos = offs
+
+	return old != dir.ind
+}
+
+func (nav *nav) midScreen() bool {
+	dir := nav.currDir()
+
+	old := dir.ind
+	beg := max(dir.ind-dir.pos, 0)
+	end := min(beg+nav.height, len(dir.files))
+
+	half := (end - beg) / 2
+	dir.ind = beg + half
+	dir.pos = half
+
+	return old != dir.ind
+}
+
+func (nav *nav) loScreen() bool {
+	dir := nav.currDir()
+
+	old := dir.ind
+	beg := max(dir.ind-dir.pos, 0)
+	end := min(beg+nav.height, len(dir.files))
+	offs := gOpts.scrolloff
+	if end == len(dir.files) {
+		offs = 0
+	}
+
+	dir.ind = end - 1 - offs
+	dir.pos = end - beg - 1 - offs
+
+	return old != dir.ind
+}
+
 func (nav *nav) toggleSelection(path string) {
 	if _, ok := nav.selections[path]; ok {
 		delete(nav.selections, path)

--- a/opts.go
+++ b/opts.go
@@ -146,6 +146,9 @@ func init() {
 	gOpts.keys["<home>"] = &callExpr{"top", nil, 1}
 	gOpts.keys["G"] = &callExpr{"bottom", nil, 1}
 	gOpts.keys["<end>"] = &callExpr{"bottom", nil, 1}
+	gOpts.keys["H"] = &callExpr{"hi-screen", nil, 1}
+	gOpts.keys["M"] = &callExpr{"mid-screen", nil, 1}
+	gOpts.keys["L"] = &callExpr{"lo-screen", nil, 1}
 	gOpts.keys["["] = &callExpr{"jump-prev", nil, 1}
 	gOpts.keys["]"] = &callExpr{"jump-next", nil, 1}
 	gOpts.keys["<space>"] = &listExpr{[]expr{&callExpr{"toggle", nil, 1}, &callExpr{"down", nil, 1}}, 1}


### PR DESCRIPTION
This PR adds VIMs `H`, `M` and `L` commands to go top, middle and low (bottom) of the screen.

`scrolloff` is respected but count is ignored.

I added default keybindings because they come from vim and there were no conflicts.