### PR TITLE
`invert-below` command to substitute for visual mode

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -35,6 +35,7 @@ var (
 		"low",
 		"toggle",
 		"invert",
+		"invert-below",
 		"unselect",
 		"glob-select",
 		"glob-unselect",

--- a/doc.go
+++ b/doc.go
@@ -36,6 +36,7 @@ The following commands are provided by lf:
 	low                      (default 'L')
 	toggle
 	invert                   (default 'v')
+	invert-below
 	unselect                 (default 'u')
 	glob-select
 	glob-unselect
@@ -335,6 +336,17 @@ Toggle the selection of the current file or files given as arguments.
 Reverse the selection of all files in the current directory (i.e. 'toggle' all files).
 Selections in other directories are not effected by this command.
 You can define a new command to select all files in the directory by combining 'invert' with 'unselect' (i.e. 'cmd select-all :unselect; invert'), though this will also remove selections in other directories.
+
+	invert-below
+
+Reverse the selection (i.e. 'toggle') of all files at or after the current file in the current directory.
+
+To select a contiguous block of files, use this command on the first file you want to select.
+Then, move down to the first file you do *not* want to select (the one after the end of the desired selection) and use this command again.
+This achieves an effect similar to the visual mode in vim.
+
+This command is experimental and may be removed once a better replacement for the visual mode is implemented in 'lf'.
+If you'd like to experiment with using this command, you should bind it to a key (e.g. 'V') for a better experience.
 
 	unselect                 (default 'u')
 

--- a/docstring.go
+++ b/docstring.go
@@ -39,6 +39,7 @@ The following commands are provided by lf:
     low                      (default 'L')
     toggle
     invert                   (default 'v')
+    invert-below
     unselect                 (default 'u')
     glob-select
     glob-unselect
@@ -346,6 +347,20 @@ all files). Selections in other directories are not effected by this command.
 You can define a new command to select all files in the directory by combining
 'invert' with 'unselect' (i.e. 'cmd select-all :unselect; invert'), though this
 will also remove selections in other directories.
+
+    invert-below
+
+Reverse the selection (i.e. 'toggle') of all files at or after the current file
+in the current directory.
+
+To select a contiguous block of files, use this command on the first file you
+want to select. Then, move down to the first file you do *not* want to select
+(the one after the end of the desired selection) and use this command again.
+This achieves an effect similar to the visual mode in vim.
+
+This command is experimental and may be removed once a better replacement for
+the visual mode is implemented in 'lf'. If you'd like to experiment with using
+this command, you should bind it to a key (e.g. 'V') for a better experience.
 
     unselect                 (default 'u')
 

--- a/eval.go
+++ b/eval.go
@@ -1152,6 +1152,11 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 		app.nav.invert()
+	case "invert-below":
+		if !app.nav.init {
+			return
+		}
+		app.nav.invertBelow()
 	case "unselect":
 		app.nav.unselect()
 	case "calcdirsize":

--- a/lf.1
+++ b/lf.1
@@ -51,6 +51,7 @@ The following commands are provided by lf:
     low                      (default 'L')
     toggle
     invert                   (default 'v')
+    invert-below
     unselect                 (default 'u')
     glob-select
     glob-unselect
@@ -393,6 +394,16 @@ Toggle the selection of the current file or files given as arguments.
 .EE
 .PP
 Reverse the selection of all files in the current directory (i.e. 'toggle' all files). Selections in other directories are not effected by this command. You can define a new command to select all files in the directory by combining 'invert' with 'unselect' (i.e. 'cmd select-all :unselect; invert'), though this will also remove selections in other directories.
+.PP
+.EX
+    invert-below
+.EE
+.PP
+Reverse the selection (i.e. 'toggle') of all files at or after the current file in the current directory.
+.PP
+To select a contiguous block of files, use this command on the first file you want to select. Then, move down to the first file you do *not* want to select (the one after the end of the desired selection) and use this command again. This achieves an effect similar to the visual mode in vim.
+.PP
+This command is experimental and may be removed once a better replacement for the visual mode is implemented in 'lf'. If you'd like to experiment with using this command, you should bind it to a key (e.g. 'V') for a better experience.
 .PP
 .EX
     unselect                 (default 'u')

--- a/nav.go
+++ b/nav.go
@@ -1149,12 +1149,20 @@ func (nav *nav) tag(tag string) error {
 	return nil
 }
 
-func (nav *nav) invert() {
+func (nav *nav) invertAfter(ix int) {
 	dir := nav.currDir()
-	for _, f := range dir.files {
+	for _, f := range dir.files[ix:] {
 		path := filepath.Join(dir.path, f.Name())
 		nav.toggleSelection(path)
 	}
+}
+
+func (nav *nav) invert() {
+	nav.invertAfter(0)
+}
+
+func (nav *nav) invertBelow() {
+	nav.invertAfter(nav.currDir().ind)
 }
 
 func (nav *nav) unselect() {


### PR DESCRIPTION
This command inverts the selection for the current file and all the files below it. Using this command twice substitutes for having a "visual" mode. This is described in more detail in the docs and in
https://github.com/gokcehan/lf/issues/477#issuecomment-1414563834.

Since `invert` is bound to `v` by default, `invert-below` gets `V` as a default binding.

Fixes #477. While that's not exactly what was asked for, I hope it's a suitable replacement and seems more in the spirit of `lf`.