### PR TITLE
enable & handle terminal focus events

### DIFF
--- a/client.go
+++ b/client.go
@@ -59,13 +59,11 @@ func run() {
 		app.ui.echoerrf("reading history file: %s", err)
 	}
 
-	// enable focus reporting
-	fmt.Print("\x1b[?1004h")
+	app.ui.enableFocusReporting()
 
 	app.loop()
 
-	// disable focus reporting
-	fmt.Print("\x1b[?1004l")
+	app.ui.disableFocusReporting()
 
 	app.ui.screen.Fini()
 }

--- a/client.go
+++ b/client.go
@@ -59,7 +59,13 @@ func run() {
 		app.ui.echoerrf("reading history file: %s", err)
 	}
 
+	// enable focus reporting
+	fmt.Print("\x1b[?1004h")
+
 	app.loop()
+
+	// disable focus reporting
+	fmt.Print("\x1b[?1004l")
 
 	app.ui.screen.Fini()
 }

--- a/eval.go
+++ b/eval.go
@@ -800,6 +800,14 @@ func insert(app *app, arg string) {
 
 func (e *callExpr) eval(app *app, args []string) {
 	switch e.name {
+	case "focus-on":
+		gOpts.hasfocus = true
+		app.ui.loadFile(app.nav, true)
+		app.ui.loadFileInfo(app.nav)
+	case "focus-off":
+		gOpts.hasfocus = false
+		app.ui.loadFile(app.nav, true)
+		app.ui.loadFileInfo(app.nav)
 	case "up":
 		if !app.nav.init {
 			return

--- a/opts.go
+++ b/opts.go
@@ -205,6 +205,8 @@ func init() {
 
 	gOpts.cmdkeys = make(map[string]expr)
 
+	gOpts.cmdkeys["<a-[>O"] = &callExpr{"focus-off", nil, 1}
+	gOpts.cmdkeys["<a-[>I"] = &callExpr{"focus-on", nil, 1}
 	gOpts.cmdkeys["<space>"] = &callExpr{"cmd-insert", []string{" "}, 1}
 	gOpts.cmdkeys["<esc>"] = &callExpr{"cmd-escape", nil, 1}
 	gOpts.cmdkeys["<tab>"] = &callExpr{"cmd-complete", nil, 1}

--- a/opts.go
+++ b/opts.go
@@ -28,6 +28,7 @@ type sortType struct {
 }
 
 var gOpts struct {
+	hasfocus       bool
 	anchorfind     bool
 	autoquit       bool
 	dircache       bool
@@ -79,6 +80,7 @@ var gOpts struct {
 }
 
 func init() {
+	gOpts.hasfocus = true
 	gOpts.anchorfind = true
 	gOpts.autoquit = false
 	gOpts.dircache = true
@@ -126,6 +128,10 @@ func init() {
 	gOpts.tagfmt = "\033[31m%s\033[0m"
 
 	gOpts.keys = make(map[string]expr)
+
+	// focus event, sent by the terminal/tmux on focus change
+	gOpts.keys["<a-[>O"] = &callExpr{"focus-off", nil, 1}
+	gOpts.keys["<a-[>I"] = &callExpr{"focus-on", nil, 1}
 
 	gOpts.keys["k"] = &callExpr{"up", nil, 1}
 	gOpts.keys["<up>"] = &callExpr{"up", nil, 1}

--- a/ui.go
+++ b/ui.go
@@ -401,7 +401,7 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]in
 			}
 		}
 
-		if i == dir.pos {
+		if i == dir.pos && gOpts.hasfocus {
 			st = st.Reverse(true)
 		}
 
@@ -452,7 +452,7 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]in
 
 		tag, ok := tags[path]
 		if ok {
-			if i == dir.pos {
+			if i == dir.pos && gOpts.hasfocus {
 				win.print(screen, lnwidth+1, i, st.Reverse(true), tag)
 			} else {
 				win.print(screen, lnwidth+1, i, tcell.StyleDefault, fmt.Sprintf(gOpts.tagfmt, tag))


### PR DESCRIPTION
When using `lf` instances in multiple panes in the same window in tmux it is hard to tell which instance has the focus. The same is true when you have multiple terminal panes side by side.

This PR allows lf to receive focus events and turns the highlight for the current selection off when lf loses focus. This means only the active lf instance will show the highlight.

Tested with tmux and kitty on Linux/macos.