### PR TITLE
Display zero when relativenumber is enabled

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -395,7 +395,6 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, context *dirContext, dir
 	}
 
 	var lnwidth int
-	var lnformat string
 
 	if gOpts.number || gOpts.relativenumber {
 		lnwidth = 1
@@ -405,7 +404,6 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, context *dirContext, dir
 		for j := 10; j <= len(dir.files); j *= 10 {
 			lnwidth++
 		}
-		lnformat = fmt.Sprintf("%%%d.d ", lnwidth)
 	}
 
 	for i, f := range dir.files[beg:end] {
@@ -415,17 +413,17 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, context *dirContext, dir
 			var ln string
 
 			if gOpts.number && (!gOpts.relativenumber) {
-				ln = fmt.Sprintf(lnformat, i+1+beg)
+				ln = fmt.Sprintf("%*d", lnwidth, i+1+beg)
 			} else if gOpts.relativenumber {
 				switch {
 				case i < dir.pos:
-					ln = fmt.Sprintf(lnformat, dir.pos-i)
+					ln = fmt.Sprintf("%*d", lnwidth, dir.pos-i)
 				case i > dir.pos:
-					ln = fmt.Sprintf(lnformat, i-dir.pos)
+					ln = fmt.Sprintf("%*d", lnwidth, i-dir.pos)
 				case gOpts.number:
-					ln = fmt.Sprintf(fmt.Sprintf("%%%d.d ", lnwidth-1), i+1+beg)
+					ln = fmt.Sprintf("%*d ", lnwidth-1, i+1+beg)
 				default:
-					ln = ""
+					ln = fmt.Sprintf("%*d", lnwidth, 0)
 				}
 			}
 


### PR DESCRIPTION
Regarding the formatting of line numbers, I think it's simpler and more readable to just pass in `lnwidth` as an argument to the format specifier, as opposed to building an intermediary format string.

Also I don't think it's necessary to specify precision for integers, so I have removed it. In fact, this was probably why the original pull request #133 didn't display a zero when `relativenumber` is enabled - I have found that `fmt.Sprintf("[%1d]", 0)` results in `[0]` while `fmt.Sprintf("[%1.d]", 0)` results in `[ ]`.