### PR TITLE
docs: fix number of special commands

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -901,7 +901,7 @@ Characters from '#' to newline are comments and ignored:
 
     # comments start with '#'
 
-There are three special commands ('set', 'map', 'cmap', and 'cmd') for configuration.
+There are four special commands ('set', 'map', 'cmap', and 'cmd') for configuration.
 
 Command 'set' is used to set an option which can be boolean, integer, or string:
 

--- a/lf.1
+++ b/lf.1
@@ -1104,7 +1104,7 @@ Characters from '#' to newline are comments and ignored:
     # comments start with '#'
 .EE
 .PP
-There are three special commands ('set', 'map', 'cmap', and 'cmd') for configuration.
+There are four special commands ('set', 'map', 'cmap', and 'cmd') for configuration.
 .PP
 Command 'set' is used to set an option which can be boolean, integer, or string:
 .PP


### PR DESCRIPTION
Replace
> There are **three** special commands ('set', 'map', 'cmap', and 'cmd') for configuration.

with
> There are **four** special commands ('set', 'map', 'cmap', and 'cmd') for configuration.