### PR TITLE
Fix staticcheck errors, minor corrections

### DIFF
--- a/server.go
+++ b/server.go
@@ -61,7 +61,7 @@ func listen(l net.Listener) {
 
 func echoerr(c net.Conn, msg string) {
 	fmt.Fprintln(c, msg)
-	log.Printf(msg)
+	log.Print(msg)
 }
 
 func echoerrf(c net.Conn, format string, a ...interface{}) {

--- a/ui.go
+++ b/ui.go
@@ -468,7 +468,7 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]in
 		tag, ok := tags[path]
 		if ok {
 			if i == dir.pos {
-				win.print(screen, lnwidth+1, i, st.Reverse(true), tag)
+				win.print(screen, lnwidth+1, i, st, tag)
 			} else {
 				win.print(screen, lnwidth+1, i, tcell.StyleDefault, fmt.Sprintf(gOpts.tagfmt, tag))
 			}
@@ -624,10 +624,6 @@ func (ui *ui) echof(format string, a ...interface{}) {
 func (ui *ui) echomsg(msg string) {
 	ui.msg = msg
 	log.Print(msg)
-}
-
-func (ui *ui) echomsgf(format string, a ...interface{}) {
-	ui.echomsg(fmt.Sprintf(format, a...))
 }
 
 func (ui *ui) echoerr(msg string) {


### PR DESCRIPTION
As requested in https://github.com/gokcehan/lf/pull/941#issuecomment-1279826056, I turned this into a pull request. If I get to it, I may also add a Github Action staticcheck check (or it could be a separate PR(.

Simplify logic in ui.go. In that diff, `st` would already have the Reversed flag set; there's no need to set it again.

Also, minor changes to remove all the statickcheck errors VS code's Go extension complains about.