### PR TITLE
Bind Ctrl+MouseWheel to scroll up/down

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -226,7 +226,7 @@ If the 'mouse' option is enabled, mouse buttons have the following default effec
 	    Enter a directory or open a file. Also works on the preview window.
 
 	Scroll wheel
-	    Scroll up or down.
+	    Move up or down. If Ctrl is pressed, scroll up or down.
 
 # Configuration
 

--- a/docstring.go
+++ b/docstring.go
@@ -231,7 +231,7 @@ effects:
         Enter a directory or open a file. Also works on the preview window.
 
     Scroll wheel
-        Scroll up or down.
+        Move up or down. If Ctrl is pressed, scroll up or down.
 
 # Configuration
 

--- a/lf.1
+++ b/lf.1
@@ -259,7 +259,7 @@ If the 'mouse' option is enabled, mouse buttons have the following default effec
 .PP
 .EX
     Scroll wheel
-        Scroll up or down.
+        Move up or down. If Ctrl is pressed, scroll up or down.
 .EE
 .SH CONFIGURATION
 Configuration files should be located at:

--- a/opts.go
+++ b/opts.go
@@ -139,6 +139,7 @@ func init() {
 	gOpts.keys["<c-b>"] = &callExpr{"page-up", nil, 1}
 	gOpts.keys["<pgup>"] = &callExpr{"page-up", nil, 1}
 	gOpts.keys["<c-y>"] = &callExpr{"scroll-up", nil, 1}
+	gOpts.keys["<c-m-up>"] = &callExpr{"scroll-up", nil, 1}
 	gOpts.keys["j"] = &callExpr{"down", nil, 1}
 	gOpts.keys["<down>"] = &callExpr{"down", nil, 1}
 	gOpts.keys["<m-down>"] = &callExpr{"down", nil, 1}
@@ -146,6 +147,7 @@ func init() {
 	gOpts.keys["<c-f>"] = &callExpr{"page-down", nil, 1}
 	gOpts.keys["<pgdn>"] = &callExpr{"page-down", nil, 1}
 	gOpts.keys["<c-e>"] = &callExpr{"scroll-down", nil, 1}
+	gOpts.keys["<c-m-down>"] = &callExpr{"scroll-down", nil, 1}
 	gOpts.keys["h"] = &callExpr{"updir", nil, 1}
 	gOpts.keys["<left>"] = &callExpr{"updir", nil, 1}
 	gOpts.keys["l"] = &callExpr{"open", nil, 1}

--- a/ui.go
+++ b/ui.go
@@ -1189,12 +1189,18 @@ func (ui *ui) readNormalEvent(ev tcell.Event, nav *nav) expr {
 		case tcell.ButtonNone:
 			return nil
 		}
+		if tev.Modifiers() == tcell.ModCtrl {
+			button = "<c-" + button[1:]
+		}
 		if expr, ok := gOpts.keys[button]; ok {
 			return expr
 		}
-
-		if tev.Buttons() != tcell.Button1 && tev.Buttons() != tcell.Button2 {
-			return nil
+		if button != "<m-1>" && button != "<m-2>" {
+			ui.echoerrf("unknown mapping: %s", button)
+			ui.keyAcc = nil
+			ui.keyCount = nil
+			ui.menuBuf = nil
+			return draw
 		}
 
 		x, y := tev.Position()


### PR DESCRIPTION
On my system, Shift+Mouse is captured by the terminal and
Alt+Mouse only works for one of the alt keys. Also, `lf` currently
tends to support Ctrl bindings but not Alt. Hence I picked
Ctrl.

This also allows binding of Ctrl+MouseButtons (but doesn't set
any such bindings). 

As a minor bonus, that should allow using Ctrl+Click to
select `lf`'s terminal without moving the cursor no matter
where you click.  On tmux, this doesn't work out of the box and
requires a change to `tmux.conf` along the following lines:

     bind-key -T root  C-MouseDown1Pane  select-pane -t = \; send-keys -M

You can omit the `send-keys -M` if you never want to pass `Ctrl+Click`
to any of your terminal apps. (Then it will work without this PR).

This builds on top of @p-ouellette's work.

---------------------

I also have subsequent commits that allow binding other modifier keys with the mouse and in keyboard bindings (e.g. Ctrl+Enter vs Alt+Enter). See various commits in https://github.com/ilyagr/lf/tree/a-enter (not all of them are polished to be easier to review). I'm not submitting that now since it might be more controversial, but let me know if you are interested.