### PR TITLE
try to fix #916: add `maps` to show all mappings

### DIFF
--- a/app.go
+++ b/app.go
@@ -471,6 +471,10 @@ func (app *app) loop() {
 	}
 }
 
+type cleanFunc func()
+
+var noopCleanFunc = func() {}
+
 // This function is used to run a shell command. Modes are as follows:
 //
 //	Prefix  Wait  Async  Stdin  Stdout  Stderr  UI action
@@ -478,7 +482,8 @@ func (app *app) loop() {
 //	%       No    No     Yes    Yes     Yes     Statline for input/output
 //	!       Yes   No     Yes    Yes     Yes     Pause and then resume
 //	&       No    Yes    No     No      No      Do nothing
-func (app *app) runShell(s string, args []string, prefix string) {
+//	$|      No    No     Pipe   Yes     Yes     Pause, Pipe execute, return cleanup to resume
+func (app *app) runShell(s string, args []string, prefix string) cleanFunc {
 	app.nav.exportFiles()
 	app.ui.exportSizes()
 	exportOpts()
@@ -488,6 +493,24 @@ func (app *app) runShell(s string, args []string, prefix string) {
 	var out io.Reader
 	var err error
 	switch prefix {
+	case "$|":
+		var stdin io.WriteCloser
+		stdin, err = cmd.StdinPipe()
+		if err != nil {
+			log.Printf("writing stdin: %s", err)
+		}
+		app.cmdIn = stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		app.nav.previewChan <- ""
+		app.nav.dirPreviewChan <- nil
+
+		if err := app.ui.suspend(); err != nil {
+			log.Printf("suspend: %s", err)
+		}
+
+		err = cmd.Start()
 	case "$", "!":
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
@@ -512,7 +535,7 @@ func (app *app) runShell(s string, args []string, prefix string) {
 	case "%":
 		shellSetPG(cmd)
 		if app.ui.cmdPrefix == ">" {
-			return
+			return noopCleanFunc
 		}
 		stdin, err := cmd.StdinPipe()
 		if err != nil {
@@ -585,5 +608,17 @@ func (app *app) runShell(s string, args []string, prefix string) {
 				log.Printf("running shell: %s", err)
 			}
 		}()
+	case "$|":
+		return func() {
+			if err := cmd.Wait(); err != nil {
+				log.Printf("running shell: %s", err)
+			}
+			app.nav.renew()
+			if err := app.ui.resume(); err != nil {
+				app.quit()
+				os.Exit(3)
+			}
+		}
 	}
+	return noopCleanFunc
 }

--- a/complete.go
+++ b/complete.go
@@ -12,6 +12,7 @@ var (
 	gCmdWords = []string{
 		"set",
 		"map",
+		"maps",
 		"cmap",
 		"cmd",
 		"quit",

--- a/doc.go
+++ b/doc.go
@@ -79,6 +79,7 @@ The following commands are provided by lf:
 	mark-remove    (modal)   (default '"')
 	tag
 	tag-toggle               (default 't')
+	maps
 
 The following command line commands are provided by lf:
 
@@ -599,6 +600,10 @@ Delete the next word in forward direction.
 	cmd-lowercase-word       (default '<a-l>')
 
 Capitalize/uppercase/lowercase the current word and jump to the next word.
+
+	maps
+
+List all key mappings.
 
 # Options
 

--- a/docstring.go
+++ b/docstring.go
@@ -82,6 +82,7 @@ The following commands are provided by lf:
     mark-remove    (modal)   (default '"')
     tag
     tag-toggle               (default 't')
+    maps
 
 The following command line commands are provided by lf:
 
@@ -626,6 +627,10 @@ Delete the next word in forward direction.
     cmd-lowercase-word       (default '<a-l>')
 
 Capitalize/uppercase/lowercase the current word and jump to the next word.
+
+    maps
+
+List all key mappings.
 
 # Options
 

--- a/eval.go
+++ b/eval.go
@@ -2076,6 +2076,11 @@ func (e *callExpr) eval(app *app, args []string) {
 
 		app.ui.cmdAccLeft = acc
 		update(app)
+	case "maps":
+		cleanUp := app.runShell("$PAGER", nil, "$|")
+		io.Copy(app.cmdIn, listBinds(gOpts.keys))
+		app.cmdIn.Close()
+		cleanUp()
 	default:
 		cmd, ok := gOpts.cmds[e.name]
 		if !ok {

--- a/lf.1
+++ b/lf.1
@@ -94,6 +94,7 @@ The following commands are provided by lf:
     mark-remove    (modal)   (default '"')
     tag
     tag-toggle               (default 't')
+    maps
 .EE
 .PP
 The following command line commands are provided by lf:
@@ -740,6 +741,12 @@ Delete the next word in forward direction.
 .EE
 .PP
 Capitalize/uppercase/lowercase the current word and jump to the next word.
+.PP
+.EX
+    maps
+.EE
+.PP
+List all key mappings.
 .SH OPTIONS
 This section shows information about options to customize the behavior. Character ':' is used as the separator for list options '[]int' and '[]string'.
 .PP


### PR DESCRIPTION
I know there is a previous effort at #918 . I took the stdio suggestion. I think this opens up doors for other internal state to be echo'ed easily, e.g. copy/cut buffers, selections etc