### PR TITLE
Top/bottom commands accept a count and move to index

### DIFF
--- a/docstring.go
+++ b/docstring.go
@@ -325,7 +325,8 @@ Change the current working directory to the next/previous jumplist item.
     top                      (default 'gg' and '<home>')
     bottom                   (default 'G' and '<end>')
 
-Move the current file selection to the top/bottom of the directory.
+Move the current file selection to the top/bottom of the directory. 
+Type a count before to go to a specific index (absolute or relative) 
 
     high                     (default 'H')
     middle                   (default 'M')
@@ -608,6 +609,9 @@ Delete the next word in forward direction.
     cmd-lowercase-word       (default '<a-l>')
 
 Capitalize/uppercase/lowercase the current word and jump to the next word.
+
+Type a number to move to the file with that position (absolute 
+or relative). This is useful while using the 'number' and 'relativenumber' options
 
 # Options
 

--- a/misc.go
+++ b/misc.go
@@ -295,6 +295,10 @@ func max(a, b int) int {
 	return b
 }
 
+func mod(a, b int) int {
+    return (a % b + b) % b
+}
+
 // We don't need no generic code
 // We don't need no type control
 // No dark templates in compiler

--- a/opts.go
+++ b/opts.go
@@ -140,6 +140,7 @@ func init() {
 	gOpts.keys["<pgup>"] = &callExpr{"page-up", nil, 1}
 	gOpts.keys["<c-y>"] = &callExpr{"scroll-up", nil, 1}
 	gOpts.keys["j"] = &callExpr{"down", nil, 1}
+	gOpts.keys["J"] = &callExpr{"down", nil, 5}
 	gOpts.keys["<down>"] = &callExpr{"down", nil, 1}
 	gOpts.keys["<m-down>"] = &callExpr{"down", nil, 1}
 	gOpts.keys["<c-d>"] = &callExpr{"half-down", nil, 1}
@@ -151,10 +152,10 @@ func init() {
 	gOpts.keys["l"] = &callExpr{"open", nil, 1}
 	gOpts.keys["<right>"] = &callExpr{"open", nil, 1}
 	gOpts.keys["q"] = &callExpr{"quit", nil, 1}
-	gOpts.keys["gg"] = &callExpr{"top", nil, 1}
-	gOpts.keys["<home>"] = &callExpr{"top", nil, 1}
-	gOpts.keys["G"] = &callExpr{"bottom", nil, 1}
-	gOpts.keys["<end>"] = &callExpr{"bottom", nil, 1}
+	gOpts.keys["gg"] = &callExpr{"top", nil, 0} 
+	gOpts.keys["<home>"] = &callExpr{"top", nil, 0} 
+	gOpts.keys["G"] = &callExpr{"bottom", nil, 0}
+	gOpts.keys["<end>"] = &callExpr{"bottom", nil, 0}
 	gOpts.keys["H"] = &callExpr{"high", nil, 1}
 	gOpts.keys["M"] = &callExpr{"middle", nil, 1}
 	gOpts.keys["L"] = &callExpr{"low", nil, 1}


### PR DESCRIPTION
Top/bottom commands now take a count if present, and move to a specific index or to a displacement if the count is relative (has a +/- symbol). Also, introduced the `goToIndex` function, which could be used in other moving functions in order to avoid repetition, such as `up` or `down`
