### PR TITLE
Getting command count from definition

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -1013,7 +1013,7 @@ func (ui *ui) pollEvent() tcell.Event {
 // preceding any non-digit characters (e.g. "42y2k" as 42 times "y2k").
 func (ui *ui) readNormalEvent(ev tcell.Event) expr {
 	draw := &callExpr{"draw", nil, 1}
-	count := 1
+	count := 0
 
 	switch tev := ev.(type) {
 	case *tcell.EventKey:
@@ -1067,11 +1067,21 @@ func (ui *ui) readNormalEvent(ev tcell.Event) expr {
 					count = c
 				}
 				expr := gOpts.keys[string(ui.keyAcc)]
+
 				if e, ok := expr.(*callExpr); ok {
-					e.count = count
+					expr = &callExpr{e.name, e.args, e.count}
+
+					if count != 0 {
+						expr.(*callExpr).count = count
+					}
 				} else if e, ok := expr.(*listExpr); ok {
-					e.count = count
+					expr = &listExpr{e.exprs, e.count}
+
+					if count != 0 {
+						expr.(*listExpr).count = count
+					}
 				}
+
 				ui.keyAcc = nil
 				ui.keyCount = nil
 				ui.menuBuf = nil

--- a/ui.go
+++ b/ui.go
@@ -1068,18 +1068,12 @@ func (ui *ui) readNormalEvent(ev tcell.Event) expr {
 				}
 				expr := gOpts.keys[string(ui.keyAcc)]
 
-				if e, ok := expr.(*callExpr); ok {
+				if e, ok := expr.(*callExpr); ok && count != 0 {
 					expr = &callExpr{e.name, e.args, e.count}
-
-					if count != 0 {
-						expr.(*callExpr).count = count
-					}
-				} else if e, ok := expr.(*listExpr); ok {
+					expr.(*callExpr).count = count
+				} else if e, ok := expr.(*listExpr); ok && count != 0 {
 					expr = &listExpr{e.exprs, e.count}
-
-					if count != 0 {
-						expr.(*listExpr).count = count
-					}
+					expr.(*listExpr).count = count
 				}
 
 				ui.keyAcc = nil


### PR DESCRIPTION
Fixes #862. Now the count in the command definition will be used by default. In order to be able to use the callExpr or listExpr defined in gOpts.keys without overwriting it countinuously to 1, a copy of the struct must be created, so that we can set e.count without overwriting the original one.
