### PR TITLE
Disallow exiting from `rename:` mode with backspace

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -1887,8 +1887,9 @@ func (e *callExpr) eval(app *app, args []string) {
 			switch app.ui.cmdPrefix {
 			case "!", "$", "%", "&":
 				app.ui.cmdPrefix = ":"
-			case ">":
-				// Don't mess with the program waiting for input
+			case ">", "rename: ":
+				// Don't mess with programs waiting for input.
+				// Exiting on backspace is also inconvenient for renames since the text field starts out nonempty.
 			default:
 				normal(app)
 			}


### PR DESCRIPTION
After looking at the list of possibilities for `app.ui.cmdPrefix` by searching through the code, renaming looks to be the only remaining mode where exiting via backspace doesn't make sense.

In particular, I don't think any commands other than `rename` commonly start out with some editable text in the prompt. The other dangerous mode is the `>` mode, but there exit-on-backspace was already disabled.

If I missed something, please let me know. I can fix it here or in a subsequent PR, depending on when we find out.

Fixes #1052, #1059