### PR TITLE
Add on-select event

### DIFF
--- a/app.go
+++ b/app.go
@@ -413,7 +413,7 @@ func (app *app) loop() {
 			curr, err := app.nav.currFile()
 			if err == nil {
 				if d.path == app.nav.currDir().path {
-					app.ui.loadFile(app.nav, true)
+					app.ui.loadFile(app, true)
 				}
 				if d.path == curr.path {
 					app.ui.dirPrev = d
@@ -462,7 +462,7 @@ func (app *app) loop() {
 			app.ui.draw(app.nav)
 		case <-app.ticker.C:
 			app.nav.renew()
-			app.ui.loadFile(app.nav, false)
+			app.ui.loadFile(app, false)
 			app.ui.draw(app.nav)
 		}
 	}
@@ -536,7 +536,7 @@ func (app *app) runShell(s string, args []string, prefix string) {
 		anyKey()
 	}
 
-	app.ui.loadFile(app.nav, true)
+	app.ui.loadFile(app, true)
 
 	switch prefix {
 	case "%":

--- a/doc.go
+++ b/doc.go
@@ -187,6 +187,7 @@ The following special shell commands are used to customize the behavior of lf wh
     delete
     pre-cd
     on-cd
+    on-select
     on-quit
 
 The following commands/keybindings are provided by default:
@@ -903,6 +904,10 @@ This shell command can be defined to be executed before changing a directory.
     on-cd
 
 This shell command can be defined to be executed after changing a directory.
+
+    on-select
+
+This shell command can be defined to be executed after the selection changes.
 
     on-quit
 

--- a/docstring.go
+++ b/docstring.go
@@ -191,6 +191,7 @@ lf when defined:
     delete
     pre-cd
     on-cd
+    on-select
     on-quit
 
 The following commands/keybindings are provided by default:
@@ -970,6 +971,11 @@ directory.
     on-cd
 
 This shell command can be defined to be executed after changing a directory.
+
+    on-select
+
+This shell command can be defined to be executed after the selection
+changes.
 
     on-quit
 

--- a/eval.go
+++ b/eval.go
@@ -45,7 +45,7 @@ func (e *setExpr) eval(app *app, args []string) {
 		app.nav.sort()
 		app.nav.position()
 		app.ui.sort()
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "dirpreviews":
 		gOpts.dirpreviews = true
 	case "nodironly":
@@ -53,13 +53,13 @@ func (e *setExpr) eval(app *app, args []string) {
 		app.nav.sort()
 		app.nav.position()
 		app.ui.sort()
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "dironly!":
 		gOpts.dironly = !gOpts.dironly
 		app.nav.sort()
 		app.nav.position()
 		app.ui.sort()
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "dirfirst":
 		gOpts.sortType.option |= dirfirstSort
 		app.nav.sort()
@@ -79,7 +79,7 @@ func (e *setExpr) eval(app *app, args []string) {
 			app.nav.height = app.ui.wins[0].h
 			app.nav.regCache = make(map[string]*reg)
 		}
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "nodrawbox":
 		gOpts.drawbox = false
 		app.ui.renew()
@@ -87,7 +87,7 @@ func (e *setExpr) eval(app *app, args []string) {
 			app.nav.height = app.ui.wins[0].h
 			app.nav.regCache = make(map[string]*reg)
 		}
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "drawbox!":
 		gOpts.drawbox = !gOpts.drawbox
 		app.ui.renew()
@@ -95,40 +95,40 @@ func (e *setExpr) eval(app *app, args []string) {
 			app.nav.height = app.ui.wins[0].h
 			app.nav.regCache = make(map[string]*reg)
 		}
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "globsearch":
 		gOpts.globsearch = true
 		app.nav.sort()
 		app.ui.sort()
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "noglobsearch":
 		gOpts.globsearch = false
 		app.nav.sort()
 		app.ui.sort()
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "globsearch!":
 		gOpts.globsearch = !gOpts.globsearch
 		app.nav.sort()
 		app.ui.sort()
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "hidden":
 		gOpts.sortType.option |= hiddenSort
 		app.nav.sort()
 		app.nav.position()
 		app.ui.sort()
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "nohidden":
 		gOpts.sortType.option &= ^hiddenSort
 		app.nav.sort()
 		app.nav.position()
 		app.ui.sort()
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "hidden!":
 		gOpts.sortType.option ^= hiddenSort
 		app.nav.sort()
 		app.nav.position()
 		app.ui.sort()
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "history":
 		gOpts.history = true
 	case "nohistory":
@@ -145,17 +145,17 @@ func (e *setExpr) eval(app *app, args []string) {
 		gOpts.ignorecase = true
 		app.nav.sort()
 		app.ui.sort()
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "noignorecase":
 		gOpts.ignorecase = false
 		app.nav.sort()
 		app.ui.sort()
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "ignorecase!":
 		gOpts.ignorecase = !gOpts.ignorecase
 		app.nav.sort()
 		app.ui.sort()
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "ignoredia":
 		gOpts.ignoredia = true
 		app.nav.sort()
@@ -240,17 +240,17 @@ func (e *setExpr) eval(app *app, args []string) {
 		gOpts.smartcase = true
 		app.nav.sort()
 		app.ui.sort()
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "nosmartcase":
 		gOpts.smartcase = false
 		app.nav.sort()
 		app.ui.sort()
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "smartcase!":
 		gOpts.smartcase = !gOpts.smartcase
 		app.nav.sort()
 		app.ui.sort()
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "smartdia":
 		gOpts.smartdia = true
 	case "nosmartdia":
@@ -342,7 +342,7 @@ func (e *setExpr) eval(app *app, args []string) {
 		app.nav.sort()
 		app.nav.position()
 		app.ui.sort()
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "ifs":
 		gOpts.ifs = e.val
 	case "info":
@@ -387,7 +387,7 @@ func (e *setExpr) eval(app *app, args []string) {
 		}
 		gOpts.ratios = rats
 		app.ui.wins = getWins(app.ui.screen)
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "selmode":
 		gOpts.selmode = e.val
 	case "shell":
@@ -495,6 +495,12 @@ func onChdir(app *app) {
 	}
 }
 
+func onSelect(app *app) {
+	if cmd, ok := gOpts.cmds["on-select"]; ok {
+		cmd.eval(app, nil)
+	}
+}
+
 func splitKeys(s string) (keys []string) {
 	for i := 0; i < len(s); {
 		r, w := utf8.DecodeRuneInString(s[i:])
@@ -576,7 +582,7 @@ func update(app *app) {
 		if _, err := app.nav.searchNext(); err != nil {
 			app.ui.echoerrf("search: %s: %s", err, app.nav.search)
 		} else if old != dir.ind {
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case gOpts.incsearch && app.ui.cmdPrefix == "?":
@@ -593,7 +599,7 @@ func update(app *app) {
 		if _, err := app.nav.searchPrev(); err != nil {
 			app.ui.echoerrf("search: %s: %s", err, app.nav.search)
 		} else if old != dir.ind {
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case gOpts.incfilter && app.ui.cmdPrefix == "filter: ":
@@ -604,7 +610,7 @@ func update(app *app) {
 		if err := app.nav.setFilter(strings.Split(filter, " ")); err != nil {
 			app.ui.echoerrf("filter: %s", err)
 		} else if old != dir.ind {
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	}
@@ -629,7 +635,7 @@ func resetIncCmd(app *app) {
 		dir.pos = app.nav.searchPos
 		if dir.ind != app.nav.searchInd {
 			dir.ind = app.nav.searchInd
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	} else if gOpts.incfilter && app.ui.cmdPrefix == "filter: " {
@@ -637,7 +643,7 @@ func resetIncCmd(app *app) {
 		old := dir.ind
 		app.nav.setFilter(app.nav.prevFilter)
 		if old != dir.ind {
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	}
@@ -671,7 +677,7 @@ func insert(app *app, arg string) {
 			case 0:
 				app.ui.echoerrf("find: pattern not found: %s", app.nav.find)
 			case 1:
-				app.ui.loadFile(app.nav, true)
+				app.ui.loadFile(app, true)
 				app.ui.loadFileInfo(app.nav)
 			default:
 				app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(arg)...)
@@ -686,7 +692,7 @@ func insert(app *app, arg string) {
 			if moved, found := app.nav.findNext(); !found {
 				app.ui.echoerrf("find: pattern not found: %s", app.nav.find)
 			} else if moved {
-				app.ui.loadFile(app.nav, true)
+				app.ui.loadFile(app, true)
 				app.ui.loadFileInfo(app.nav)
 			}
 		}
@@ -700,7 +706,7 @@ func insert(app *app, arg string) {
 			case 0:
 				app.ui.echoerrf("find-back: pattern not found: %s", app.nav.find)
 			case 1:
-				app.ui.loadFile(app.nav, true)
+				app.ui.loadFile(app, true)
 				app.ui.loadFileInfo(app.nav)
 			default:
 				app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(arg)...)
@@ -715,7 +721,7 @@ func insert(app *app, arg string) {
 			if moved, found := app.nav.findPrev(); !found {
 				app.ui.echoerrf("find-back: pattern not found: %s", app.nav.find)
 			} else if moved {
-				app.ui.loadFile(app.nav, true)
+				app.ui.loadFile(app, true)
 				app.ui.loadFileInfo(app.nav)
 			}
 		}
@@ -725,21 +731,21 @@ func insert(app *app, arg string) {
 		normal(app)
 
 		if arg == "y" {
-			if err := app.nav.del(app.ui); err != nil {
+			if err := app.nav.del(app); err != nil {
 				app.ui.echoerrf("delete: %s", err)
 				return
 			}
 			app.nav.unselect()
 			if gSingleMode {
 				app.nav.renew()
-				app.ui.loadFile(app.nav, true)
+				app.ui.loadFile(app, true)
 			} else {
 				if err := remote("send load"); err != nil {
 					app.ui.echoerrf("delete: %s", err)
 					return
 				}
 			}
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case strings.HasPrefix(app.ui.cmdPrefix, "replace"):
@@ -752,14 +758,14 @@ func insert(app *app, arg string) {
 			}
 			if gSingleMode {
 				app.nav.renew()
-				app.ui.loadFile(app.nav, true)
+				app.ui.loadFile(app, true)
 			} else {
 				if err := remote("send load"); err != nil {
 					app.ui.echoerrf("rename: %s", err)
 					return
 				}
 			}
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case strings.HasPrefix(app.ui.cmdPrefix, "create"):
@@ -776,14 +782,14 @@ func insert(app *app, arg string) {
 			}
 			if gSingleMode {
 				app.nav.renew()
-				app.ui.loadFile(app.nav, true)
+				app.ui.loadFile(app, true)
 			} else {
 				if err := remote("send load"); err != nil {
 					app.ui.echoerrf("rename: %s", err)
 					return
 				}
 			}
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case app.ui.cmdPrefix == "mark-save: ":
@@ -825,7 +831,7 @@ func insert(app *app, arg string) {
 			app.ui.echoerrf("%s", err)
 			return
 		}
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 		app.ui.loadFileInfo(app.nav)
 
 		if wd != path {
@@ -873,7 +879,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 		if app.nav.up(e.count) {
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "half-up":
@@ -881,7 +887,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 		if app.nav.up(e.count * app.nav.height / 2) {
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "page-up":
@@ -889,7 +895,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 		if app.nav.up(e.count * app.nav.height) {
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "scroll-up":
@@ -897,7 +903,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 		if app.nav.scrollUp(e.count) {
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "down":
@@ -905,7 +911,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 		if app.nav.down(e.count) {
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "half-down":
@@ -913,7 +919,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 		if app.nav.down(e.count * app.nav.height / 2) {
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "page-down":
@@ -921,7 +927,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 		if app.nav.down(e.count * app.nav.height) {
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "scroll-down":
@@ -929,7 +935,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 		if app.nav.scrollDown(e.count) {
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "updir":
@@ -944,7 +950,7 @@ func (e *callExpr) eval(app *app, args []string) {
 				return
 			}
 		}
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 		app.ui.loadFileInfo(app.nav)
 		restartIncCmd(app)
 		onChdir(app)
@@ -966,7 +972,7 @@ func (e *callExpr) eval(app *app, args []string) {
 				app.ui.echoerrf("opening directory: %s", err)
 				return
 			}
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 			restartIncCmd(app)
 			onChdir(app)
@@ -1007,7 +1013,7 @@ func (e *callExpr) eval(app *app, args []string) {
 		for i := 0; i < e.count; i++ {
 			app.nav.cdJumpListPrev()
 		}
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 		app.ui.loadFileInfo(app.nav)
 		restartIncCmd(app)
 		onChdir(app)
@@ -1017,7 +1023,7 @@ func (e *callExpr) eval(app *app, args []string) {
 		for i := 0; i < e.count; i++ {
 			app.nav.cdJumpListNext()
 		}
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 		app.ui.loadFileInfo(app.nav)
 		restartIncCmd(app)
 		onChdir(app)
@@ -1028,7 +1034,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 		if app.nav.top() {
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "bottom":
@@ -1036,7 +1042,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 		if app.nav.bottom() {
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "high":
@@ -1044,7 +1050,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 		if app.nav.high() {
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "middle":
@@ -1052,7 +1058,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 		if app.nav.middle() {
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "low":
@@ -1060,7 +1066,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 		if app.nav.low() {
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "toggle":
@@ -1203,11 +1209,11 @@ func (e *callExpr) eval(app *app, args []string) {
 
 		if cmd, ok := gOpts.cmds["paste"]; ok {
 			cmd.eval(app, e.args)
-		} else if err := app.nav.paste(app.ui); err != nil {
+		} else if err := app.nav.paste(app); err != nil {
 			app.ui.echoerrf("paste: %s", err)
 			return
 		}
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 		app.ui.loadFileInfo(app.nav)
 	case "delete":
 		if !app.nav.init {
@@ -1219,7 +1225,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			app.nav.unselect()
 			if gSingleMode {
 				app.nav.renew()
-				app.ui.loadFile(app.nav, true)
+				app.ui.loadFile(app, true)
 			} else {
 				if err := remote("send load"); err != nil {
 					app.ui.echoerrf("delete: %s", err)
@@ -1243,7 +1249,7 @@ func (e *callExpr) eval(app *app, args []string) {
 				app.ui.cmdPrefix = "delete " + strconv.Itoa(len(list)) + " items? [y/N] "
 			}
 		}
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 		app.ui.loadFileInfo(app.nav)
 	case "clear":
 		if !app.nav.init {
@@ -1276,13 +1282,13 @@ func (e *callExpr) eval(app *app, args []string) {
 			app.nav.height = app.ui.wins[0].h
 			app.nav.regCache = make(map[string]*reg)
 		}
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "load":
 		if !app.nav.init {
 			return
 		}
 		app.nav.renew()
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 	case "reload":
 		if !app.nav.init {
 			return
@@ -1290,7 +1296,7 @@ func (e *callExpr) eval(app *app, args []string) {
 		if err := app.nav.reload(); err != nil {
 			app.ui.echoerrf("reload: %s", err)
 		}
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 		app.ui.loadFileInfo(app.nav)
 	case "read":
 		if app.ui.cmdPrefix == ">" {
@@ -1357,7 +1363,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			}
 		}
 		if old != dir.ind {
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "find-prev":
@@ -1374,7 +1380,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			}
 		}
 		if old != dir.ind {
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
 	case "search":
@@ -1414,14 +1420,14 @@ func (e *callExpr) eval(app *app, args []string) {
 				if moved, err := app.nav.searchPrev(); err != nil {
 					app.ui.echoerrf("search-back: %s: %s", err, app.nav.search)
 				} else if moved {
-					app.ui.loadFile(app.nav, true)
+					app.ui.loadFile(app, true)
 					app.ui.loadFileInfo(app.nav)
 				}
 			} else {
 				if moved, err := app.nav.searchNext(); err != nil {
 					app.ui.echoerrf("search: %s: %s", err, app.nav.search)
 				} else if moved {
-					app.ui.loadFile(app.nav, true)
+					app.ui.loadFile(app, true)
 					app.ui.loadFileInfo(app.nav)
 				}
 			}
@@ -1435,14 +1441,14 @@ func (e *callExpr) eval(app *app, args []string) {
 				if moved, err := app.nav.searchNext(); err != nil {
 					app.ui.echoerrf("search-back: %s: %s", err, app.nav.search)
 				} else if moved {
-					app.ui.loadFile(app.nav, true)
+					app.ui.loadFile(app, true)
 					app.ui.loadFileInfo(app.nav)
 				}
 			} else {
 				if moved, err := app.nav.searchPrev(); err != nil {
 					app.ui.echoerrf("search: %s: %s", err, app.nav.search)
 				} else if moved {
-					app.ui.loadFile(app.nav, true)
+					app.ui.loadFile(app, true)
 					app.ui.loadFileInfo(app.nav)
 				}
 			}
@@ -1472,7 +1478,7 @@ func (e *callExpr) eval(app *app, args []string) {
 		if err := app.nav.setFilter(e.args); err != nil {
 			app.ui.echoerrf("filter: %s", err)
 		}
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 		app.ui.loadFileInfo(app.nav)
 	case "mark-save":
 		if app.ui.cmdPrefix == ">" {
@@ -1502,7 +1508,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			cmd.eval(app, e.args)
 			if gSingleMode {
 				app.nav.renew()
-				app.ui.loadFile(app.nav, true)
+				app.ui.loadFile(app, true)
 			} else {
 				if err := remote("send load"); err != nil {
 					app.ui.echoerrf("rename: %s", err)
@@ -1522,7 +1528,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			app.ui.cmdPrefix = "rename: "
 			app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(curr.Name())...)
 		}
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 		app.ui.loadFileInfo(app.nav)
 	case "sync":
 		if err := app.nav.sync(); err != nil {
@@ -1562,7 +1568,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 		app.ui.loadFileInfo(app.nav)
 
 		if wd != path {
@@ -1602,7 +1608,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 
-		app.ui.loadFile(app.nav, true)
+		app.ui.loadFile(app, true)
 		app.ui.loadFileInfo(app.nav)
 
 		if wd != path {
@@ -1729,7 +1735,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			if _, err := app.nav.searchNext(); err != nil {
 				app.ui.echoerrf("search: %s: %s", err, app.nav.search)
 			} else if old != dir.ind {
-				app.ui.loadFile(app.nav, true)
+				app.ui.loadFile(app, true)
 				app.ui.loadFileInfo(app.nav)
 			}
 		case "?":
@@ -1745,7 +1751,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			if _, err := app.nav.searchPrev(); err != nil {
 				app.ui.echoerrf("search-back: %s: %s", err, app.nav.search)
 			} else if old != dir.ind {
-				app.ui.loadFile(app.nav, true)
+				app.ui.loadFile(app, true)
 				app.ui.loadFileInfo(app.nav)
 			}
 		case "filter: ":
@@ -1754,14 +1760,14 @@ func (e *callExpr) eval(app *app, args []string) {
 			if err := app.nav.setFilter(strings.Split(s, " ")); err != nil {
 				app.ui.echoerrf("filter: %s", err)
 			}
-			app.ui.loadFile(app.nav, true)
+			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		case "find: ":
 			app.ui.cmdPrefix = ""
 			if moved, found := app.nav.findNext(); !found {
 				app.ui.echoerrf("find: pattern not found: %s", app.nav.find)
 			} else if moved {
-				app.ui.loadFile(app.nav, true)
+				app.ui.loadFile(app, true)
 				app.ui.loadFileInfo(app.nav)
 			}
 		case "find-back: ":
@@ -1769,7 +1775,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			if moved, found := app.nav.findPrev(); !found {
 				app.ui.echoerrf("find-back: pattern not found: %s", app.nav.find)
 			} else if moved {
-				app.ui.loadFile(app.nav, true)
+				app.ui.loadFile(app, true)
 				app.ui.loadFileInfo(app.nav)
 			}
 		case "rename: ":
@@ -1821,7 +1827,7 @@ func (e *callExpr) eval(app *app, args []string) {
 
 				if gSingleMode {
 					app.nav.renew()
-					app.ui.loadFile(app.nav, true)
+					app.ui.loadFile(app, true)
 				} else {
 					if err := remote("send load"); err != nil {
 						app.ui.echoerrf("rename: %s", err)
@@ -1829,7 +1835,7 @@ func (e *callExpr) eval(app *app, args []string) {
 					}
 				}
 
-				app.ui.loadFile(app.nav, true)
+				app.ui.loadFile(app, true)
 				app.ui.loadFileInfo(app.nav)
 			}
 		default:

--- a/lf.1
+++ b/lf.1
@@ -209,6 +209,7 @@ The following special shell commands are used to customize the behavior of lf wh
     delete
     pre-cd
     on-cd
+    on-select
     on-quit
 .EE
 .PP
@@ -1108,6 +1109,12 @@ This shell command can be defined to be executed before changing a directory.
 .EE
 .PP
 This shell command can be defined to be executed after changing a directory.
+.PP
+.EX
+    on-select
+.EE
+.PP
+This shell command can be defined to be executed after the selection changes.
 .PP
 .EX
     on-quit


### PR DESCRIPTION
This PR adds an `on-select` event.

```
    on-select

This shell command can be defined to be executed after 
the selection changes.
```

This works similar to the `on-cd` command but for every selection change.

To avoid merge conflicts this PR depends on #849, #850 and #861.

Use case: I'm using termplug to preview files in a (non terminal) popup. I tried using the preview script but it is not really the right tool (I want to keep the internal preview) and this works a lot better.