### PR TITLE
Support custom line number colors

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -194,6 +194,7 @@ var (
 		"history",
 		"ifs",
 		"info",
+		"numberfmt",
 		"previewer",
 		"cleaner",
 		"promptfmt",

--- a/doc.go
+++ b/doc.go
@@ -143,6 +143,7 @@ The following options can be used to customize the behavior of lf:
 	infotimefmtold   string    (default 'Jan _2  2006')
 	mouse            bool      (default false)
 	number           bool      (default false)
+	numberfmt        string    (default "\033[33m")
 	period           int       (default 0)
 	preview          bool      (default true)
 	previewer        string    (default '')
@@ -760,6 +761,10 @@ Send mouse events as input.
 
 Show the position number for directory items at the left side of pane.
 When 'relativenumber' option is enabled, only the current line shows the absolute position and relative positions are shown for the rest.
+
+	numberfmt      string    (default "\033[33m")
+
+Format string of the position number for each line.
 
 	period         int       (default 0)
 

--- a/docstring.go
+++ b/docstring.go
@@ -146,6 +146,7 @@ The following options can be used to customize the behavior of lf:
     infotimefmtold   string    (default 'Jan _2  2006')
     mouse            bool      (default false)
     number           bool      (default false)
+    numberfmt        string    (default "\033[33m")
     period           int       (default 0)
     preview          bool      (default true)
     previewer        string    (default '')
@@ -806,6 +807,10 @@ Send mouse events as input.
 Show the position number for directory items at the left side of pane. When
 'relativenumber' option is enabled, only the current line shows the absolute
 position and relative positions are shown for the rest.
+
+    numberfmt      string    (default "\033[33m")
+
+Format string of the position number for each line.
 
     period         int       (default 0)
 

--- a/eval.go
+++ b/eval.go
@@ -731,6 +731,8 @@ func (e *setExpr) eval(app *app, args []string) {
 			return
 		}
 		gOpts.smartdia = false
+	case "numberfmt":
+		gOpts.numberfmt = e.val
 	case "smartdia!":
 		if e.val != "" {
 			app.ui.echoerrf("smartdia!: unexpected value: %s", e.val)

--- a/eval.go
+++ b/eval.go
@@ -543,6 +543,8 @@ func (e *setExpr) eval(app *app, args []string) {
 			return
 		}
 		gOpts.number = !gOpts.number
+	case "numberfmt":
+		gOpts.numberfmt = e.val
 	case "period":
 		n, err := strconv.Atoi(e.val)
 		if err != nil {
@@ -731,8 +733,6 @@ func (e *setExpr) eval(app *app, args []string) {
 			return
 		}
 		gOpts.smartdia = false
-	case "numberfmt":
-		gOpts.numberfmt = e.val
 	case "smartdia!":
 		if e.val != "" {
 			app.ui.echoerrf("smartdia!: unexpected value: %s", e.val)

--- a/lf.1
+++ b/lf.1
@@ -162,6 +162,7 @@ The following options can be used to customize the behavior of lf:
     infotimefmtold   string    (default 'Jan _2  2006')
     mouse            bool      (default false)
     number           bool      (default false)
+    numberfmt        string    (default "\e033[33m")
     period           int       (default 0)
     preview          bool      (default true)
     previewer        string    (default '')
@@ -927,6 +928,12 @@ Send mouse events as input.
 .EE
 .PP
 Show the position number for directory items at the left side of pane. When 'relativenumber' option is enabled, only the current line shows the absolute position and relative positions are shown for the rest.
+.PP
+.EX
+    numberfmt      string    (default "\e033[33m")
+.EE
+.PP
+Format string of the position number for each line.
 .PP
 .EX
     period         int       (default 0)

--- a/opts.go
+++ b/opts.go
@@ -81,6 +81,7 @@ var gOpts struct {
 	user             map[string]string
 	sortType         sortType
 	tempmarks        string
+	numberfmt        string
 	tagfmt           string
 }
 
@@ -134,6 +135,7 @@ func init() {
 	gOpts.shellopts = nil
 	gOpts.sortType = sortType{naturalSort, dirfirstSort}
 	gOpts.tempmarks = "'"
+	gOpts.numberfmt = "\033[33m"
 	gOpts.tagfmt = "\033[31m"
 
 	gOpts.keys = make(map[string]expr)

--- a/ui.go
+++ b/ui.go
@@ -347,7 +347,6 @@ type dirStyle struct {
 }
 
 // These colors are not currently customizeable
-const LineNumberColor = tcell.ColorOlive
 const SelectionColor = tcell.ColorPurple
 const YankColor = tcell.ColorOlive
 const CutColor = tcell.ColorMaroon
@@ -427,7 +426,7 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, context *dirContext, dir
 				}
 			}
 
-			win.print(screen, 0, i, tcell.StyleDefault.Foreground(LineNumberColor), ln)
+			win.print(screen, 0, i, tcell.StyleDefault, fmt.Sprintf(optionToFmtstr(gOpts.numberfmt), ln))
 		}
 
 		path := filepath.Join(dir.path, f.Name())


### PR DESCRIPTION
Fixes #920 

Add a `numberfmt` option for allowing users customise the line number color. The implementation is identical to the existing `tagfmt` option.

Vim allows for even more fine-grained customisation, allowing the user to specify separate colors for the current line, and also lines above and below, but I decided for now to just keep things simple and have everything the same color.