### PR TITLE
Remove commented code

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -534,7 +534,6 @@ func (nav *nav) addJumpList() {
 }
 
 func (nav *nav) cdJumpListPrev() {
-	// currPath := nav.currDir().path
 	if nav.jumpListInd > 0 {
 		nav.jumpListInd -= 1
 		nav.cd(nav.jumpList[nav.jumpListInd])


### PR DESCRIPTION
Seems to have been accidentally introduced in [375133e](https://github.com/gokcehan/lf/commit/375133e4834c9173a18698387d60ebe3cec5b079#diff-709f5e973a2336a6ffa87ae2b743b4a850de2c5c4c61e68a2cb0efc5352db00bR511), probably when copying/pasting code.