### PR TITLE
Case insensitive extension matching for icons & colors

### DIFF
--- a/colors.go
+++ b/colors.go
@@ -319,7 +319,7 @@ func (sm styleMap) get(f *file) tcell.Style {
 		return val
 	}
 
-	if val, ok := sm["*"+f.ext]; ok {
+	if val, ok := sm["*"+strings.ToLower(f.ext)]; ok {
 		return val
 	}
 

--- a/icons.go
+++ b/icons.go
@@ -156,7 +156,7 @@ func (im iconMap) get(f *file) string {
 		return val
 	}
 
-	if val, ok := im["*"+f.ext]; ok {
+	if val, ok := im["*"+strings.ToLower(f.ext)]; ok {
 		return val
 	}
 


### PR DESCRIPTION
This changes the extension matching algorithm for icons & color selection to force lowercase search, effectively making it case insensitive.

I noticed that the icons & coloring where different for `.jpg` and `.JPG` files. For the icons I can generate a new `~/.config/lf/icons` file with all extensions lowercase and uppercase but that is not ideal since it does not cover mixed case for example `Jpg` extension. For colors I use `vivid` to generate the `LS_COLORS` environement varibale, wich only generates lowercase extensions.

This change makes `lf` behavior in line with other programs I checked (I suspect they are many more):
* GNU ls handling of LS_COLORS
* [`lsd`](https://github.com/Peltoche/lsd) handling of LS_COLORS and icons
* [`vivid`](https://github.com/sharkdp/vivid)