### PR TITLE
Updated `times` import path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/mattn/go-runewidth v0.0.14
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
-	gopkg.in/djherbis/times.v1 v1.2.0
+	github.com/djherbis/times v1.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -35,5 +35,5 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gopkg.in/djherbis/times.v1 v1.2.0 h1:UCvDKl1L/fmBygl2Y7hubXCnY7t4Yj46ZrBFNUipFbM=
-gopkg.in/djherbis/times.v1 v1.2.0/go.mod h1:AQlg6unIsrsCEdQYhTzERy542dz6SFdQFZFv6mUY0P8=
+github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
+github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=

--- a/nav.go
+++ b/nav.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	times "gopkg.in/djherbis/times.v1"
+	times "github.com/djherbis/times"
 )
 
 type linkState byte


### PR DESCRIPTION
The `times` package is currently uses `github.com/djherbis/times` as it's import path, instead of `gopkg.in/djherbis/times.v1`.

I've made this update specifically to enable `lf` to built in line with Fedora packaging guidelines. 
