### PR TITLE
Add staticcheck and go-generate Github check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,6 +15,8 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
 
     - name: Set up Go
       uses: actions/setup-go@v2
@@ -26,3 +28,24 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+    - uses: dominikh/staticcheck-action@v1.2.0
+      with:
+        version: "2022.1.3"
+        install-go: false
+
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.19
+
+    - name: Test `go fmt && go generate` on Go 1.19 creates no diffs
+      run: go fmt && go generate && git diff --exit-code
+

--- a/server.go
+++ b/server.go
@@ -61,7 +61,7 @@ func listen(l net.Listener) {
 
 func echoerr(c net.Conn, msg string) {
 	fmt.Fprintln(c, msg)
-	log.Printf(msg)
+	log.Print(msg)
 }
 
 func echoerrf(c net.Conn, format string, a ...interface{}) {

--- a/ui.go
+++ b/ui.go
@@ -468,7 +468,7 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, selections map[string]in
 		tag, ok := tags[path]
 		if ok {
 			if i == dir.pos {
-				win.print(screen, lnwidth+1, i, st.Reverse(true), tag)
+				win.print(screen, lnwidth+1, i, st, tag)
 			} else {
 				win.print(screen, lnwidth+1, i, tcell.StyleDefault, fmt.Sprintf(gOpts.tagfmt, tag))
 			}
@@ -624,10 +624,6 @@ func (ui *ui) echof(format string, a ...interface{}) {
 func (ui *ui) echomsg(msg string) {
 	ui.msg = msg
 	log.Print(msg)
-}
-
-func (ui *ui) echomsgf(format string, a ...interface{}) {
-	ui.echomsg(fmt.Sprintf(format, a...))
 }
 
 func (ui *ui) echoerr(msg string) {


### PR DESCRIPTION
This adds a few Github action checks:

1. Check that `go fmt` and `go generate` were run on Go 1.19, following
up on https://github.com/gokcehan/lf/commit/654b8737b8a35729aa89aa93acf05ed5871b2616.
On earlier Go versions, `go generate` results in whitespace changes.

2. Check that [Staticcheck](https://staticcheck.io/) passes.

This includes https://github.com/gokcehan/lf/pull/967, which makes Staticcheck pass.