### PR TITLE
Enhance rename prompt

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -1925,7 +1925,7 @@ func (e *callExpr) eval(app *app, args []string) {
 				// no extension or .hidden
 				app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(curr.Name())...)
 			} else {
-				app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(curr.Name()[:len(extension)])...)
+				app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(curr.Name()[:len(extension)-1])...)
 				app.ui.cmdAccRight = append(app.ui.cmdAccRight, []rune(extension)...)
 			}
 		}

--- a/eval.go
+++ b/eval.go
@@ -1926,7 +1926,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			} else if len(e.args) == 1 && e.args[0] == "ext" {
 				dotidx := strings.LastIndex(curr.Name(), ".")
 				if dotidx < 1 {
-			app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(curr.Name())...)
+					app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(curr.Name())...)
 				} else {
 					app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(curr.Name()[:dotidx])...)
 					app.ui.cmdAccRight = append(app.ui.cmdAccRight, []rune(curr.Name()[dotidx:])...)

--- a/eval.go
+++ b/eval.go
@@ -1920,7 +1920,22 @@ func (e *callExpr) eval(app *app, args []string) {
 			}
 			normal(app)
 			app.ui.cmdPrefix = "rename: "
+
+			if len(e.args) == 1 && e.args[0] == "start" {
+				app.ui.cmdAccRight = append(app.ui.cmdAccRight, []rune(curr.Name())...)
+			} else if len(e.args) == 1 && e.args[0] == "ext" {
+				dotidx := strings.LastIndex(curr.Name(), ".")
+				if dotidx < 1 {
 			app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(curr.Name())...)
+				} else {
+					app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(curr.Name()[:dotidx])...)
+					app.ui.cmdAccRight = append(app.ui.cmdAccRight, []rune(curr.Name()[dotidx:])...)
+				}
+			} else if len(e.args) == 1 && e.args[0] == "cw" {
+				// user types whole word
+			} else {
+				app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(curr.Name())...)
+			}
 		}
 		app.ui.loadFile(app, true)
 		app.ui.loadFileInfo(app.nav)

--- a/eval.go
+++ b/eval.go
@@ -1920,21 +1920,13 @@ func (e *callExpr) eval(app *app, args []string) {
 			}
 			normal(app)
 			app.ui.cmdPrefix = "rename: "
-
-			if len(e.args) == 1 && e.args[0] == "start" {
-				app.ui.cmdAccRight = append(app.ui.cmdAccRight, []rune(curr.Name())...)
-			} else if len(e.args) == 1 && e.args[0] == "ext" {
-				dotidx := strings.LastIndex(curr.Name(), ".")
-				if dotidx < 1 {
-					app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(curr.Name())...)
-				} else {
-					app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(curr.Name()[:dotidx])...)
-					app.ui.cmdAccRight = append(app.ui.cmdAccRight, []rune(curr.Name()[dotidx:])...)
-				}
-			} else if len(e.args) == 1 && e.args[0] == "cw" {
-				// user types whole word
-			} else {
+			extension := filepath.Ext(curr.Name())
+			if len(extension) == 0 || extension == curr.Name() {
+				// no extension or .hidden
 				app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(curr.Name())...)
+			} else {
+				app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(curr.Name()[:len(extension)])...)
+				app.ui.cmdAccRight = append(app.ui.cmdAccRight, []rune(extension)...)
 			}
 		}
 		app.ui.loadFile(app, true)

--- a/eval.go
+++ b/eval.go
@@ -1925,7 +1925,7 @@ func (e *callExpr) eval(app *app, args []string) {
 				// no extension or .hidden
 				app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(curr.Name())...)
 			} else {
-				app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(curr.Name()[:len(extension)-1])...)
+				app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(curr.Name()[:len(curr.Name())-len(extension)])...)
 				app.ui.cmdAccRight = append(app.ui.cmdAccRight, []rune(extension)...)
 			}
 		}


### PR DESCRIPTION
Argument for `rename` to work like this:

```
map r rename       # original rename
map i rename start # place the cursor at the beginning
map a rename ext   # place the cursor on the last .
map w rename cw    # no original name in prompt
```