### PR TITLE
load file info after init

### DIFF
--- a/app.go
+++ b/app.go
@@ -414,6 +414,7 @@ func (app *app) loop() {
 			if err == nil {
 				if d.path == app.nav.currDir().path {
 					app.ui.loadFile(app, true)
+					app.ui.loadFileInfo(app.nav)
 				}
 				if d.path == curr.path {
 					app.ui.dirPrev = d

--- a/app.go
+++ b/app.go
@@ -414,7 +414,9 @@ func (app *app) loop() {
 			if err == nil {
 				if d.path == app.nav.currDir().path {
 					app.ui.loadFile(app, true)
-					app.ui.loadFileInfo(app.nav)
+					if app.ui.msg == "" {
+						app.ui.loadFileInfo(app.nav)
+					}
 				}
 				if d.path == curr.path {
 					app.ui.dirPrev = d


### PR DESCRIPTION
After init is set to true here https://github.com/gokcehan/lf/blob/a94015d2210a7983744f47395f542459a56175d9/app.go#L287
loadFileInfo still needs to be called to display the file information after start.

Currently, the file information are only displayed after the user has changed the selected file/directory at least once.
This change fixes this issue by calling loadFileInfo after the current file information have been loaded.
 