### PR TITLE
Refactor code for printing directories

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -444,12 +444,9 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, context *dirContext, dir
 
 		s = append(s, ' ')
 
-		var iwidth int
-
 		if gOpts.icons {
 			s = append(s, []rune(dirStyle.icons.get(f))...)
 			s = append(s, ' ')
-			iwidth = 2
 		}
 
 		for _, r := range f.Name() {
@@ -458,23 +455,30 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, context *dirContext, dir
 
 		w := runeSliceWidth(s)
 
-		if w > win.w-3 {
-			s = runeSliceWidthRange(s, 0, win.w-4)
+		// make space for select marker, and leave another space at the end
+		maxlength := win.w - lnwidth - 2
+		// make extra space to separate windows if drawbox is not enabled
+		if !gOpts.drawbox {
+			maxlength -= 1
+		}
+
+		if w > maxlength {
+			s = runeSliceWidthRange(s, 0, maxlength-1)
 			s = append(s, []rune(gOpts.truncatechar)...)
 		} else {
-			for i := 0; i < win.w-3-w; i++ {
+			for i := 0; i < maxlength-w; i++ {
 				s = append(s, ' ')
 			}
 		}
 
 		info := fileInfo(f, dir)
 
-		if len(info) > 0 && win.w-lnwidth-iwidth-2 > 2*len(info) {
-			if win.w-2 > w+len(info) {
-				s = runeSliceWidthRange(s, 0, win.w-3-len(info)-lnwidth)
-			} else {
-				s = runeSliceWidthRange(s, 0, win.w-4-len(info)-lnwidth)
+		if len(info) > 0 && 2*len(info) < maxlength {
+			if w+len(info) > maxlength {
+				s = runeSliceWidthRange(s, 0, maxlength-len(info)-1)
 				s = append(s, []rune(gOpts.truncatechar)...)
+			} else {
+				s = runeSliceWidthRange(s, 0, maxlength-len(info))
 			}
 			for _, r := range info {
 				s = append(s, r)
@@ -518,16 +522,16 @@ func getWidths(wtot int) []int {
 	wlen := len(gOpts.ratios)
 	widths := make([]int, wlen)
 
+	if gOpts.drawbox {
+		wtot -= (wlen + 1)
+	}
+
 	wsum := 0
 	for i := 0; i < wlen-1; i++ {
 		widths[i] = gOpts.ratios[i] * wtot / rsum
 		wsum += widths[i]
 	}
 	widths[wlen-1] = wtot - wsum
-
-	if gOpts.drawbox {
-		widths[wlen-1]--
-	}
 
 	return widths
 }
@@ -543,7 +547,8 @@ func getWins(screen tcell.Screen) []*win {
 	wlen := len(widths)
 	for i := 0; i < wlen; i++ {
 		if gOpts.drawbox {
-			wins = append(wins, newWin(widths[i], htot-4, wacc+1, 2))
+			wacc++
+			wins = append(wins, newWin(widths[i], htot-4, wacc, 2))
 		} else {
 			wins = append(wins, newWin(widths[i], htot-2, wacc, 1))
 		}
@@ -627,21 +632,9 @@ func (ui *ui) pollEvents() {
 }
 
 func (ui *ui) renew() {
+	ui.wins = getWins(ui.screen)
+
 	wtot, htot := ui.screen.Size()
-
-	widths := getWidths(wtot)
-
-	wacc := 0
-	wlen := len(widths)
-	for i := 0; i < wlen; i++ {
-		if gOpts.drawbox {
-			ui.wins[i].renew(widths[i], htot-4, wacc+1, 2)
-		} else {
-			ui.wins[i].renew(widths[i], htot-2, wacc, 1)
-		}
-		wacc += widths[i]
-	}
-
 	ui.promptWin.renew(wtot, 1, 0, 0)
 	ui.msgWin.renew(wtot, 1, 0, htot-1)
 	ui.menuWin.renew(wtot, 1, 0, htot-2)
@@ -892,7 +885,7 @@ func (ui *ui) drawBox() {
 
 	wacc := 0
 	for wind := 0; wind < len(ui.wins)-1; wind++ {
-		wacc += ui.wins[wind].w
+		wacc += ui.wins[wind].w + 1
 		ui.screen.SetContent(wacc, 1, '┬', nil, st)
 		for i := 2; i < h-2; i++ {
 			ui.screen.SetContent(wacc, i, '│', nil, st)


### PR DESCRIPTION
Fixes #602, Fixes #889

Changes:
- Calculate window width correctly when `drawbox` is enabled. For example, the default configuration contains three windows (shaped like `| 1 | 2 | 3 |`), so four spaces needs to be subtracted from the screen width, but the current implementation only subtracts one space from the last window.
- The `renew` function now calls `getWins` directly, instead of executing its own code which does the same thing.
- A `maxlength` variable is defined to indicate the maximum amount of space for displaying a filename, including the icon, the filename itself and the file info. This is the space left over from the window width after subtracting the space for line numbers and the select marker.

I have tested this using various combinations of settings including `drawbox`, `number`, `relativenumber` and `icons`. I would appreciate it if anyone else has the time to test this as well.