### PR TITLE
Update the Go version in `go.mod` to 1.18

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -34,7 +33,7 @@ func run() {
 		defer f.Close()
 		log.SetOutput(f)
 	} else {
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 	}
 
 	log.Print("hi!")

--- a/complete.go
+++ b/complete.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -252,7 +251,7 @@ func matchExec(s string) (matches []string, longest []rune) {
 			continue
 		}
 
-		files, err := ioutil.ReadDir(p)
+		files, err := os.ReadDir(p)
 		if err != nil {
 			log.Printf("reading path: %s", err)
 		}
@@ -262,18 +261,18 @@ func matchExec(s string) (matches []string, longest []rune) {
 				continue
 			}
 
-			f, err = os.Stat(filepath.Join(p, f.Name()))
+			finfo, err := f.Info()
 			if err != nil {
 				log.Printf("getting file information: %s", err)
 				continue
 			}
 
-			if !f.Mode().IsRegular() || !isExecutable(f) {
+			if !finfo.Mode().IsRegular() || !isExecutable(finfo) {
 				continue
 			}
 
-			log.Print(f.Name())
-			words = append(words, f.Name())
+			log.Print(finfo.Name())
+			words = append(words, finfo.Name())
 		}
 	}
 
@@ -306,7 +305,7 @@ func matchFile(s string) (matches []string, longest []rune) {
 
 	dir = filepath.Dir(unescape(dir))
 
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		log.Printf("reading directory: %s", err)
 	}
@@ -424,7 +423,7 @@ func completeFile(acc []rune) (matches []string, longestAcc []rune) {
 		log.Printf("getting current directory: %s", err)
 	}
 
-	files, err := ioutil.ReadDir(wd)
+	files, err := os.ReadDir(wd)
 	if err != nil {
 		log.Printf("reading directory: %s", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,18 @@
 module github.com/gokcehan/lf
 
-go 1.12
+go 1.18
 
 require (
+	github.com/djherbis/times v1.5.0
 	github.com/gdamore/tcell/v2 v2.5.4-0.20221019011350-d3cbfcfb7aa3
 	github.com/mattn/go-runewidth v0.0.14
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
-	github.com/djherbis/times v1.5.0
+)
+
+require (
+	github.com/gdamore/encoding v1.0.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	golang.org/x/text v0.4.0 // indirect
 )

--- a/scan.go
+++ b/scan.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"io"
-	"io/ioutil"
 	"log"
 	"strconv"
 )
@@ -38,7 +37,7 @@ type scanner struct {
 }
 
 func newScanner(r io.Reader) *scanner {
-	buf, err := ioutil.ReadAll(r)
+	buf, err := io.ReadAll(r)
 	if err != nil {
 		log.Printf("scanning: %s", err)
 	}


### PR DESCRIPTION
This requires abandoning use of the `ioutil` module to pass `staticcheck`.

This should be sufficient to let dependabot to update `tcell` to 2.6.0 (at least, I can upgrade it on my machine).

Alternatively, we could upgrade to `tcell 2.5.6` instead of `tcell 2.6.0` which shouldn't require changing the `go.mod` version.