### PR TITLE
Update file info after reload command

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -1312,7 +1312,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			app.ui.echoerrf("reload: %s", err)
 		}
 		app.ui.loadFile(app, true)
-		app.ui.loadFileInfo(app.nav)
+		app.ui.msg = ""
 	case "read":
 		if app.ui.cmdPrefix == ">" {
 			return

--- a/eval.go
+++ b/eval.go
@@ -1312,6 +1312,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			app.ui.echoerrf("reload: %s", err)
 		}
 		app.ui.loadFile(app, true)
+		// clear file information, will be loaded asynchronously
 		app.ui.msg = ""
 	case "read":
 		if app.ui.cmdPrefix == ">" {


### PR DESCRIPTION
Fixes #1087 

To reproduce the issue:

1. Open `lf` and select a file
2. Start a new terminal, and use `chmod` to change the file permissions
3. Go back to `lf` and run the `reload` command

The current behaviour is that although `reload` does load the new file info (asynchronously), it isn't displayed because of the following condition: https://github.com/gokcehan/lf/blob/3fc1db5d1426d417869857d4b6cf090f05d73d26/app.go#L417-L419

It turns out that this code was added to display the file info when starting up, see #994. So just after the `reload` command, I clear `app.ui.msg` to create a similar situation.

I also considered just removing the `if app.ui.msg == ""` condition during the asynchronous reload, but that could cause issues like clearing out error messages at unexpected times.