### PR TITLE
Refresh preview even if selection doesn't change

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -679,11 +679,10 @@ func (ui *ui) loadFile(app *app, volatile bool) {
 		return
 	}
 
-	if curr.path == ui.currentFile {
-		return
+	if curr.path != ui.currentFile {
+		ui.currentFile = curr.path
+		onSelect(app)
 	}
-	ui.currentFile = curr.path
-	onSelect(app)
 
 	if !gOpts.preview {
 		return


### PR DESCRIPTION
Fixes #1055 

The `loadFile` function is responsible for refreshing the preview, which should happen even if the selected file hasn't changed (e.g. if the terminal is resized or if a shell command is run). I believe this is a bug that was accidentally introduced when adding the `on-select` command.