### PR TITLE
Add a spacer `%S` to promptfmt

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -708,7 +708,7 @@ Preview filtering is disabled and files are displayed as they are when the value
     promptfmt      string    (default "\033[32;1m%u@%h\033[0m:\033[34;1m%d\033[0m\033[1m%f\033[0m")
 
 Format string of the prompt shown in the top line.
-Special expansions are provided, '%u' as the user name, '%h' as the host name, '%w' as the working directory, '%d' as the working directory with a trailing path separator, '%f' as the file name, and '%F' as the current filter.
+Special expansions are provided, '%u' as the user name, '%h' as the host name, '%w' as the working directory, '%d' as the working directory with a trailing path separator, '%f' as the file name, and '%F' as the current filter. '%S' may be used once and will provide a spacer so that the following parts are right aligned on the screen.
 Home folder is shown as '~' in the working directory expansion.
 Directory names are automatically shortened to a single character starting from the left most parent when the prompt does not fit to the screen.
 

--- a/docstring.go
+++ b/docstring.go
@@ -754,10 +754,11 @@ value of this option is left empty.
 Format string of the prompt shown in the top line. Special expansions are
 provided, '%u' as the user name, '%h' as the host name, '%w' as the working
 directory, '%d' as the working directory with a trailing path separator,
-'%f' as the file name, and '%F' as the current filter. Home folder is shown
-as '~' in the working directory expansion. Directory names are automatically
-shortened to a single character starting from the left most parent when the
-prompt does not fit to the screen.
+'%f' as the file name, and '%F' as the current filter. '%S' may be used once
+and will provide a spacer so that the following parts are right aligned on
+the screen. Home folder is shown as '~' in the working directory expansion.
+Directory names are automatically shortened to a single character starting
+from the left most parent when the prompt does not fit to the screen.
 
     ratios         []int     (default '1:2:3')
 

--- a/lf.1
+++ b/lf.1
@@ -860,7 +860,7 @@ Set the path of a previewer file to filter the content of regular files for prev
     promptfmt      string    (default "\e033[32;1m%u@%h\e033[0m:\e033[34;1m%d\e033[0m\e033[1m%f\e033[0m")
 .EE
 .PP
-Format string of the prompt shown in the top line. Special expansions are provided, '%u' as the user name, '%h' as the host name, '%w' as the working directory, '%d' as the working directory with a trailing path separator, '%f' as the file name, and '%F' as the current filter. Home folder is shown as '~' in the working directory expansion. Directory names are automatically shortened to a single character starting from the left most parent when the prompt does not fit to the screen.
+Format string of the prompt shown in the top line. Special expansions are provided, '%u' as the user name, '%h' as the host name, '%w' as the working directory, '%d' as the working directory with a trailing path separator, '%f' as the file name, and '%F' as the current filter. '%S' may be used once and will provide a spacer so that the following parts are right aligned on the screen. Home folder is shown as '~' in the working directory expansion. Directory names are automatically shortened to a single character starting from the left most parent when the prompt does not fit to the screen.
 .PP
 .EX
     ratios         []int     (default '1:2:3')

--- a/ui.go
+++ b/ui.go
@@ -733,6 +733,13 @@ func (ui *ui) drawPromptLine(nav *nav) {
 		prompt = strings.Replace(prompt, "%F", "", -1)
 	}
 
+	// spacer
+	avail := ui.promptWin.w - printLength(prompt) + 2
+	if avail > 0 {
+		prompt = strings.Replace(prompt, "%S", strings.Repeat(" ", avail), 1)
+	}
+	prompt = strings.Replace(prompt, "%S", "", -1)
+
 	ui.promptWin.print(ui.screen, 0, 0, st, prompt)
 }
 


### PR DESCRIPTION
This allows you to right align part of the prompt:

> '%S' may be used once and will provide a spacer so that the following parts are right aligned on the screen.