### PR TITLE
Add example to hiddenfiles documentation

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -663,8 +663,8 @@ On Windows, only files with hidden attributes are considered hidden files.
 
 List of hidden file glob patterns.
 Patterns can be given as relative or absolute paths.
-Globbing supports the usual special characters, '*' to match any sequence, '?' to match any character, and '[...]' or '[^...] to match character sets or ranges.
-In addition, if a pattern starts with '!', then its matches are excluded from hidden files.
+Globbing supports the usual special characters, '*' to match any sequence, '?' to match any character, and '[...]' or '[^...]' to match character sets or ranges.
+In addition, if a pattern starts with '!', then its matches are excluded from hidden files. To add multiple patterns, use ':' as a separator. Example: '.*:lost+found:*.bak'
 
 	history        bool      (default on)
 

--- a/doc.go
+++ b/doc.go
@@ -650,7 +650,7 @@ When this value is set to 0, find command prompts until there is only a single m
 	globsearch     bool      (default off)
 
 When this option is enabled, search command patterns are considered as globs, otherwise they are literals.
-With globbing, '*' matches any sequence, '?' matches any character, and '[...]' or '[^...] matches character sets or ranges.
+With globbing, '*' matches any sequence, '?' matches any character, and '[...]' or '[^...]' matches character sets or ranges.
 Otherwise, these characters are interpreted as they are.
 
 	hidden         bool      (default off)

--- a/docstring.go
+++ b/docstring.go
@@ -681,7 +681,7 @@ find command prompts until there is only a single match left.
 
 When this option is enabled, search command patterns are considered as globs,
 otherwise they are literals. With globbing, '*' matches any sequence, '?'
-matches any character, and '[...]' or '[^...] matches character sets or ranges.
+matches any character, and '[...]' or '[^...]' matches character sets or ranges.
 Otherwise, these characters are interpreted as they are.
 
     hidden         bool      (default off)
@@ -694,9 +694,10 @@ hidden files.
 
 List of hidden file glob patterns. Patterns can be given as relative or
 absolute paths. Globbing supports the usual special characters, '*' to match any
-sequence, '?' to match any character, and '[...]' or '[^...] to match character
+sequence, '?' to match any character, and '[...]' or '[^...]' to match character
 sets or ranges. In addition, if a pattern starts with '!', then its matches are
-excluded from hidden files.
+excluded from hidden files. To add multiple patterns, use ':' as a separator.
+Example: '.*:lost+found:*.bak'
 
     history        bool      (default on)
 

--- a/lf.1
+++ b/lf.1
@@ -805,7 +805,7 @@ Number of characters prompted for the find command. When this value is set to 0,
     globsearch     bool      (default off)
 .EE
 .PP
-When this option is enabled, search command patterns are considered as globs, otherwise they are literals. With globbing, '*' matches any sequence, '?' matches any character, and '[...]' or '[^...] matches character sets or ranges. Otherwise, these characters are interpreted as they are.
+When this option is enabled, search command patterns are considered as globs, otherwise they are literals. With globbing, '*' matches any sequence, '?' matches any character, and '[...]' or '[^...]' matches character sets or ranges. Otherwise, these characters are interpreted as they are.
 .PP
 .EX
     hidden         bool      (default off)
@@ -817,7 +817,7 @@ Show hidden files. On Unix systems, hidden files are determined by the value of 
     hiddenfiles    []string  (default '.*')
 .EE
 .PP
-List of hidden file glob patterns. Patterns can be given as relative or absolute paths. Globbing supports the usual special characters, '*' to match any sequence, '?' to match any character, and '[...]' or '[^...] to match character sets or ranges. In addition, if a pattern starts with '!', then its matches are excluded from hidden files.
+List of hidden file glob patterns. Patterns can be given as relative or absolute paths. Globbing supports the usual special characters, '*' to match any sequence, '?' to match any character, and '[...]' or '[^...]' to match character sets or ranges. In addition, if a pattern starts with '!', then its matches are excluded from hidden files. To add multiple patterns, use ':' as a separator. Example: '.*:lost+found:*.bak'
 .PP
 .EX
     history        bool      (default on)


### PR DESCRIPTION
This documents the use of `:` as a separator for multiple hidden file patterns as well as an example.