### PR TITLE
Option to change look of cursors in parent dirs, rename an option.

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -114,6 +114,7 @@ var (
 		"noautoquit",
 		"autoquit!",
 		"cursorfmt",
+		"cursorparentfmt",
 		"cursorpreviewfmt",
 		"dircache",
 		"nodircache",

--- a/complete.go
+++ b/complete.go
@@ -113,7 +113,7 @@ var (
 		"autoquit",
 		"noautoquit",
 		"autoquit!",
-		"cursorfmt",
+		"cursoractivefmt",
 		"cursorparentfmt",
 		"cursorpreviewfmt",
 		"dircache",

--- a/doc.go
+++ b/doc.go
@@ -114,7 +114,7 @@ The following options can be used to customize the behavior of lf:
 	anchorfind       bool      (default on)
 	autoquit         bool      (default off)
 	cleaner          string    (default '')
-	cursorfmt        string    (default "\033[7m")
+	cursoractivefmt  string    (default "\033[7m")
 	cursorparentfmt  string    (default "\033[7m")
 	cursorpreviewfmt string    (default "\033[4m")
 	dircache         bool      (default on)
@@ -609,12 +609,12 @@ This file is called if previewing is enabled, the previewer is set, and the prev
 Five arguments are passed to the file, (1) current file name, (2) width, (3) height, (4) horizontal position, and (5) vertical position of preview pane respectively.
 Preview clearing is disabled when the value of this option is left empty.
 
-	cursorfmt         string    (default "\033[7m")
+	cursoractivefmt   string    (default "\033[7m")
 	cursorparentfmt   string    (default "\033[7m")
 	cursorpreviewfmt  string    (default "\033[4m")
 
 Format strings for highlighting the cursor.
-`cursorfmt` applies in the current directory pane,
+`cursoractivefmt` applies in the current directory pane,
 `cursorparentfmt` applies in panes that show parents of the current directory,
 and `cursorpreviewfmt` applies in panes that preview directories.
 

--- a/doc.go
+++ b/doc.go
@@ -115,6 +115,7 @@ The following options can be used to customize the behavior of lf:
 	autoquit         bool      (default off)
 	cleaner          string    (default '')
 	cursorfmt        string    (default "\033[7m")
+	cursorparentfmt  string    (default "\033[7m")
 	cursorpreviewfmt string    (default "\033[4m")
 	dircache         bool      (default on)
 	dircounts        bool      (default off)
@@ -609,14 +610,17 @@ Five arguments are passed to the file, (1) current file name, (2) width, (3) hei
 Preview clearing is disabled when the value of this option is left empty.
 
 	cursorfmt         string    (default "\033[7m")
+	cursorparentfmt   string    (default "\033[7m")
 	cursorpreviewfmt  string    (default "\033[4m")
 
 Format strings for highlighting the cursor.
-`cursorpreviewfmt` applies in panes that preview directories, and `cursorfmt` applies in all other panes.
+`cursorfmt` applies in the current directory pane,
+`cursorparentfmt` applies in panes that show parents of the current directory,
+and `cursorpreviewfmt` applies in panes that preview directories.
 
-The default is to make the normal cursor inverted and the preview cursor underlined.
+The default is to make the active cursor and the parent directory cursor inverted. The preview cursor is underlined.
 
-Some other possibilities to consider for the preview cursor: an empty string for no cursor, "\033[7;2m" for dimmed inverted text (visibility varies by terminal), "\033[7;90m" for inverted text with grey (aka "brightblack") background.
+Some other possibilities to consider for the preview or parent cursors: an empty string for no cursor, "\033[7;2m" for dimmed inverted text (visibility varies by terminal), "\033[7;90m" for inverted text with grey (aka "brightblack") background.
 
 If the format string contains the characters `%s`, it is interpreted as a format string for `fmt.Sprintf`. Such a string should end with the terminal reset sequence.
 For example, "\033[4m%s\033[0m" has the same effect as "\033[4m".

--- a/docstring.go
+++ b/docstring.go
@@ -118,6 +118,7 @@ The following options can be used to customize the behavior of lf:
     autoquit         bool      (default off)
     cleaner          string    (default '')
     cursorfmt        string    (default "\033[7m")
+    cursorparentfmt  string    (default "\033[7m")
     cursorpreviewfmt string    (default "\033[4m")
     dircache         bool      (default on)
     dircounts        bool      (default off)
@@ -635,17 +636,21 @@ and (5) vertical position of preview pane respectively. Preview clearing is
 disabled when the value of this option is left empty.
 
     cursorfmt         string    (default "\033[7m")
+    cursorparentfmt   string    (default "\033[7m")
     cursorpreviewfmt  string    (default "\033[4m")
 
-Format strings for highlighting the cursor. 'cursorpreviewfmt' applies in panes
-that preview directories, and 'cursorfmt' applies in all other panes.
+Format strings for highlighting the cursor. 'cursorfmt' applies in the current
+directory pane, 'cursorparentfmt' applies in panes that show parents of the
+current directory, and 'cursorpreviewfmt' applies in panes that preview
+directories.
 
-The default is to make the normal cursor inverted and the preview cursor
-underlined.
+The default is to make the active cursor and the parent directory cursor
+inverted. The preview cursor is underlined.
 
-Some other possibilities to consider for the preview cursor: an empty string for
-no cursor, "\033[7;2m" for dimmed inverted text (visibility varies by terminal),
-"\033[7;90m" for inverted text with grey (aka "brightblack") background.
+Some other possibilities to consider for the preview or parent cursors: an empty
+string for no cursor, "\033[7;2m" for dimmed inverted text (visibility varies
+by terminal), "\033[7;90m" for inverted text with grey (aka "brightblack")
+background.
 
 If the format string contains the characters '%s', it is interpreted as a format
 string for 'fmt.Sprintf'. Such a string should end with the terminal reset

--- a/docstring.go
+++ b/docstring.go
@@ -117,7 +117,7 @@ The following options can be used to customize the behavior of lf:
     anchorfind       bool      (default on)
     autoquit         bool      (default off)
     cleaner          string    (default '')
-    cursorfmt        string    (default "\033[7m")
+    cursoractivefmt  string    (default "\033[7m")
     cursorparentfmt  string    (default "\033[7m")
     cursorpreviewfmt string    (default "\033[4m")
     dircache         bool      (default on)
@@ -635,13 +635,13 @@ file, (1) current file name, (2) width, (3) height, (4) horizontal position,
 and (5) vertical position of preview pane respectively. Preview clearing is
 disabled when the value of this option is left empty.
 
-    cursorfmt         string    (default "\033[7m")
+    cursoractivefmt   string    (default "\033[7m")
     cursorparentfmt   string    (default "\033[7m")
     cursorpreviewfmt  string    (default "\033[4m")
 
-Format strings for highlighting the cursor. 'cursorfmt' applies in the current
-directory pane, 'cursorparentfmt' applies in panes that show parents of the
-current directory, and 'cursorpreviewfmt' applies in panes that preview
+Format strings for highlighting the cursor. 'cursoractivefmt' applies in the
+current directory pane, 'cursorparentfmt' applies in panes that show parents
+of the current directory, and 'cursorpreviewfmt' applies in panes that preview
 directories.
 
 The default is to make the active cursor and the parent directory cursor

--- a/eval.go
+++ b/eval.go
@@ -28,6 +28,8 @@ func (e *setExpr) eval(app *app, args []string) {
 		gOpts.autoquit = false
 	case "cursorfmt":
 		gOpts.cursorfmt = e.val
+	case "cursorparentfmt":
+		gOpts.cursorparentfmt = e.val
 	case "cursorpreviewfmt":
 		gOpts.cursorpreviewfmt = e.val
 	case "autoquit!":

--- a/eval.go
+++ b/eval.go
@@ -26,8 +26,8 @@ func (e *setExpr) eval(app *app, args []string) {
 		gOpts.autoquit = true
 	case "noautoquit":
 		gOpts.autoquit = false
-	case "cursorfmt":
-		gOpts.cursorfmt = e.val
+	case "cursoractivefmt":
+		gOpts.cursoractivefmt = e.val
 	case "cursorparentfmt":
 		gOpts.cursorparentfmt = e.val
 	case "cursorpreviewfmt":

--- a/lf.1
+++ b/lf.1
@@ -133,7 +133,7 @@ The following options can be used to customize the behavior of lf:
     anchorfind       bool      (default on)
     autoquit         bool      (default off)
     cleaner          string    (default '')
-    cursorfmt        string    (default "\e033[7m")
+    cursoractivefmt  string    (default "\e033[7m")
     cursorparentfmt  string    (default "\e033[7m")
     cursorpreviewfmt string    (default "\e033[4m")
     dircache         bool      (default on)
@@ -751,12 +751,12 @@ Automatically quit server when there are no clients left connected.
 Set the path of a cleaner file. The file should be executable. This file is called if previewing is enabled, the previewer is set, and the previously selected file had its preview cache disabled. Five arguments are passed to the file, (1) current file name, (2) width, (3) height, (4) horizontal position, and (5) vertical position of preview pane respectively. Preview clearing is disabled when the value of this option is left empty.
 .PP
 .EX
-    cursorfmt         string    (default "\e033[7m")
+    cursoractivefmt   string    (default "\e033[7m")
     cursorparentfmt   string    (default "\e033[7m")
     cursorpreviewfmt  string    (default "\e033[4m")
 .EE
 .PP
-Format strings for highlighting the cursor. `cursorfmt` applies in the current directory pane, `cursorparentfmt` applies in panes that show parents of the current directory, and `cursorpreviewfmt` applies in panes that preview directories.
+Format strings for highlighting the cursor. `cursoractivefmt` applies in the current directory pane, `cursorparentfmt` applies in panes that show parents of the current directory, and `cursorpreviewfmt` applies in panes that preview directories.
 .PP
 The default is to make the active cursor and the parent directory cursor inverted. The preview cursor is underlined.
 .PP

--- a/lf.1
+++ b/lf.1
@@ -134,6 +134,7 @@ The following options can be used to customize the behavior of lf:
     autoquit         bool      (default off)
     cleaner          string    (default '')
     cursorfmt        string    (default "\e033[7m")
+    cursorparentfmt  string    (default "\e033[7m")
     cursorpreviewfmt string    (default "\e033[4m")
     dircache         bool      (default on)
     dircounts        bool      (default off)
@@ -751,14 +752,15 @@ Set the path of a cleaner file. The file should be executable. This file is call
 .PP
 .EX
     cursorfmt         string    (default "\e033[7m")
+    cursorparentfmt   string    (default "\e033[7m")
     cursorpreviewfmt  string    (default "\e033[4m")
 .EE
 .PP
-Format strings for highlighting the cursor. `cursorpreviewfmt` applies in panes that preview directories, and `cursorfmt` applies in all other panes.
+Format strings for highlighting the cursor. `cursorfmt` applies in the current directory pane, `cursorparentfmt` applies in panes that show parents of the current directory, and `cursorpreviewfmt` applies in panes that preview directories.
 .PP
-The default is to make the normal cursor inverted and the preview cursor underlined.
+The default is to make the active cursor and the parent directory cursor inverted. The preview cursor is underlined.
 .PP
-Some other possibilities to consider for the preview cursor: an empty string for no cursor, "\e033[7;2m" for dimmed inverted text (visibility varies by terminal), "\e033[7;90m" for inverted text with grey (aka "brightblack") background.
+Some other possibilities to consider for the preview or parent cursors: an empty string for no cursor, "\e033[7;2m" for dimmed inverted text (visibility varies by terminal), "\e033[7;90m" for inverted text with grey (aka "brightblack") background.
 .PP
 If the format string contains the characters `%s`, it is interpreted as a format string for `fmt.Sprintf`. Such a string should end with the terminal reset sequence. For example, "\e033[4m%s\e033[0m" has the same effect as "\e033[4m".
 .PP

--- a/opts.go
+++ b/opts.go
@@ -30,7 +30,7 @@ type sortType struct {
 var gOpts struct {
 	anchorfind       bool
 	autoquit         bool
-	cursorfmt        string
+	cursoractivefmt  string
 	cursorparentfmt  string
 	cursorpreviewfmt string
 	dircache         bool
@@ -92,7 +92,7 @@ func init() {
 	gOpts.dironly = false
 	gOpts.dirpreviews = false
 	gOpts.drawbox = false
-	gOpts.cursorfmt = "\033[7m"
+	gOpts.cursoractivefmt = "\033[7m"
 	gOpts.cursorparentfmt = "\033[7m"
 	gOpts.cursorpreviewfmt = "\033[4m"
 	gOpts.globsearch = false

--- a/opts.go
+++ b/opts.go
@@ -31,6 +31,7 @@ var gOpts struct {
 	anchorfind       bool
 	autoquit         bool
 	cursorfmt        string
+	cursorparentfmt  string
 	cursorpreviewfmt string
 	dircache         bool
 	dircounts        bool
@@ -92,6 +93,7 @@ func init() {
 	gOpts.dirpreviews = false
 	gOpts.drawbox = false
 	gOpts.cursorfmt = "\033[7m"
+	gOpts.cursorparentfmt = "\033[7m"
 	gOpts.cursorpreviewfmt = "\033[4m"
 	gOpts.globsearch = false
 	gOpts.icons = false

--- a/ui.go
+++ b/ui.go
@@ -330,10 +330,18 @@ type dirContext struct {
 	tags       map[string]string
 }
 
+type dirRole byte
+
+const (
+	Active dirRole = iota
+	Parent
+	Preview
+)
+
 type dirStyle struct {
-	colors     styleMap
-	icons      iconMap
-	previewing bool
+	colors styleMap
+	icons  iconMap
+	role   dirRole
 }
 
 // These colors are not currently customizeable
@@ -353,12 +361,12 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, context *dirContext, dir
 		win.print(screen, 2, 0, messageStyle, "permission denied")
 		return
 	}
-	if (dir.loading && len(dir.files) == 0) || (dirStyle.previewing && dir.loading && gOpts.dirpreviews) {
+	if (dir.loading && len(dir.files) == 0) || (dirStyle.role == Preview && dir.loading && gOpts.dirpreviews) {
 		win.print(screen, 2, 0, messageStyle, "loading...")
 		return
 	}
 
-	if dirStyle.previewing && gOpts.dirpreviews && len(gOpts.previewer) > 0 {
+	if dirStyle.role == Preview && gOpts.dirpreviews && len(gOpts.previewer) > 0 {
 		// Print previewer result instead of default directory print operation.
 		st := tcell.StyleDefault
 		for i, l := range dir.lines {
@@ -475,10 +483,13 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, context *dirContext, dir
 
 		ce := ""
 		if i == dir.pos {
-			if dirStyle.previewing {
-				ce = gOpts.cursorpreviewfmt
-			} else {
+			switch dirStyle.role {
+			case Active:
 				ce = gOpts.cursorfmt
+			case Parent:
+				ce = gOpts.cursorparentfmt
+			case Preview:
+				ce = gOpts.cursorpreviewfmt
 			}
 		}
 		cursorescapefmt := optionToFmtstr(ce)
@@ -920,9 +931,13 @@ func (ui *ui) draw(nav *nav) {
 		wins--
 	}
 	for i := 0; i < wins; i++ {
+		role := Parent
+		if i == wins-1 {
+			role = Active
+		}
 		if dir := ui.dirOfWin(nav, i); dir != nil {
 			ui.wins[i].printDir(ui.screen, dir, &context,
-				&dirStyle{colors: ui.styles, icons: ui.icons, previewing: false})
+				&dirStyle{colors: ui.styles, icons: ui.icons, role: role})
 		}
 	}
 
@@ -958,7 +973,7 @@ func (ui *ui) draw(nav *nav) {
 
 			if curr.IsDir() {
 				preview.printDir(ui.screen, ui.dirPrev, &context,
-					&dirStyle{colors: ui.styles, icons: ui.icons, previewing: true})
+					&dirStyle{colors: ui.styles, icons: ui.icons, role: Preview})
 			} else if curr.Mode().IsRegular() {
 				preview.printReg(ui.screen, ui.regPrev)
 			}

--- a/ui.go
+++ b/ui.go
@@ -485,7 +485,7 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, context *dirContext, dir
 		if i == dir.pos {
 			switch dirStyle.role {
 			case Active:
-				ce = gOpts.cursorfmt
+				ce = gOpts.cursoractivefmt
 			case Parent:
 				ce = gOpts.cursorparentfmt
 			case Preview:


### PR DESCRIPTION
This follows up on https://github.com/gokcehan/lf/pull/1086.

The new `cursorparentfmt` option defaults to the same value as `cursorfmt`, so the default look of `lf` is unchanged. However, I find it useful to make it different in my config, since I seem to have so much trouble figuring out which of my cursors is the active one. :)

For example, here's what it looks like if one has `set cursorparentfmt "\033[7;90m"` in their `lfrc`:

![image](https://user-images.githubusercontent.com/4123047/218299130-09ac411f-307a-489e-a4f0-4691710f8549.png)


-----

In a separate commit, it also seemed appropriate to rename `cursorfmt` into `cursoractivefmt` at the same time, but this can easily be undone.

This PR does nothing to resolve the issue from #1086 where @gokcehan and @laktak weren't very happy with the work "cursor", but if we can come up with a better word, I can rename it here.
