### PR TITLE
Fix previewer race condition

### DIFF
--- a/app.go
+++ b/app.go
@@ -526,7 +526,8 @@ func (app *app) runShell(s string, args []string, prefix string) {
 		anyKey()
 	}
 
-	app.ui.loadFile(app.nav, true)
+	// do not call loadFile because of race condition with previewer
+	// app.ui.loadFile(app.nav, true)
 
 	switch prefix {
 	case "%":


### PR DESCRIPTION
This PR removes `app.ui.loadFile()` when invoking a shell request.

I have `&` scripts to turn the previewer on and off. Without this change the previewer will start again because it was invoked by `loadFile` before the script had a chance to turn it off. (I'm using this to launch and terminate an overlay GUI app to preview PDF documents and images.)

I've run this code for over a month and noticed no side effects.