### PR TITLE
Switching back and forth between `:` and `!/$/%/&` command-line modes

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -801,6 +801,13 @@ func insert(app *app, arg string) {
 				app.ui.echoerrf("mark-remove: %s", err)
 			}
 		}
+	case app.ui.cmdPrefix == ":" && len(app.ui.cmdAccLeft) == 0:
+		switch arg {
+		case "!", "$", "%", "&":
+			app.ui.cmdPrefix = arg
+			return
+		}
+		fallthrough
 	default:
 		app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(arg)...)
 	}
@@ -1917,7 +1924,14 @@ func (e *callExpr) eval(app *app, args []string) {
 		update(app)
 	case "cmd-delete-back":
 		if len(app.ui.cmdAccLeft) == 0 {
-			normal(app)
+			switch app.ui.cmdPrefix {
+			case "!", "$", "%", "&":
+				app.ui.cmdPrefix = ":"
+			case ">":
+				// Don't mess with the program waiting for input
+			default:
+				normal(app)
+			}
 			return
 		}
 		app.ui.cmdAccLeft = app.ui.cmdAccLeft[:len(app.ui.cmdAccLeft)-1]


### PR DESCRIPTION
# What this does

This makes the following changes:

1. If the we are in any of the shell command-line modes (after pressing one of `!/$/%/&`) and the cursor is at the first character, pressing `backspace` switches you to the `:` mode. Pressing `backspace` again will take you out of the command-line mode as before (this commit extends the recent [escape on backspace] functionality).

[escape on backspace]: https://github.com/gokcehan/lf/commit/36a7a18316580864f2f2ebd79e9ddae4858f6b60

2. Conversely, if we are in the `:` mode and the cursor is at the first character, pressing one of `!/$/%/&` will take you to the corresponding mode insted of inserting that character. This is a very minor change, since already pressing `:!ls<ret>` and `!ls <ret>` in `lf` has the same effect. After this commit, these will also look the same even before pressing `<ret>`.

3. There is a minor bugfix to the [escape on backspace] commit. In `>` mode (when a program launched with `&` waits for input), `lf` currently switches to normal mode on `backspace` without terminating the program. After this commit, the "escape on backspace" functionality is disabled in `>` mode.

This idea is borrowed from the [Julia REPL modes].

[Julia REPL modes]: https://docs.julialang.org/en/v1/stdlib/REPL/#Help-mode

# What problems this solves

The main problem I want to solve is that I often type `$ls <many options>` and realize I wanted `!ls` all along. Currently, there is no easy way to switch. With this commit, it becomes trivial.

This problem also occurs when you scroll up to a `$ls <many options>` command in history.

Finally, since `!` and `:!` have essentially the same effect in `lf`, I think they should look the same.