### PR TITLE
Add `:keys` command to list current key bindings.

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -77,6 +77,7 @@ var (
 		"mark-remove",
 		"tag",
 		"tag-toggle",
+		"keys",
 		"cmd-escape",
 		"cmd-complete",
 		"cmd-menu-complete",

--- a/doc.go
+++ b/doc.go
@@ -11,12 +11,14 @@ You can also use 'doc' command (default '<f-1>') inside lf to view the documenta
 A man page with the same content is also available in the repository at https://github.com/gokcehan/lf/blob/master/lf.1
 
 You can run 'lf -help' to see descriptions of command line options.
+The 'keys' command inside lf lists available key bindings.
 
 # Quick Reference
 
 The following commands are provided by lf:
 
 	quit                     (default 'q')
+	keys
 	up                       (default 'k' and '<up>')
 	half-up                  (default '<c-u>')
 	page-up                  (default '<c-b>' and '<pgup>')
@@ -214,6 +216,7 @@ The following additional keybindings are provided by default:
 	map se :set sortby ext; set info
 	map gh cd ~
 	map <space> :toggle; down
+	map <f-1> :doc
 
 If the 'mouse' option is enabled, mouse buttons have the following default effects:
 
@@ -284,6 +287,10 @@ Modal commands do not take any arguments, but instead change the operation mode 
 	quit                     (default 'q')
 
 Quit lf and return to the shell.
+
+	keys
+
+List active key bindings in the pager.
 
 	up                       (default 'k' and '<up>')
 	half-up                  (default '<c-u>')

--- a/docstring.go
+++ b/docstring.go
@@ -13,13 +13,15 @@ command (default '<f-1>') inside lf to view the documentation in a pager.
 A man page with the same content is also available in the repository at
 https://github.com/gokcehan/lf/blob/master/lf.1
 
-You can run 'lf -help' to see descriptions of command line options.
+You can run 'lf -help' to see descriptions of command line options. The 'keys'
+command inside lf lists available key bindings.
 
 # Quick Reference
 
 The following commands are provided by lf:
 
     quit                     (default 'q')
+    keys
     up                       (default 'k' and '<up>')
     half-up                  (default '<c-u>')
     page-up                  (default '<c-b>' and '<pgup>')
@@ -218,6 +220,7 @@ The following additional keybindings are provided by default:
     map se :set sortby ext; set info
     map gh cd ~
     map <space> :toggle; down
+    map <f-1> :doc
 
 If the 'mouse' option is enabled, mouse buttons have the following default
 effects:
@@ -291,6 +294,10 @@ conveniently, and so they are meant to be assigned to keybindings.
     quit                     (default 'q')
 
 Quit lf and return to the shell.
+
+    keys
+
+List active key bindings in the pager.
 
     up                       (default 'k' and '<up>')
     half-up                  (default '<c-u>')

--- a/eval.go
+++ b/eval.go
@@ -1540,6 +1540,25 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.ui.echomsg(strings.Join(e.args, " "))
 	case "echoerr":
 		app.ui.echoerr(strings.Join(e.args, " "))
+	case "keys":
+		tempfile, err := os.CreateTemp("", "lf_bindings")
+		if err != nil {
+			app.ui.echoerrf("keys: %s:", err)
+			return
+		}
+		_, err = tempfile.Write(listBinds(gOpts.keys).Bytes())
+		tempfile.Close()
+
+		filename := tempfile.Name()
+		if err == nil {
+			app.runShell(pageFileCommand(filename), e.args, "$")
+		}
+
+		os.Remove(filename)
+		app.ui.loadFile(app, false)
+		if err != nil {
+			app.ui.echoerrf("keys: %s:", err)
+		}
 	case "cd":
 		path := "~"
 		if len(e.args) > 0 {

--- a/lf.1
+++ b/lf.1
@@ -26,12 +26,13 @@ Source code can be found in the repository at https://github.com/gokcehan/lf
 .PP
 This documentation can either be read from terminal using 'lf -doc' or online at https://pkg.go.dev/github.com/gokcehan/lf You can also use 'doc' command (default '<f-1>') inside lf to view the documentation in a pager. A man page with the same content is also available in the repository at https://github.com/gokcehan/lf/blob/master/lf.1
 .PP
-You can run 'lf -help' to see descriptions of command line options.
+You can run 'lf -help' to see descriptions of command line options. The 'keys' command inside lf lists available key bindings.
 .SH QUICK REFERENCE
 The following commands are provided by lf:
 .PP
 .EX
     quit                     (default 'q')
+    keys
     up                       (default 'k' and '<up>')
     half-up                  (default '<c-u>')
     page-up                  (default '<c-b>' and '<pgup>')
@@ -241,6 +242,7 @@ The following additional keybindings are provided by default:
     map se :set sortby ext; set info
     map gh cd ~
     map <space> :toggle; down
+    map <f-1> :doc
 .EE
 .PP
 If the 'mouse' option is enabled, mouse buttons have the following default effects:
@@ -330,6 +332,12 @@ This section shows information about builtin commands. Modal commands do not tak
 .EE
 .PP
 Quit lf and return to the shell.
+.PP
+.EX
+    keys
+.EE
+.PP
+List active key bindings in the pager.
 .PP
 .EX
     up                       (default 'k' and '<up>')

--- a/os.go
+++ b/os.go
@@ -153,10 +153,14 @@ func shellKill(cmd *exec.Cmd) error {
 	return cmd.Process.Kill()
 }
 
+func pageFileCommand(filename string) string {
+	return fmt.Sprintf(`$PAGER "%s"`, filename)
+}
+
 func setDefaults() {
 	gOpts.cmds["open"] = &execExpr{"&", `$OPENER "$f"`}
 	gOpts.keys["e"] = &execExpr{"$", `$EDITOR "$f"`}
-	gOpts.keys["i"] = &execExpr{"$", `$PAGER "$f"`}
+	gOpts.keys["i"] = &execExpr{"$", pageFileCommand(`$f`)}
 	gOpts.keys["w"] = &execExpr{"$", "$SHELL"}
 
 	gOpts.cmds["doc"] = &execExpr{"$", "lf -doc | $PAGER"}

--- a/os_windows.go
+++ b/os_windows.go
@@ -109,10 +109,14 @@ func shellKill(cmd *exec.Cmd) error {
 	return cmd.Process.Kill()
 }
 
+func pageFileCommand(filename string) string {
+	return `%PAGER% ` + fmt.Sprintf(`"%s"`, filename)
+}
+
 func setDefaults() {
 	gOpts.cmds["open"] = &execExpr{"&", "%OPENER% %f%"}
 	gOpts.keys["e"] = &execExpr{"$", "%EDITOR% %f%"}
-	gOpts.keys["i"] = &execExpr{"!", "%PAGER% %f%"}
+	gOpts.keys["i"] = &execExpr{"!", pageFileCommand("%f%")}
 	gOpts.keys["w"] = &execExpr{"$", "%SHELL%"}
 
 	gOpts.cmds["doc"] = &execExpr{"!", "lf -doc | %PAGER%"}


### PR DESCRIPTION
This outputs the result of [`listBinds`] to a temporary file
and then pass it to `$PAGER`. A bit of care is taken to remove
the temporary file and refresh lf (just in case it's showing
`/tmp`).

I haven't tested it on Windows, since `lf` doesn't seem to work
on `wine`, but I think it should work there too.

It would be a bit more elegant to pipe the output directly to
`$PAGER` without a temporary file, but that would require larger
code changes, which doesn't seem worth it at the moment.

This is also the first Go code I ever wrote, so let me know if  something
could be more idiomatic.

Fixes https://github.com/gokcehan/lf/issues/916.

[`listBinds`]: https://github.com/gokcehan/lf/blob/e03143299d4596bbc9bb8a2d8a1b0931e3183410/ui.go#L940