### PR TITLE
Fix minor incsearch weirdness

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -511,6 +511,9 @@ func update(app *app) {
 	switch {
 	case gOpts.incsearch && app.ui.cmdPrefix == "/":
 		app.nav.search = string(app.ui.cmdAccLeft) + string(app.ui.cmdAccRight)
+		if app.nav.search == "" {
+			return
+		}
 
 		dir := app.nav.currDir()
 		old := dir.ind
@@ -525,6 +528,9 @@ func update(app *app) {
 		}
 	case gOpts.incsearch && app.ui.cmdPrefix == "?":
 		app.nav.search = string(app.ui.cmdAccLeft) + string(app.ui.cmdAccRight)
+		if app.nav.search == "" {
+			return
+		}
 
 		dir := app.nav.currDir()
 		old := dir.ind


### PR DESCRIPTION
This fixes an issue where if you stared a search then deleted the search text (with e.g. backspace) it would perform a search for the empty string and move the selection to the next file.