### PR TITLE
Avoid refreshing previews for async shell commands

### DIFF
--- a/app.go
+++ b/app.go
@@ -563,7 +563,11 @@ func (app *app) runShell(s string, args []string, prefix string) cleanFunc {
 		anyKey()
 	}
 
-	app.ui.loadFile(app, true)
+	// Asynchronous shell invocations return immediately without waiting for the
+	// command to finish, so there is no point refreshing the preview if nothing
+	// has changed yet.
+	volatile := prefix != "&"
+	app.ui.loadFile(app, volatile)
 
 	switch prefix {
 	case "%":


### PR DESCRIPTION
This pull request addresses a user complaint where previews are redrawn when opening a file, see https://github.com/gokcehan/lf/issues/414#issuecomment-1468557109 for more details.

I think this issue probably extends to running any other asynchronous shell commands which could take a while to complete (e.g. `tar`), and when this happens there is no point refreshing the preview immediately because the command would not have completed yet.