### PR TITLE
Fix user query when using libc implementation of os/user

### DIFF
--- a/os.go
+++ b/os.go
@@ -64,12 +64,19 @@ func init() {
 
 	u, err := user.Current()
 	if err != nil {
+		// When the user is not in /etc/passwd (for e.g. LDAP) and CGO_ENABLED=1 in go env,
+		// the cgo implementation of user.Current() fails even when HOME and USER are set.
+
 		log.Printf("user: %s", err)
 		if os.Getenv("HOME") == "" {
-			log.Print("$HOME variable is empty or not set")
+			panic("$HOME variable is empty or not set")
 		}
 		if os.Getenv("USER") == "" {
-			log.Print("$USER variable is empty or not set")
+			panic("$USER variable is empty or not set")
+		}
+		u = &user.User{
+			Username: os.Getenv("USER"),
+			HomeDir:  os.Getenv("HOME"),
 		}
 	}
 	gUser = u


### PR DESCRIPTION
Fixes #191 

In the case where the user is not in `/etc/passwd` (for e.g. LDAP), the cgo implementation of `os/user` which uses the `libc` functions is not able to find the user name and home directory.

This fix implements a fallback that uses the `$USER` and `$HOME` environment variables.

Note: This problem does not occur when using the pure go implementation of `os/user` (for e.g. when specifying `CGO_ENABLED=0`) which already implements the same kind of fallback.