### PR TITLE
Add a selection mode

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -164,6 +164,7 @@ var (
 		"cleaner",
 		"promptfmt",
 		"ratios",
+		"selmode",
 		"shell",
 		"shellflag",
 		"shellopts",

--- a/doc.go
+++ b/doc.go
@@ -144,6 +144,7 @@ The following options can be used to customize the behavior of lf:
     relativenumber bool      (default off)
     reverse        bool      (default off)
     scrolloff      int       (default 0)
+    selmode        string    (default 'all')
     shell          string    (default 'sh' for Unix and 'cmd' for Windows)
     shellflag      string    (default '-c' for Unix and '/c' for Windows)
     shellopts      []string  (default '')
@@ -727,6 +728,12 @@ When 'number' is enabled, current line shows the absolute position, otherwise no
     reverse        bool      (default off)
 
 Reverse the direction of sort.
+
+    selmode        string    (default 'all')
+
+Selection mode for commands.
+When set to 'all' it will use the selected files from all directories.
+When set to 'dir' it will only use the selected files in the current directory.
 
     scrolloff      int       (default 0)
 

--- a/docstring.go
+++ b/docstring.go
@@ -148,6 +148,7 @@ The following options can be used to customize the behavior of lf:
     relativenumber bool      (default off)
     reverse        bool      (default off)
     scrolloff      int       (default 0)
+    selmode        string    (default 'all')
     shell          string    (default 'sh' for Unix and 'cmd' for Windows)
     shellflag      string    (default '-c' for Unix and '/c' for Windows)
     shellopts      []string  (default '')
@@ -776,6 +777,12 @@ shown.
     reverse        bool      (default off)
 
 Reverse the direction of sort.
+
+    selmode        string    (default 'all')
+
+Selection mode for commands. When set to 'all' it will use the selected
+files from all directories. When set to 'dir' it will only use the selected
+files in the current directory.
 
     scrolloff      int       (default 0)
 

--- a/eval.go
+++ b/eval.go
@@ -384,6 +384,8 @@ func (e *setExpr) eval(app *app, args []string) {
 		gOpts.ratios = rats
 		app.ui.wins = getWins(app.ui.screen)
 		app.ui.loadFile(app.nav, true)
+	case "selmode":
+		gOpts.selmode = e.val
 	case "shell":
 		gOpts.shell = e.val
 	case "shellflag":

--- a/lf.1
+++ b/lf.1
@@ -163,6 +163,7 @@ The following options can be used to customize the behavior of lf:
     relativenumber bool      (default off)
     reverse        bool      (default off)
     scrolloff      int       (default 0)
+    selmode        string    (default 'all')
     shell          string    (default 'sh' for Unix and 'cmd' for Windows)
     shellflag      string    (default '-c' for Unix and '/c' for Windows)
     shellopts      []string  (default '')
@@ -880,6 +881,12 @@ Show the position number relative to the current line. When 'number' is enabled,
 .EE
 .PP
 Reverse the direction of sort.
+.PP
+.EX
+    selmode        string    (default 'all')
+.EE
+.PP
+Selection mode for commands. When set to 'all' it will use the selected files from all directories. When set to 'dir' it will only use the selected files in the current directory.
 .PP
 .EX
     scrolloff      int       (default 0)

--- a/nav.go
+++ b/nav.go
@@ -1739,27 +1739,37 @@ func (m indexedSelections) Swap(i, j int) {
 func (m indexedSelections) Less(i, j int) bool { return m.indices[i] < m.indices[j] }
 
 func (nav *nav) currSelections() []string {
+
+	currDirOnly := gOpts.selmode == "dir"
+	currDirPath := ""
+	if currDirOnly {
+		// select only from this directory
+		currDirPath = nav.currDir().path
+	}
+
 	paths := make([]string, 0, len(nav.selections))
 	indices := make([]int, 0, len(nav.selections))
 	for path, index := range nav.selections {
-		paths = append(paths, path)
-		indices = append(indices, index)
+		if !currDirOnly || filepath.Dir(path) == currDirPath {
+			paths = append(paths, path)
+			indices = append(indices, index)
+		}
 	}
 	sort.Sort(indexedSelections{paths: paths, indices: indices})
 	return paths
 }
 
 func (nav *nav) currFileOrSelections() (list []string, err error) {
-	if len(nav.selections) == 0 {
+	sel := nav.currSelections()
+
+	if len(sel) == 0 {
 		curr, err := nav.currFile()
 		if err != nil {
 			return nil, errors.New("no file selected")
 		}
-
 		return []string{curr.path}, nil
 	}
-
-	return nav.currSelections(), nil
+	return sel, nil
 }
 
 func (nav *nav) calcDirSize() error {

--- a/opts.go
+++ b/opts.go
@@ -59,6 +59,7 @@ var gOpts struct {
 	previewer      string
 	cleaner        string
 	promptfmt      string
+	selmode        string
 	shell          string
 	shellflag      string
 	timefmt        string
@@ -110,6 +111,7 @@ func init() {
 	gOpts.previewer = ""
 	gOpts.cleaner = ""
 	gOpts.promptfmt = "\033[32;1m%u@%h\033[0m:\033[34;1m%d\033[0m\033[1m%f\033[0m"
+	gOpts.selmode = "all"
 	gOpts.shell = gDefaultShell
 	gOpts.shellflag = gDefaultShellFlag
 	gOpts.timefmt = time.ANSIC

--- a/ui.go
+++ b/ui.go
@@ -774,8 +774,9 @@ func (ui *ui) drawStatLine(nav *nav) {
 		}
 	}
 
-	if len(nav.selections) > 0 {
-		selection += fmt.Sprintf("  \033[35;7m %d \033[0m", len(nav.selections))
+	currSelections := nav.currSelections()
+	if len(currSelections) > 0 {
+		selection += fmt.Sprintf("  \033[35;7m %d \033[0m", len(currSelections))
 	}
 
 	if len(dir.filter) != 0 {


### PR DESCRIPTION
When working with lf I prefer to have it use only the selections I made in the current directory.

```
    selmode        string    (default 'all')

Selection mode for commands.
When set to 'all' it will use the selected files from all directories.
When set to 'dir' it will only use the selected files in the current directory.
```

Use case: I often forget to clear selections before selecting files in the current directory and have to start over or (worst case) deleted some files by mistake.
