### PR TITLE
PDF preview in plain text | CMD

### DIFF
--- a/etc/lfrc.cmd.example
+++ b/etc/lfrc.cmd.example
@@ -1,6 +1,13 @@
 # interpreter for shell commands
 set shell cmd
 
+# To preview the content of files with syntax highlighting and to preview PDF in
+# plain text, uncomment the following line and set the full path pointing to the
+# address of your scope.bat file. Get this script in the /etc/ directory of the
+# repo and paste it into your LF config path. ATENTION: This script requires "bat"
+# and "xpdf-utils" installed on your system. Find them in chocolatey and install them.
+# set previewer 'C:/ProgramData/lf/scope.bat'
+
 # Shell commands with multiline definitions and/or positional arguments and/or
 # quotes do not work in Windows. For anything but the simplest shell commands,
 # it is recommended to create separate script files and simply call them here

--- a/etc/scope.bat
+++ b/etc/scope.bat
@@ -1,0 +1,11 @@
+:: ATENTION: You need to install "bat" and "xpdf-utils" in order for this script to work.
+::The most comfortable way is through chocolatey.
+
+@echo off
+if "%~x1" == ".pdf" (
+    pdftotext -f 1 -l 5 -layout "%f%" - | bat --paging=never --style=numbers -f
+) else if "%~x1" == ".exe" (
+    echo Executable file
+) else (
+    bat --paging=never --style=numbers,changes -f "%f%"
+)


### PR DESCRIPTION
Small script for PDF display in plain text.

Requires xpdf-utils.

PS: It also contains preview with highlight for files. I did notice that there was already a fixed issue for this after creating the script, however.