### PR TITLE
Make `lfcd` examples safer for people who alias `lf` to `lfcd`

### DIFF
--- a/etc/lfcd.fish
+++ b/etc/lfcd.fish
@@ -5,7 +5,7 @@
 #     mkdir -p ~/.config/fish/functions
 #     ln -s "/path/to/lfcd.fish" ~/.config/fish/functions
 #
-# You may also like to assign a key to this command:
+# You may also like to assign a key (Ctrl-O) to this command:
 #
 #     bind \co 'set old_tty (stty -g); stty sane; lfcd; stty $old_tty; commandline -f repaint'
 #
@@ -13,7 +13,8 @@
 
 function lfcd
     set tmp (mktemp)
-    lf -last-dir-path=$tmp $argv
+    # `command` is needed in case `lfcd` is aliased to `lf`
+    command lf -last-dir-path=$tmp $argv
     if test -f "$tmp"
         set dir (cat $tmp)
         rm -f $tmp

--- a/etc/lfcd.sh
+++ b/etc/lfcd.sh
@@ -8,7 +8,7 @@
 #         source "$LFCD"
 #     fi
 #
-# You may also like to assign a key to this command:
+# You may also like to assign a key (Ctrl-O) to this command:
 #
 #     bind '"\C-o":"lfcd\C-m"'  # bash
 #     bindkey -s '^o' 'lfcd\n'  # zsh
@@ -16,7 +16,8 @@
 
 lfcd () {
     tmp="$(mktemp)"
-    lf -last-dir-path="$tmp" "$@"
+    # `command` is needed in case `lfcd` is aliased to `lf`
+    command lf -last-dir-path="$tmp" "$@"
     if [ -f "$tmp" ]; then
         dir="$(cat "$tmp")"
         rm -f "$tmp"


### PR DESCRIPTION
People keep running into an infinite loop and being confused. See https://github.com/gokcehan/lf/issues/140#issuecomment-1256368250 and https://github.com/gokcehan/lf/discussions/1043.

This fixes the issues in `lfcd.sh` and `lfcd.fish`. For the other scripts, I'm not sure whether this issue exists or is fixable.

I also documented the key binding in more detail since it was a source of confusion in one of the discussions above.