### PR TITLE
Fix width used for line numbers

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -398,7 +398,7 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, context *dirContext, dir
 		if gOpts.number && gOpts.relativenumber {
 			lnwidth++
 		}
-		for j := 10; j < len(dir.files); j *= 10 {
+		for j := 10; j <= len(dir.files); j *= 10 {
 			lnwidth++
 		}
 		lnformat = fmt.Sprintf("%%%d.d ", lnwidth)


### PR DESCRIPTION
To reproduce the issue:

1. Ensure that you are in a directory containing **exactly** 10 files
2. Start `lf` and enable the `number` option to display line numbers
3. Navigate to the 10th file at the bottom
4. Select the file using `toggle`

The select marker overlaps with the line number because there isn't enough space is allocated for it.