### PR TITLE
Make the `:doc` command work even if `lf` is not in the PATH, add `lf` environment variable

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -927,19 +927,23 @@ For example, with POSIX shells, you can use '[ -n "$LF_LEVEL" ] && PS1="$PS1""(l
 
 	OPENER
 
-If this variable is set in the environment, use the same value, otherwise set the value to 'start' in Windows, 'open' in MacOS, 'xdg-open' in others.
+If this variable is set in the environment, use the same value. Otherwise, this is set to 'start' in Windows, 'open' in MacOS, 'xdg-open' in others.
 
 	EDITOR
 
-If this variable is set in the environment, use the same value, otherwise set the value to 'vi' on Unix, 'notepad' in Windows.
+If this variable is set in the environment, use the same value. Otherwise, this is set to 'vi' on Unix, 'notepad' in Windows.
 
 	PAGER
 
-If this variable is set in the environment, use the same value, otherwise set the value to 'less' on Unix, 'more' in Windows.
+If this variable is set in the environment, use the same value. Otherwise, this is set to 'less' on Unix, 'more' in Windows.
 
 	SHELL
 
-If this variable is set in the environment, use the same value, otherwise set the value to 'sh' on Unix, 'cmd' in Windows.
+If this variable is set in the environment, use the same value. Otherwise, this is set to 'sh' on Unix, 'cmd' in Windows.
+
+	lf
+
+Absolute path to the currently running lf binary, if it can be found. Otherwise, this is set to the string 'lf'.
 
 	lf_{option}
 

--- a/docstring.go
+++ b/docstring.go
@@ -990,23 +990,28 @@ $LF_LEVEL) "' in your shell configuration file (e.g. '~/.bashrc').
 
     OPENER
 
-If this variable is set in the environment, use the same value, otherwise set
-the value to 'start' in Windows, 'open' in MacOS, 'xdg-open' in others.
+If this variable is set in the environment, use the same value. Otherwise,
+this is set to 'start' in Windows, 'open' in MacOS, 'xdg-open' in others.
 
     EDITOR
 
-If this variable is set in the environment, use the same value, otherwise set
-the value to 'vi' on Unix, 'notepad' in Windows.
+If this variable is set in the environment, use the same value. Otherwise,
+this is set to 'vi' on Unix, 'notepad' in Windows.
 
     PAGER
 
-If this variable is set in the environment, use the same value, otherwise set
-the value to 'less' on Unix, 'more' in Windows.
+If this variable is set in the environment, use the same value. Otherwise,
+this is set to 'less' on Unix, 'more' in Windows.
 
     SHELL
 
-If this variable is set in the environment, use the same value, otherwise set
-the value to 'sh' on Unix, 'cmd' in Windows.
+If this variable is set in the environment, use the same value. Otherwise,
+this is set to 'sh' on Unix, 'cmd' in Windows.
+
+    lf
+
+Absolute path to the currently running lf binary, if it can be found. Otherwise,
+this is set to the string 'lf'.
 
     lf_{option}
 

--- a/lf.1
+++ b/lf.1
@@ -1122,25 +1122,31 @@ The value of this variable is set to the current nesting level when you run lf f
     OPENER
 .EE
 .PP
-If this variable is set in the environment, use the same value, otherwise set the value to 'start' in Windows, 'open' in MacOS, 'xdg-open' in others.
+If this variable is set in the environment, use the same value. Otherwise, this is set to 'start' in Windows, 'open' in MacOS, 'xdg-open' in others.
 .PP
 .EX
     EDITOR
 .EE
 .PP
-If this variable is set in the environment, use the same value, otherwise set the value to 'vi' on Unix, 'notepad' in Windows.
+If this variable is set in the environment, use the same value. Otherwise, this is set to 'vi' on Unix, 'notepad' in Windows.
 .PP
 .EX
     PAGER
 .EE
 .PP
-If this variable is set in the environment, use the same value, otherwise set the value to 'less' on Unix, 'more' in Windows.
+If this variable is set in the environment, use the same value. Otherwise, this is set to 'less' on Unix, 'more' in Windows.
 .PP
 .EX
     SHELL
 .EE
 .PP
-If this variable is set in the environment, use the same value, otherwise set the value to 'sh' on Unix, 'cmd' in Windows.
+If this variable is set in the environment, use the same value. Otherwise, this is set to 'sh' on Unix, 'cmd' in Windows.
+.PP
+.EX
+    lf
+.EE
+.PP
+Absolute path to the currently running lf binary, if it can be found. Otherwise, this is set to the string 'lf'.
 .PP
 .EX
     lf_{option}

--- a/main.go
+++ b/main.go
@@ -79,6 +79,13 @@ func exportEnvVars() {
 	level++
 
 	os.Setenv("LF_LEVEL", strconv.Itoa(level))
+
+	lfPath, err := os.Executable()
+	if err != nil {
+		log.Printf("getting path to lf binary: %s", err)
+		lfPath = "lf"
+	}
+	os.Setenv("lf", lfPath)
 }
 
 // used by exportOpts below

--- a/os.go
+++ b/os.go
@@ -159,7 +159,7 @@ func setDefaults() {
 	gOpts.keys["i"] = &execExpr{"$", `$PAGER "$f"`}
 	gOpts.keys["w"] = &execExpr{"$", "$SHELL"}
 
-	gOpts.cmds["doc"] = &execExpr{"$", "lf -doc | $PAGER"}
+	gOpts.cmds["doc"] = &execExpr{"$", `"$lf" -doc | $PAGER`}
 	gOpts.keys["<f-1>"] = &callExpr{"doc", nil, 1}
 }
 

--- a/os_windows.go
+++ b/os_windows.go
@@ -115,7 +115,7 @@ func setDefaults() {
 	gOpts.keys["i"] = &execExpr{"!", "%PAGER% %f%"}
 	gOpts.keys["w"] = &execExpr{"$", "%SHELL%"}
 
-	gOpts.cmds["doc"] = &execExpr{"!", "lf -doc | %PAGER%"}
+	gOpts.cmds["doc"] = &execExpr{"!", "%lf% -doc | %PAGER%"}
 	gOpts.keys["<f-1>"] = &callExpr{"doc", nil, 1}
 }
 


### PR DESCRIPTION
This makes `lf` export a new environment variable named `lf` with the path to the `lf` binary. So, scripts can use `$lf` instead of `lf` and work even in `lf` is not in the path.

The `:doc` command now executes  `$lf -doc` (or `%lf% -doc` on Windows) instead of `lf -doc`. **I'd appreciate it if somebody could double-check that this works on Windows.**

If Go fails to find a path to the lf binary, `$lf` is set to the string `lf` so that it still works if `lf` is in the PATH. (Though, from looking at the source briefly, Go might already look in the path if it couldn't find the binary normally)

Before this change, `:doc` did not work if `lf` is not in the PATH. This is likely to be a problem for new users who are trying out `lf` and need docs the most.

Moreover, if a developer makes some changes to the docs and runs `lf` with `go run .`, `:doc` would previously return the docs for the version of `lf` in the PATH (if any) instead of what is expected.

-------------------------

Another motivation for this is to make adding command-line options like `lf -buffers` (see https://github.com/gokcehan/lf/pull/1152#discussion_r1148463704) or `lf -marks`, if we decide it's a good idea in the future, work regardless of whether lf is in the PATH.
