### PR TITLE
Delete stale dircache entry during rename

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -1434,6 +1434,7 @@ func (nav *nav) rename() error {
 		return err
 	}
 
+	delete(nav.regCache, newPath)
 	delete(nav.dirCache, newPath)
 	dir := nav.loadDir(filepath.Dir(newPath))
 

--- a/nav.go
+++ b/nav.go
@@ -1434,6 +1434,10 @@ func (nav *nav) rename() error {
 		return err
 	}
 
+	// It is possible for newPath to already have cache entries if it previously
+	// existed and was deleted. In this case the cache entries should be deleted
+	// before loading newPath to prevent displaying a stale preview. However,
+	// this clears only the current instance of lf, and not any other instances.
 	delete(nav.regCache, newPath)
 	delete(nav.dirCache, newPath)
 	dir := nav.loadDir(filepath.Dir(newPath))

--- a/nav.go
+++ b/nav.go
@@ -1434,6 +1434,7 @@ func (nav *nav) rename() error {
 		return err
 	}
 
+	delete(nav.dirCache, newPath)
 	dir := nav.loadDir(filepath.Dir(newPath))
 
 	if dir.loading {


### PR DESCRIPTION
Fixes #914 

To reproduce the issue:

1. Create `folderA` (with some files inside) and `folderB` (empty)
2. Delete `folderB` (or alternatively rename it to something else)
3. Rename `folderA` to `folderB`

Because there is still an entry in the directory cache for `folderB` for when it previously existed, the renamed directory will be displayed as empty even though it has files inside it. This change deletes `newPath` from the directory cache before loading it during a `rename` command, in case such a stale entry exists.

Some other observations I found:

- `nav.checkDir` (and by extension the `period` setting) reloads a directory if its mtime is later than `loadTime`. But it won't help in this scenario because although `folderA` is renamed, it isn't actually modified (i.e. its contents haven't changed).
- This issue doesn't occur if you copy `folderA` to `folderB`, or create a new `folderB` with some files in it. This is because the mtime of the newly created `folderB` will be new enough to ensure that it will be reloaded via `nav.checkDir`.