### PR TITLE
For directories in preview column, dim cursor

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -324,26 +324,45 @@ func fileInfo(f *file, d *dir) string {
 	return info
 }
 
-func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]int, saves map[string]bool, tags map[string]string, colors styleMap, icons iconMap, previewing bool) {
+type dirContext struct {
+	selections map[string]int
+	saves      map[string]bool
+	tags       map[string]string
+}
+
+type dirStyle struct {
+	colors     styleMap
+	icons      iconMap
+	previewing bool
+}
+
+// These colors are not currently customizeable
+const LineNumberColor = tcell.ColorOlive
+const SelectionColor = tcell.ColorPurple
+const YankColor = tcell.ColorOlive
+const CutColor = tcell.ColorMaroon
+const DimCursorColor = tcell.ColorGrey
+
+func (win *win) printDir(screen tcell.Screen, dir *dir, context *dirContext, dirStyle *dirStyle) {
 	if win.w < 5 || dir == nil {
 		return
 	}
 
 	messageStyle := tcell.StyleDefault.Reverse(true)
-	if previewing {
-		messageStyle = messageStyle.Foreground(tcell.ColorGrey)
+	if dirStyle.previewing {
+		messageStyle = messageStyle.Foreground(DimCursorColor)
 	}
 
 	if dir.noPerm {
 		win.print(screen, 2, 0, messageStyle, "permission denied")
 		return
 	}
-	if (dir.loading && len(dir.files) == 0) || (previewing && dir.loading && gOpts.dirpreviews) {
+	if (dir.loading && len(dir.files) == 0) || (dirStyle.previewing && dir.loading && gOpts.dirpreviews) {
 		win.print(screen, 2, 0, messageStyle, "loading...")
 		return
 	}
 
-	if previewing && gOpts.dirpreviews && len(gOpts.previewer) > 0 {
+	if dirStyle.previewing && gOpts.dirpreviews && len(gOpts.previewer) > 0 {
 		// Print previewer result instead of default directory print operation.
 		st := tcell.StyleDefault
 		for i, l := range dir.lines {
@@ -382,7 +401,7 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]in
 	}
 
 	for i, f := range dir.files[beg:end] {
-		st := colors.get(f)
+		st := dirStyle.colors.get(f)
 
 		if lnwidth > 0 {
 			var ln string
@@ -402,25 +421,25 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]in
 				}
 			}
 
-			win.print(screen, 0, i, tcell.StyleDefault.Foreground(tcell.ColorOlive), ln)
+			win.print(screen, 0, i, tcell.StyleDefault.Foreground(LineNumberColor), ln)
 		}
 
 		path := filepath.Join(dir.path, f.Name())
 
-		if _, ok := selections[path]; ok {
-			win.print(screen, lnwidth, i, st.Background(tcell.ColorPurple), " ")
-		} else if cp, ok := saves[path]; ok {
+		if _, ok := context.selections[path]; ok {
+			win.print(screen, lnwidth, i, st.Background(SelectionColor), " ")
+		} else if cp, ok := context.saves[path]; ok {
 			if cp {
-				win.print(screen, lnwidth, i, st.Background(tcell.ColorOlive), " ")
+				win.print(screen, lnwidth, i, st.Background(YankColor), " ")
 			} else {
-				win.print(screen, lnwidth, i, st.Background(tcell.ColorMaroon), " ")
+				win.print(screen, lnwidth, i, st.Background(CutColor), " ")
 			}
 		}
 
 		if i == dir.pos {
 			st = st.Reverse(true)
-			if previewing {
-				st = st.Foreground(tcell.ColorGrey)
+			if dirStyle.previewing {
+				st = st.Foreground(DimCursorColor)
 			}
 		}
 
@@ -431,7 +450,7 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]in
 		var iwidth int
 
 		if gOpts.icons {
-			s = append(s, []rune(icons.get(f))...)
+			s = append(s, []rune(dirStyle.icons.get(f))...)
 			s = append(s, ' ')
 			iwidth = 2
 		}
@@ -469,7 +488,7 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]in
 
 		win.print(screen, lnwidth+1, i, st, string(s))
 
-		tag, ok := tags[path]
+		tag, ok := context.tags[path]
 		if ok {
 			if i == dir.pos {
 				win.print(screen, lnwidth+1, i, st.Reverse(true), tag)
@@ -478,33 +497,6 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]in
 			}
 		}
 	}
-}
-
-type ui struct {
-	screen      tcell.Screen
-	polling     bool
-	wins        []*win
-	promptWin   *win
-	msgWin      *win
-	menuWin     *win
-	msg         string
-	regPrev     *reg
-	dirPrev     *dir
-	exprChan    chan expr
-	keyChan     chan string
-	tevChan     chan tcell.Event
-	evChan      chan tcell.Event
-	menuBuf     *bytes.Buffer
-	cmdPrefix   string
-	cmdAccLeft  []rune
-	cmdAccRight []rune
-	cmdYankBuf  []rune
-	cmdTmp      []rune
-	keyAcc      []rune
-	keyCount    []rune
-	styles      styleMap
-	icons       iconMap
-	currentFile string
 }
 
 func getWidths(wtot int) []int {
@@ -549,6 +541,33 @@ func getWins(screen tcell.Screen) []*win {
 	}
 
 	return wins
+}
+
+type ui struct {
+	screen      tcell.Screen
+	polling     bool
+	wins        []*win
+	promptWin   *win
+	msgWin      *win
+	menuWin     *win
+	msg         string
+	regPrev     *reg
+	dirPrev     *dir
+	exprChan    chan expr
+	keyChan     chan string
+	tevChan     chan tcell.Event
+	evChan      chan tcell.Event
+	menuBuf     *bytes.Buffer
+	cmdPrefix   string
+	cmdAccLeft  []rune
+	cmdAccRight []rune
+	cmdYankBuf  []rune
+	cmdTmp      []rune
+	keyAcc      []rune
+	keyCount    []rune
+	styles      styleMap
+	icons       iconMap
+	currentFile string
 }
 
 func newUI(screen tcell.Screen) *ui {
@@ -861,6 +880,7 @@ func (ui *ui) drawBox() {
 
 func (ui *ui) draw(nav *nav) {
 	st := tcell.StyleDefault
+	context := dirContext{selections: nav.selections, saves: nav.saves, tags: nav.tags}
 
 	wtot, htot := ui.screen.Size()
 	for i := 0; i < wtot; i++ {
@@ -881,7 +901,8 @@ func (ui *ui) draw(nav *nav) {
 
 	doff := len(nav.dirs) - length
 	for i := 0; i < length; i++ {
-		ui.wins[woff+i].printDir(ui.screen, nav.dirs[doff+i], nav.selections, nav.saves, nav.tags, ui.styles, ui.icons, false)
+		ui.wins[woff+i].printDir(ui.screen, nav.dirs[doff+i], &context,
+			&dirStyle{colors: ui.styles, icons: ui.icons, previewing: false})
 	}
 
 	switch ui.cmdPrefix {
@@ -915,7 +936,8 @@ func (ui *ui) draw(nav *nav) {
 			preview := ui.wins[len(ui.wins)-1]
 
 			if curr.IsDir() {
-				preview.printDir(ui.screen, ui.dirPrev, nav.selections, nav.saves, nav.tags, ui.styles, ui.icons, true)
+				preview.printDir(ui.screen, ui.dirPrev, &context,
+					&dirStyle{colors: ui.styles, icons: ui.icons, previewing: true})
 			} else if curr.Mode().IsRegular() {
 				preview.printReg(ui.screen, ui.regPrev)
 			}


### PR DESCRIPTION
## Reviewing note

This PR consists of two commits: one that does all the work with
a small diff, and another one that is a no-op and tries  to make
the code easier to read.


## PR Description

When preview is on and consists of a directory listing, make the
cursor in there dimmer to emphasize it's not active (as in the first screenshot below). This makes it
visually obvious which cursor is active at all times, without
having to read the path. The active cursor is now always  the
rightmost bright one, regardless of whether the `preview` option
is on or off.

For example, you can easily and without reading anything tell the difference between the following two situations:

1. Preview is on, we are in the second column (this PR in action).

    ![Preview on](https://user-images.githubusercontent.com/4123047/187365270-c38b315e-9633-4a94-a5b2-48b5edaece63.png)

2. Preview is off, we are in the third column (same as before this PR).

    ![no_preview](https://user-images.githubusercontent.com/4123047/187365408-965c3dd0-b42c-4e5a-a65e-51f2717ab3c7.png)

If the preview is on but shows a file rather than a directory, this PR doesn't change anything.

In an ideal world, the color for the dim cursor would be customizable, but there is currently no framework for specifying these sorts of colors in `lf` (it could be a nonstandard extension to LS_COLORS, perhaps?). I picked a grey color with 50% brightness, which should be available on all terminals. I hope it will work OK for both bright and dark themes.

## More motivation

Before this, I noticed that I often open a file by accident because
I got confused which of the three cursors on the screen is the active
one.
