### PR TITLE
docs: update lifted restrictions on cmap

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -921,9 +921,10 @@ Command 'map' is used to bind a key to a command which can be builtin command, c
     map i $less $f     # shell command
     map U !du -csh *   # waiting shell command
 
-Command 'cmap' is used to bind a key to a command line command which can only be one of the builtin commands:
+Command 'cmap' is used to bind a key on the command line to a command line command or any other command:
 
     cmap <c-g> cmd-escape
+    cmap <a-i> set incsearch!
 
 You can delete an existing binding by leaving the expression empty:
 

--- a/docstring.go
+++ b/docstring.go
@@ -995,10 +995,11 @@ command, custom command, or shell command:
     map i $less $f     # shell command
     map U !du -csh *   # waiting shell command
 
-Command 'cmap' is used to bind a key to a command line command which can
-only be one of the builtin commands:
+Command 'cmap' is used to bind a key on the command line to a command line
+command or any other command:
 
     cmap <c-g> cmd-escape
+    cmap <a-i> set incsearch!
 
 You can delete an existing binding by leaving the expression empty:
 

--- a/lf.1
+++ b/lf.1
@@ -1128,10 +1128,11 @@ Command 'map' is used to bind a key to a command which can be builtin command, c
     map U !du -csh *   # waiting shell command
 .EE
 .PP
-Command 'cmap' is used to bind a key to a command line command which can only be one of the builtin commands:
+Command 'cmap' is used to bind a key on the command line to a command line command or any other command:
 .PP
 .EX
     cmap <c-g> cmd-escape
+    cmap <a-i> set incsearch!
 .EE
 .PP
 You can delete an existing binding by leaving the expression empty:


### PR DESCRIPTION
The restrictions on `cmap` have been lifted since r25. This updates the introduction to the `cmap` command accordingly.

Fixes #884
