### PR TITLE
Fix documentation for dironly/dirpreviews options

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -639,11 +639,11 @@ Show directories first above regular files.
 
 	dironly        bool      (default off)
 
-If enabled, directories will also be passed to the previewer script. This allows custom previews for directories.
+Show only directories.
 
 	dirpreviews    bool      (default off)
 
-Show only directories.
+If enabled, directories will also be passed to the previewer script. This allows custom previews for directories.
 
 	drawbox        bool      (default off)
 

--- a/docstring.go
+++ b/docstring.go
@@ -672,12 +672,12 @@ Show directories first above regular files.
 
     dironly        bool      (default off)
 
-If enabled, directories will also be passed to the previewer script. This allows
-custom previews for directories.
+Show only directories.
 
     dirpreviews    bool      (default off)
 
-Show only directories.
+If enabled, directories will also be passed to the previewer script. This allows
+custom previews for directories.
 
     drawbox        bool      (default off)
 

--- a/lf.1
+++ b/lf.1
@@ -784,13 +784,13 @@ Show directories first above regular files.
     dironly        bool      (default off)
 .EE
 .PP
-If enabled, directories will also be passed to the previewer script. This allows custom previews for directories.
+Show only directories.
 .PP
 .EX
     dirpreviews    bool      (default off)
 .EE
 .PP
-Show only directories.
+If enabled, directories will also be passed to the previewer script. This allows custom previews for directories.
 .PP
 .EX
     drawbox        bool      (default off)


### PR DESCRIPTION
The descriptions for the `dironly` and `dirpreviews` options were accidentally swapped.