### PR TITLE
Implement directory previews

### DIFF
--- a/app.go
+++ b/app.go
@@ -237,6 +237,7 @@ func (app *app) writeHistory() error {
 // separate goroutines and sent here for update.
 func (app *app) loop() {
 	go app.nav.previewLoop(app.ui)
+	go app.nav.dirPreviewLoop(app.ui)
 
 	var serverChan <-chan expr
 	if !gSingleMode {
@@ -318,6 +319,7 @@ func (app *app) loop() {
 			app.quit()
 
 			app.nav.previewChan <- ""
+			app.nav.dirPreviewChan <- nil
 
 			log.Print("bye!")
 
@@ -382,6 +384,7 @@ func (app *app) loop() {
 			}
 			app.ui.draw(app.nav)
 		case d := <-app.nav.dirChan:
+
 			app.nav.checkDir(d)
 
 			if gOpts.dircache {

--- a/app.go
+++ b/app.go
@@ -485,6 +485,8 @@ func (app *app) runShell(s string, args []string, prefix string) {
 		cmd.Stderr = os.Stderr
 
 		app.nav.previewChan <- ""
+		app.nav.dirPreviewChan <- nil
+
 		if err := app.ui.suspend(); err != nil {
 			log.Printf("suspend: %s", err)
 		}

--- a/complete.go
+++ b/complete.go
@@ -90,6 +90,7 @@ var (
 		"nodirfirst",
 		"dirfirst!",
 		"dironly",
+		"dirpreviews",
 		"nodironly",
 		"dironly!",
 		"drawbox",

--- a/doc.go
+++ b/doc.go
@@ -117,6 +117,7 @@ The following options can be used to customize the behavior of lf:
     dircounts      bool      (default off)
     dirfirst       bool      (default on)
     dironly        bool      (default off)
+    dirpreviews    bool      (default off)
     drawbox        bool      (default off)
     errorfmt       string    (default "\033[7;31;47m%s\033[0m")
     filesep        string    (default "\n")
@@ -590,6 +591,10 @@ This option only has an effect when 'info' has a 'size' field and the pane is wi
 Show directories first above regular files.
 
     dironly        bool      (default off)
+
+If enabled, directories will also be passed to the previewer script. This allows custom previews for directories.
+
+    dirpreviews    bool      (default off)
 
 Show only directories.
 

--- a/eval.go
+++ b/eval.go
@@ -44,6 +44,8 @@ func (e *setExpr) eval(app *app, args []string) {
 		app.nav.position()
 		app.ui.sort()
 		app.ui.loadFile(app.nav, true)
+	case "dirpreviews":
+		gOpts.dirpreviews = true
 	case "nodironly":
 		gOpts.dironly = false
 		app.nav.sort()

--- a/nav.go
+++ b/nav.go
@@ -498,7 +498,7 @@ func newNav(height int) *nav {
 		deleteTotalChan: make(chan int, 1024),
 		previewChan:     make(chan string, 1024),
 		dirPreviewChan:  make(chan *dir, 1024),
-		dirChan:         make(chan *dir), // Directory channel, consumed by main loop
+		dirChan:         make(chan *dir),
 		regChan:         make(chan *reg),
 		dirCache:        make(map[string]*dir),
 		regCache:        make(map[string]*reg),
@@ -744,7 +744,7 @@ func (nav *nav) preview(path string, win *win) {
 	if len(gOpts.previewer) != 0 {
 		nav.exportFiles()
 		exportOpts()
-		cmd := exec.Command(gOpts.previewer, path, // Doing the preview
+		cmd := exec.Command(gOpts.previewer, path,
 			strconv.Itoa(win.w),
 			strconv.Itoa(win.h),
 			strconv.Itoa(win.x),

--- a/nav.go
+++ b/nav.go
@@ -454,6 +454,9 @@ func (nav *nav) checkDir(dir *dir) {
 			nd := newDir(dir.path)
 			nd.filter = dir.filter
 			nd.sort()
+			if gOpts.dirpreviews {
+				nav.dirPreviewChan <- nd
+			}
 			nav.dirChan <- nd
 		}()
 	case dir.sortType != gOpts.sortType ||
@@ -606,6 +609,7 @@ func (nav *nav) exportFiles() {
 
 	exportFiles(currFile, currSelections, nav.currDir().path)
 }
+
 func (nav *nav) dirPreviewLoop(ui *ui) {
 	var prevPath string
 	for {

--- a/nav.go
+++ b/nav.go
@@ -736,12 +736,6 @@ func (nav *nav) previewDir(dir *dir, win *win) {
 
 func (nav *nav) preview(path string, win *win) {
 
-	if dir, ok := nav.dirCache[path]; ok {
-		log.Printf("previewing dir: %s", dir.path)
-		nav.previewDir(dir, win)
-		return
-	}
-
 	reg := &reg{loadTime: time.Now(), path: path}
 	defer func() { nav.regChan <- reg }()
 

--- a/opts.go
+++ b/opts.go
@@ -33,6 +33,7 @@ var gOpts struct {
 	dircache       bool
 	dircounts      bool
 	dironly        bool
+	dirpreviews    bool
 	drawbox        bool
 	globsearch     bool
 	icons          bool
@@ -83,6 +84,7 @@ func init() {
 	gOpts.dircache = true
 	gOpts.dircounts = false
 	gOpts.dironly = false
+	gOpts.dirpreviews = false
 	gOpts.drawbox = false
 	gOpts.globsearch = false
 	gOpts.icons = false

--- a/ui.go
+++ b/ui.go
@@ -326,20 +326,6 @@ func fileInfo(f *file, d *dir) string {
 
 func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]int, saves map[string]bool, tags map[string]string, colors styleMap, icons iconMap, previewAllowed  bool) {
 
-	// Directory previews are printed only in the right pane.
-	if( previewAllowed && gOpts.dirpreviews ) {
-		st := tcell.StyleDefault
-		for i, l := range dir.lines {
-		 	if i > win.h-1 {
-		 		break
-		 	}
-
-			log.Print(l)
-			st = win.print(screen, 2, i, st, l)
-		}
-		return // Draw dir.lines if
-	}
-
 	if win.w < 5 || dir == nil {
 		return
 	}
@@ -349,8 +335,22 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]in
 		return
 	}
 
-	if dir.loading && len(dir.files) == 0 {
+	if ( dir.loading && len(dir.files) == 0 ) || ( previewAllowed && dir.loading && gOpts.dirpreviews ) {
 		win.print(screen, 2, 0, tcell.StyleDefault.Reverse(true), "loading...")
+		return
+	}
+
+	if( previewAllowed && gOpts.dirpreviews ) {
+
+		// Print previewer result instead of default directory print operation.
+		st := tcell.StyleDefault
+		for i, l := range dir.lines {
+		 	if i > win.h-1 {
+		 		break
+		 	}
+
+			st = win.print(screen, 2, i, st, l)
+		}
 		return
 	}
 

--- a/ui.go
+++ b/ui.go
@@ -340,7 +340,7 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]in
 		return
 	}
 
-	if previewAllowed && gOpts.dirpreviews {
+	if previewAllowed && gOpts.dirpreviews && len(gOpts.previewer) > 0 {
 
 		// Print previewer result instead of default directory print operation.
 		st := tcell.StyleDefault

--- a/ui.go
+++ b/ui.go
@@ -324,7 +324,22 @@ func fileInfo(f *file, d *dir) string {
 	return info
 }
 
-func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]int, saves map[string]bool, tags map[string]string, colors styleMap, icons iconMap) {
+func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]int, saves map[string]bool, tags map[string]string, colors styleMap, icons iconMap, previewAllowed  bool) {
+
+	// Directory previews are printed only in the right pane.
+	if( previewAllowed && gOpts.dirpreviews ) {
+		st := tcell.StyleDefault
+		for i, l := range dir.lines {
+		 	if i > win.h-1 {
+		 		break
+		 	}
+
+			log.Print(l)
+			st = win.print(screen, 2, i, st, l)
+		}
+		return // Draw dir.lines if
+	}
+
 	if win.w < 5 || dir == nil {
 		return
 	}
@@ -848,7 +863,7 @@ func (ui *ui) draw(nav *nav) {
 
 	doff := len(nav.dirs) - length
 	for i := 0; i < length; i++ {
-		ui.wins[woff+i].printDir(ui.screen, nav.dirs[doff+i], nav.selections, nav.saves, nav.tags, ui.styles, ui.icons)
+		ui.wins[woff+i].printDir(ui.screen, nav.dirs[doff+i], nav.selections, nav.saves, nav.tags, ui.styles, ui.icons, false)
 	}
 
 	switch ui.cmdPrefix {
@@ -882,7 +897,7 @@ func (ui *ui) draw(nav *nav) {
 			preview := ui.wins[len(ui.wins)-1]
 
 			if curr.IsDir() {
-				preview.printDir(ui.screen, ui.dirPrev, nav.selections, nav.saves, nav.tags, ui.styles, ui.icons)
+				preview.printDir(ui.screen, ui.dirPrev, nav.selections, nav.saves, nav.tags, ui.styles, ui.icons, true)
 			} else if curr.Mode().IsRegular() {
 				preview.printReg(ui.screen, ui.regPrev)
 			}

--- a/ui.go
+++ b/ui.go
@@ -324,7 +324,7 @@ func fileInfo(f *file, d *dir) string {
 	return info
 }
 
-func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]int, saves map[string]bool, tags map[string]string, colors styleMap, icons iconMap, previewAllowed  bool) {
+func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]int, saves map[string]bool, tags map[string]string, colors styleMap, icons iconMap, previewAllowed bool) {
 
 	if win.w < 5 || dir == nil {
 		return
@@ -335,19 +335,19 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]in
 		return
 	}
 
-	if ( dir.loading && len(dir.files) == 0 ) || ( previewAllowed && dir.loading && gOpts.dirpreviews ) {
+	if (dir.loading && len(dir.files) == 0) || (previewAllowed && dir.loading && gOpts.dirpreviews) {
 		win.print(screen, 2, 0, tcell.StyleDefault.Reverse(true), "loading...")
 		return
 	}
 
-	if( previewAllowed && gOpts.dirpreviews ) {
+	if previewAllowed && gOpts.dirpreviews {
 
 		// Print previewer result instead of default directory print operation.
 		st := tcell.StyleDefault
 		for i, l := range dir.lines {
-		 	if i > win.h-1 {
-		 		break
-		 	}
+			if i > win.h-1 {
+				break
+			}
 
 			st = win.print(screen, 2, i, st, l)
 		}


### PR DESCRIPTION
Implementation for #701.

Added option `dirpreviews`. When enabled, the selected directory is passed to previewer script.

Implementation essentially just adds another channel for directory previews `dirPreviewChan` and a corresponding goroutine `dirPreviewLoop` which work in the same manner as preview functionality for regular files. 

(BTW: my first PR here, love the project so wanted to contribute with this as it seemed like a gentle introduction to the codebase)