### PR TITLE
Navigate cmd history with up/down by default

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -88,8 +88,8 @@ The following command line commands are provided by lf:
 	cmd-menu-accept
 	cmd-enter                (default '<c-j>' and '<enter>')
 	cmd-interrupt            (default '<c-c>')
-	cmd-history-next         (default '<c-n>')
-	cmd-history-prev         (default '<c-p>')
+	cmd-history-next         (default '<c-n>' and '<down>')
+	cmd-history-prev         (default '<c-p>' and '<up>')
 	cmd-left                 (default '<c-b>' and '<left>')
 	cmd-right                (default '<c-f>' and '<right>')
 	cmd-home                 (default '<c-a>' and '<home>')
@@ -530,8 +530,8 @@ Execute the current line.
 
 Interrupt the current shell-pipe command and return to the normal mode.
 
-	cmd-history-next         (default '<c-n>')
-	cmd-history-prev         (default '<c-p>')
+	cmd-history-next         (default '<c-n>' and '<down>')
+	cmd-history-prev         (default '<c-p>' and '<up>')
 
 Go to next/previous item in the history.
 

--- a/docstring.go
+++ b/docstring.go
@@ -91,8 +91,8 @@ The following command line commands are provided by lf:
     cmd-menu-accept
     cmd-enter                (default '<c-j>' and '<enter>')
     cmd-interrupt            (default '<c-c>')
-    cmd-history-next         (default '<c-n>')
-    cmd-history-prev         (default '<c-p>')
+    cmd-history-next         (default '<c-n>' and '<down>')
+    cmd-history-prev         (default '<c-p>' and '<up>')
     cmd-left                 (default '<c-b>' and '<left>')
     cmd-right                (default '<c-f>' and '<right>')
     cmd-home                 (default '<c-a>' and '<home>')
@@ -554,8 +554,8 @@ Execute the current line.
 
 Interrupt the current shell-pipe command and return to the normal mode.
 
-    cmd-history-next         (default '<c-n>')
-    cmd-history-prev         (default '<c-p>')
+    cmd-history-next         (default '<c-n>' and '<down>')
+    cmd-history-prev         (default '<c-p>' and '<up>')
 
 Go to next/previous item in the history.
 

--- a/lf.1
+++ b/lf.1
@@ -105,8 +105,8 @@ The following command line commands are provided by lf:
     cmd-menu-accept
     cmd-enter                (default '<c-j>' and '<enter>')
     cmd-interrupt            (default '<c-c>')
-    cmd-history-next         (default '<c-n>')
-    cmd-history-prev         (default '<c-p>')
+    cmd-history-next         (default '<c-n>' and '<down>')
+    cmd-history-prev         (default '<c-p>' and '<up>')
     cmd-left                 (default '<c-b>' and '<left>')
     cmd-right                (default '<c-f>' and '<right>')
     cmd-home                 (default '<c-a>' and '<home>')
@@ -650,8 +650,8 @@ Execute the current line.
 Interrupt the current shell-pipe command and return to the normal mode.
 .PP
 .EX
-    cmd-history-next         (default '<c-n>')
-    cmd-history-prev         (default '<c-p>')
+    cmd-history-next         (default '<c-n>' and '<down>')
+    cmd-history-prev         (default '<c-p>' and '<up>')
 .EE
 .PP
 Go to next/previous item in the history.

--- a/opts.go
+++ b/opts.go
@@ -217,7 +217,9 @@ func init() {
 	gOpts.cmdkeys["<tab>"] = &callExpr{"cmd-complete", nil, 1}
 	gOpts.cmdkeys["<enter>"] = &callExpr{"cmd-enter", nil, 1}
 	gOpts.cmdkeys["<c-j>"] = &callExpr{"cmd-enter", nil, 1}
+	gOpts.cmdkeys["<down>"] = &callExpr{"cmd-history-next", nil, 1}
 	gOpts.cmdkeys["<c-n>"] = &callExpr{"cmd-history-next", nil, 1}
+	gOpts.cmdkeys["<up>"] = &callExpr{"cmd-history-prev", nil, 1}
 	gOpts.cmdkeys["<c-p>"] = &callExpr{"cmd-history-prev", nil, 1}
 	gOpts.cmdkeys["<delete>"] = &callExpr{"cmd-delete", nil, 1}
 	gOpts.cmdkeys["<c-d>"] = &callExpr{"cmd-delete", nil, 1}


### PR DESCRIPTION
This makes it possible to navigate history in command mode with the up and down arrow keys, which replicates the behavior of VIM.