### PR TITLE
Make preview cursor an underline

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -433,7 +433,11 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, context *dirContext, dir
 		}
 
 		if i == dir.pos {
-			st = st.Reverse(true)
+			if dirStyle.previewing {
+				st = st.Underline(true)
+			} else {
+				st = st.Reverse(true)
+			}
 		}
 
 		var s []rune


### PR DESCRIPTION
This restores functionality from https://github.com/gokcehan/lf/pull/924 reverted in https://github.com/gokcehan/lf/commit/b47cf6d5a5, while fixing https://github.com/gokcehan/lf/issues/1038.

Unlike before, the cursor in the preview column is now an underline rather than a grey background. This seems to work on most terminals. In no case should the visibility of the file name itself be affected.

![Screenshot](https://user-images.githubusercontent.com/4123047/209767426-abcbddd4-965a-43a8-a5a8-6242681bbd98.png)

For messages such as "empty" or "permission denied", the preview cursor is the same as the active cursor for now.

There is no configuration, but there is nothing preventing adding config as discussed in https://github.com/gokcehan/lf/issues/1038#issuecomment-1364586156 in the future.

Fixes #1038 
