### PR TITLE
Check Go version is < 1.19 in `go generate`

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,3 +1,4 @@
+//go:generate gen/check_go_version.sh
 //go:generate gen/docstring.sh
 //go:generate gen/man.sh
 

--- a/gen/check_go_version.sh
+++ b/gen/check_go_version.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# This script is should be removed after we
+# require Go 1.19+ and the `man.sh` script
+# is updated to work with the new `go doc`
+# output format.
+if (go version | grep -E 'go1\.1[4-8]' > /dev/null);then
+    exit 0
+fi
+
+cat <<'EOF'
+`go generate` scripts in this repo require the
+`go` binary in the PATH to be between Go 1.14
+and Go 1.18. Currenlty, `go version` returns:
+EOF
+printf "  %s\n\n"  "$(go version)"
+
+cat <<'EOF'
+If Go 1.18 binary is in /lib/go-1.18/bin (for
+example), you can use the following command:
+  env PATH="/lib/go-1.18/bin:$PATH" go generate
+EOF
+
+exit 1


### PR DESCRIPTION
This PR prevents `go generate` from running on Go 1.19. Go versions between Go 1.14 (where the `go generate`
command was introduced) and 1.18 are allowed. There is also a detailed error message with a suggested workaround.

Starting with Go 1.19, the `go doc` command changed the format of its output. The `gen/man.sh` script fails to parse the new output and generates a badly formatted manpage. The `gen/docstring.sh` script generates a readable docstring, but it's different from what it was before.

This is a temporary and imperfect fix. A better fix would be nice, but it might be easiest to wait until we can require Go 1.19 for building `lf`. Otherwise, we would need a solution that works the same on both Go 1.18 and Go 1.19.

Fixes https://github.com/gokcehan/lf/issues/959.

**Update:** The first version of this PR only allowed Go 1.17 and 1.18. After realizing that `lf` supports Go 1.12, I expanded the list of allowed versions.