### PR TITLE
Go to normal mode when backspacing on empty prompt

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -1916,6 +1916,7 @@ func (e *callExpr) eval(app *app, args []string) {
 		update(app)
 	case "cmd-delete-back":
 		if len(app.ui.cmdAccLeft) == 0 {
+			normal(app)
 			return
 		}
 		app.ui.cmdAccLeft = app.ui.cmdAccLeft[:len(app.ui.cmdAccLeft)-1]


### PR DESCRIPTION
This matches up with vim's behavior.