### PR TITLE
When clicking on file preview, only open files on right-click (+ doc fix)

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -218,10 +218,10 @@ The following additional keybindings are provided by default:
 If the 'mouse' option is enabled, mouse buttons have the following default effects:
 
 	Left mouse button
-	    Click on a file or directory to select it. To open a file, click on the preview.
+	    Click on a file or directory to select it.
 
 	Right mouse button
-	    Enter a directory or open a file.
+	    Enter a directory or open a file. Also works on the preview window.
 
 	Scroll wheel
 	    Scroll up or down.

--- a/doc.go
+++ b/doc.go
@@ -1204,7 +1204,8 @@ So now you can display a message in the current client by calling the following 
 Since lf does not have control flow syntax, remote commands are used for such needs.
 For example, you can configure the number of columns in the ui with respect to the terminal width as follows:
 
-	cmd recol %{{
+	cmd recol ${{
+	    # Use ${{ instead of %{{ to work around https://github.com/gokcehan/lf/issues/718.
 	    w=$(tput cols)
 	    if [ $w -le 80 ]; then
 	        lf -remote "send $id set ratios 1:2"

--- a/docstring.go
+++ b/docstring.go
@@ -223,10 +223,10 @@ If the 'mouse' option is enabled, mouse buttons have the following default
 effects:
 
     Left mouse button
-        Click on a file or directory to select it. To open a file, click on the preview.
+        Click on a file or directory to select it.
 
     Right mouse button
-        Enter a directory or open a file.
+        Enter a directory or open a file. Also works on the preview window.
 
     Scroll wheel
         Scroll up or down.

--- a/docstring.go
+++ b/docstring.go
@@ -1286,7 +1286,8 @@ Since lf does not have control flow syntax, remote commands are used for such
 needs. For example, you can configure the number of columns in the ui with
 respect to the terminal width as follows:
 
-    cmd recol %{{
+    cmd recol ${{
+        # Use ${{ instead of %{{ to work around https://github.com/gokcehan/lf/issues/718.
         w=$(tput cols)
         if [ $w -le 80 ]; then
             lf -remote "send $id set ratios 1:2"

--- a/lf.1
+++ b/lf.1
@@ -247,12 +247,12 @@ If the 'mouse' option is enabled, mouse buttons have the following default effec
 .PP
 .EX
     Left mouse button
-        Click on a file or directory to select it. To open a file, click on the preview.
+        Click on a file or directory to select it.
 .EE
 .PP
 .EX
     Right mouse button
-        Enter a directory or open a file.
+        Enter a directory or open a file. Also works on the preview window.
 .EE
 .PP
 .EX

--- a/lf.1
+++ b/lf.1
@@ -1435,7 +1435,8 @@ All clients have a unique id number but you may not be aware of the id number wh
 Since lf does not have control flow syntax, remote commands are used for such needs. For example, you can configure the number of columns in the ui with respect to the terminal width as follows:
 .PP
 .EX
-    cmd recol %{{
+    cmd recol ${{
+        # Use ${{ instead of %{{ to work around https://github.com/gokcehan/lf/issues/718.
         w=$(tput cols)
         if [ $w -le 80 ]; then
             lf -remote "send $id set ratios 1:2"

--- a/ui.go
+++ b/ui.go
@@ -1209,6 +1209,9 @@ func (ui *ui) readNormalEvent(ev tcell.Event, nav *nav) expr {
 			if err != nil {
 				return nil
 			} else if !curr.IsDir() || gOpts.dirpreviews {
+				if tev.Buttons() != tcell.Button2 {
+					return nil
+				}
 				return &callExpr{"open", nil, 1}
 			}
 			dir = ui.dirPrev


### PR DESCRIPTION
After #963, when the mouse is on, I often click on the preview accidentally since it's such a large target, which takes me to another program. Moreover, if the terminal with `lf` isn't focused and a file is previewed, there is very little space where I can click without having the state change drastically (clicking the preview is out, clicking almost anywhere else changes the preview).

This commit fixes the issue, at the cost of the ability to open files with the mouse becoming slightly harder to discover.

I hope you're OK with this, @p-ouellette. An alternative I considered would be to create a special command `preview-left-click` that could default to something like `:echo Right-click to open file` but could be changed to `open` (or vice versa), but I'm not sure that's worth it.

P.S. I also included a separate minor fix to the docs related to https://github.com/gokcehan/lf/issues/718. I can extract that to a separate PR; if another of my PRs is likely to go in earlier, I'll probably move it there.
