### PR TITLE
Add native 'mkdir' command.

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -55,6 +55,7 @@ var (
 		"cd",
 		"select",
 		"delete",
+		"mkdir",
 		"rename",
 		"source",
 		"push",

--- a/doc.go
+++ b/doc.go
@@ -56,7 +56,7 @@ The following commands are provided by lf:
 	cd
 	select
 	delete         (modal)
-	mkdir          (modal)   (default 'n')
+	mkdir          (modal)   (default 'a')
 	rename         (modal)   (default 'r')
 	source
 	push

--- a/doc.go
+++ b/doc.go
@@ -16,71 +16,71 @@ You can run 'lf -help' to see descriptions of command line options.
 
 The following commands are provided by lf:
 
-		quit                     (default 'q')
-		up                       (default 'k' and '<up>')
-		half-up                  (default '<c-u>')
-		page-up                  (default '<c-b>' and '<pgup>')
-		scroll-up                (default '<c-y>')
-		down                     (default 'j' and '<down>')
-		half-down                (default '<c-d>')
-		page-down                (default '<c-f>' and '<pgdn>')
-		scroll-down              (default '<c-e>')
-		updir                    (default 'h' and '<left>')
-		open                     (default 'l' and '<right>')
-		jump-next                (default ']')
-		jump-prev                (default '[')
-		top                      (default 'gg' and '<home>')
-		bottom                   (default 'G' and '<end>')
-		high                     (default 'H')
-		middle                   (default 'M')
-		low                      (default 'L')
-		toggle
-		invert                   (default 'v')
-		invert-below
-		unselect                 (default 'u')
-		glob-select
-		glob-unselect
-		calcdirsize
-		copy                     (default 'y')
-		cut                      (default 'd')
-		paste                    (default 'p')
-		clear                    (default 'c')
-		sync
-		draw
-		redraw                   (default '<c-l>')
-		load
-		reload                   (default '<c-r>')
-		echo
-		echomsg
-		echoerr
-		cd
-		select
-		delete         (modal)
-	    mkdir          (modal)   (default 'n')
-		rename         (modal)   (default 'r')
-		source
-		push
-		read           (modal)   (default ':')
-		shell          (modal)   (default '$')
-		shell-pipe     (modal)   (default '%')
-		shell-wait     (modal)   (default '!')
-		shell-async    (modal)   (default '&')
-		find           (modal)   (default 'f')
-		find-back      (modal)   (default 'F')
-		find-next                (default ';')
-		find-prev                (default ',')
-		search         (modal)   (default '/')
-		search-back    (modal)   (default '?')
-		search-next              (default 'n')
-		search-prev              (default 'N')
-		filter         (modal)
-		setfilter
-		mark-save      (modal)   (default 'm')
-		mark-load      (modal)   (default "'")
-		mark-remove    (modal)   (default '"')
-		tag
-		tag-toggle               (default 't')
-		maps
+	quit                     (default 'q')
+	up                       (default 'k' and '<up>')
+	half-up                  (default '<c-u>')
+	page-up                  (default '<c-b>' and '<pgup>')
+	scroll-up                (default '<c-y>')
+	down                     (default 'j' and '<down>')
+	half-down                (default '<c-d>')
+	page-down                (default '<c-f>' and '<pgdn>')
+	scroll-down              (default '<c-e>')
+	updir                    (default 'h' and '<left>')
+	open                     (default 'l' and '<right>')
+	jump-next                (default ']')
+	jump-prev                (default '[')
+	top                      (default 'gg' and '<home>')
+	bottom                   (default 'G' and '<end>')
+	high                     (default 'H')
+	middle                   (default 'M')
+	low                      (default 'L')
+	toggle
+	invert                   (default 'v')
+	invert-below
+	unselect                 (default 'u')
+	glob-select
+	glob-unselect
+	calcdirsize
+	copy                     (default 'y')
+	cut                      (default 'd')
+	paste                    (default 'p')
+	clear                    (default 'c')
+	sync
+	draw
+	redraw                   (default '<c-l>')
+	load
+	reload                   (default '<c-r>')
+	echo
+	echomsg
+	echoerr
+	cd
+	select
+	delete         (modal)
+	mkdir          (modal)   (default 'n')
+	rename         (modal)   (default 'r')
+	source
+	push
+	read           (modal)   (default ':')
+	shell          (modal)   (default '$')
+	shell-pipe     (modal)   (default '%')
+	shell-wait     (modal)   (default '!')
+	shell-async    (modal)   (default '&')
+	find           (modal)   (default 'f')
+	find-back      (modal)   (default 'F')
+	find-next                (default ';')
+	find-prev                (default ',')
+	search         (modal)   (default '/')
+	search-back    (modal)   (default '?')
+	search-next              (default 'n')
+	search-prev              (default 'N')
+	filter         (modal)
+	setfilter
+	mark-save      (modal)   (default 'm')
+	mark-load      (modal)   (default "'")
+	mark-remove    (modal)   (default '"')
+	tag
+	tag-toggle               (default 't')
+	maps
 
 The following command line commands are provided by lf:
 

--- a/doc.go
+++ b/doc.go
@@ -16,70 +16,71 @@ You can run 'lf -help' to see descriptions of command line options.
 
 The following commands are provided by lf:
 
-	quit                     (default 'q')
-	up                       (default 'k' and '<up>')
-	half-up                  (default '<c-u>')
-	page-up                  (default '<c-b>' and '<pgup>')
-	scroll-up                (default '<c-y>')
-	down                     (default 'j' and '<down>')
-	half-down                (default '<c-d>')
-	page-down                (default '<c-f>' and '<pgdn>')
-	scroll-down              (default '<c-e>')
-	updir                    (default 'h' and '<left>')
-	open                     (default 'l' and '<right>')
-	jump-next                (default ']')
-	jump-prev                (default '[')
-	top                      (default 'gg' and '<home>')
-	bottom                   (default 'G' and '<end>')
-	high                     (default 'H')
-	middle                   (default 'M')
-	low                      (default 'L')
-	toggle
-	invert                   (default 'v')
-	invert-below
-	unselect                 (default 'u')
-	glob-select
-	glob-unselect
-	calcdirsize
-	copy                     (default 'y')
-	cut                      (default 'd')
-	paste                    (default 'p')
-	clear                    (default 'c')
-	sync
-	draw
-	redraw                   (default '<c-l>')
-	load
-	reload                   (default '<c-r>')
-	echo
-	echomsg
-	echoerr
-	cd
-	select
-	delete         (modal)
-	rename         (modal)   (default 'r')
-	source
-	push
-	read           (modal)   (default ':')
-	shell          (modal)   (default '$')
-	shell-pipe     (modal)   (default '%')
-	shell-wait     (modal)   (default '!')
-	shell-async    (modal)   (default '&')
-	find           (modal)   (default 'f')
-	find-back      (modal)   (default 'F')
-	find-next                (default ';')
-	find-prev                (default ',')
-	search         (modal)   (default '/')
-	search-back    (modal)   (default '?')
-	search-next              (default 'n')
-	search-prev              (default 'N')
-	filter         (modal)
-	setfilter
-	mark-save      (modal)   (default 'm')
-	mark-load      (modal)   (default "'")
-	mark-remove    (modal)   (default '"')
-	tag
-	tag-toggle               (default 't')
-	maps
+		quit                     (default 'q')
+		up                       (default 'k' and '<up>')
+		half-up                  (default '<c-u>')
+		page-up                  (default '<c-b>' and '<pgup>')
+		scroll-up                (default '<c-y>')
+		down                     (default 'j' and '<down>')
+		half-down                (default '<c-d>')
+		page-down                (default '<c-f>' and '<pgdn>')
+		scroll-down              (default '<c-e>')
+		updir                    (default 'h' and '<left>')
+		open                     (default 'l' and '<right>')
+		jump-next                (default ']')
+		jump-prev                (default '[')
+		top                      (default 'gg' and '<home>')
+		bottom                   (default 'G' and '<end>')
+		high                     (default 'H')
+		middle                   (default 'M')
+		low                      (default 'L')
+		toggle
+		invert                   (default 'v')
+		invert-below
+		unselect                 (default 'u')
+		glob-select
+		glob-unselect
+		calcdirsize
+		copy                     (default 'y')
+		cut                      (default 'd')
+		paste                    (default 'p')
+		clear                    (default 'c')
+		sync
+		draw
+		redraw                   (default '<c-l>')
+		load
+		reload                   (default '<c-r>')
+		echo
+		echomsg
+		echoerr
+		cd
+		select
+		delete         (modal)
+	    mkdir          (modal)   (default 'n')
+		rename         (modal)   (default 'r')
+		source
+		push
+		read           (modal)   (default ':')
+		shell          (modal)   (default '$')
+		shell-pipe     (modal)   (default '%')
+		shell-wait     (modal)   (default '!')
+		shell-async    (modal)   (default '&')
+		find           (modal)   (default 'f')
+		find-back      (modal)   (default 'F')
+		find-next                (default ';')
+		find-prev                (default ',')
+		search         (modal)   (default '/')
+		search-back    (modal)   (default '?')
+		search-next              (default 'n')
+		search-prev              (default 'N')
+		filter         (modal)
+		setfilter
+		mark-save      (modal)   (default 'm')
+		mark-load      (modal)   (default "'")
+		mark-remove    (modal)   (default '"')
+		tag
+		tag-toggle               (default 't')
+		maps
 
 The following command line commands are provided by lf:
 
@@ -434,6 +435,11 @@ A custom 'delete' command can be defined to override this default.
 
 Rename the current file using the builtin method.
 A custom 'rename' command can be defined to override this default.
+
+	mkdir          (modal)   (default 'n')
+
+Create a new directory using the builtin method.
+A custom 'mkdir' command can be defined to override this default.
 
 	source
 

--- a/doc.go
+++ b/doc.go
@@ -436,7 +436,7 @@ A custom 'delete' command can be defined to override this default.
 Rename the current file using the builtin method.
 A custom 'rename' command can be defined to override this default.
 
-	mkdir          (modal)   (default 'n')
+	mkdir          (modal)   (default 'a')
 
 Create a new directory using the builtin method.
 A custom 'mkdir' command can be defined to override this default.

--- a/doc.go
+++ b/doc.go
@@ -56,7 +56,7 @@ The following commands are provided by lf:
 	cd
 	select
 	delete         (modal)
-	mkdir          (modal)   (default 'a')
+	mkdir          (modal)
 	rename         (modal)   (default 'r')
 	source
 	push
@@ -436,7 +436,7 @@ A custom 'delete' command can be defined to override this default.
 Rename the current file using the builtin method.
 A custom 'rename' command can be defined to override this default.
 
-	mkdir          (modal)   (default 'a')
+	mkdir          (modal)
 
 Create a new directory using the builtin method.
 A custom 'mkdir' command can be defined to override this default.

--- a/docstring.go
+++ b/docstring.go
@@ -19,71 +19,71 @@ You can run 'lf -help' to see descriptions of command line options.
 
 The following commands are provided by lf:
 
-    	quit                     (default 'q')
-    	up                       (default 'k' and '<up>')
-    	half-up                  (default '<c-u>')
-    	page-up                  (default '<c-b>' and '<pgup>')
-    	scroll-up                (default '<c-y>')
-    	down                     (default 'j' and '<down>')
-    	half-down                (default '<c-d>')
-    	page-down                (default '<c-f>' and '<pgdn>')
-    	scroll-down              (default '<c-e>')
-    	updir                    (default 'h' and '<left>')
-    	open                     (default 'l' and '<right>')
-    	jump-next                (default ']')
-    	jump-prev                (default '[')
-    	top                      (default 'gg' and '<home>')
-    	bottom                   (default 'G' and '<end>')
-    	high                     (default 'H')
-    	middle                   (default 'M')
-    	low                      (default 'L')
-    	toggle
-    	invert                   (default 'v')
-    	invert-below
-    	unselect                 (default 'u')
-    	glob-select
-    	glob-unselect
-    	calcdirsize
-    	copy                     (default 'y')
-    	cut                      (default 'd')
-    	paste                    (default 'p')
-    	clear                    (default 'c')
-    	sync
-    	draw
-    	redraw                   (default '<c-l>')
-    	load
-    	reload                   (default '<c-r>')
-    	echo
-    	echomsg
-    	echoerr
-    	cd
-    	select
-    	delete         (modal)
-        mkdir          (modal)   (default 'n')
-    	rename         (modal)   (default 'r')
-    	source
-    	push
-    	read           (modal)   (default ':')
-    	shell          (modal)   (default '$')
-    	shell-pipe     (modal)   (default '%')
-    	shell-wait     (modal)   (default '!')
-    	shell-async    (modal)   (default '&')
-    	find           (modal)   (default 'f')
-    	find-back      (modal)   (default 'F')
-    	find-next                (default ';')
-    	find-prev                (default ',')
-    	search         (modal)   (default '/')
-    	search-back    (modal)   (default '?')
-    	search-next              (default 'n')
-    	search-prev              (default 'N')
-    	filter         (modal)
-    	setfilter
-    	mark-save      (modal)   (default 'm')
-    	mark-load      (modal)   (default "'")
-    	mark-remove    (modal)   (default '"')
-    	tag
-    	tag-toggle               (default 't')
-    	maps
+    quit                     (default 'q')
+    up                       (default 'k' and '<up>')
+    half-up                  (default '<c-u>')
+    page-up                  (default '<c-b>' and '<pgup>')
+    scroll-up                (default '<c-y>')
+    down                     (default 'j' and '<down>')
+    half-down                (default '<c-d>')
+    page-down                (default '<c-f>' and '<pgdn>')
+    scroll-down              (default '<c-e>')
+    updir                    (default 'h' and '<left>')
+    open                     (default 'l' and '<right>')
+    jump-next                (default ']')
+    jump-prev                (default '[')
+    top                      (default 'gg' and '<home>')
+    bottom                   (default 'G' and '<end>')
+    high                     (default 'H')
+    middle                   (default 'M')
+    low                      (default 'L')
+    toggle
+    invert                   (default 'v')
+    invert-below
+    unselect                 (default 'u')
+    glob-select
+    glob-unselect
+    calcdirsize
+    copy                     (default 'y')
+    cut                      (default 'd')
+    paste                    (default 'p')
+    clear                    (default 'c')
+    sync
+    draw
+    redraw                   (default '<c-l>')
+    load
+    reload                   (default '<c-r>')
+    echo
+    echomsg
+    echoerr
+    cd
+    select
+    delete         (modal)
+    mkdir          (modal)   (default 'n')
+    rename         (modal)   (default 'r')
+    source
+    push
+    read           (modal)   (default ':')
+    shell          (modal)   (default '$')
+    shell-pipe     (modal)   (default '%')
+    shell-wait     (modal)   (default '!')
+    shell-async    (modal)   (default '&')
+    find           (modal)   (default 'f')
+    find-back      (modal)   (default 'F')
+    find-next                (default ';')
+    find-prev                (default ',')
+    search         (modal)   (default '/')
+    search-back    (modal)   (default '?')
+    search-next              (default 'n')
+    search-prev              (default 'N')
+    filter         (modal)
+    setfilter
+    mark-save      (modal)   (default 'm')
+    mark-load      (modal)   (default "'")
+    mark-remove    (modal)   (default '"')
+    tag
+    tag-toggle               (default 't')
+    maps
 
 The following command line commands are provided by lf:
 

--- a/docstring.go
+++ b/docstring.go
@@ -59,7 +59,7 @@ The following commands are provided by lf:
     cd
     select
     delete         (modal)
-    mkdir          (modal)   (default 'n')
+    mkdir          (modal)   (default 'a')
     rename         (modal)   (default 'r')
     source
     push

--- a/docstring.go
+++ b/docstring.go
@@ -59,7 +59,7 @@ The following commands are provided by lf:
     cd
     select
     delete         (modal)
-    mkdir          (modal)   (default 'a')
+    mkdir          (modal)
     rename         (modal)   (default 'r')
     source
     push
@@ -454,7 +454,7 @@ defined to override this default.
 Rename the current file using the builtin method. A custom 'rename' command can
 be defined to override this default.
 
-    mkdir          (modal)   (default 'a')
+    mkdir          (modal)
 
 Create a new directory using the builtin method. A custom 'mkdir' command can be
 defined to override this default.

--- a/docstring.go
+++ b/docstring.go
@@ -19,70 +19,71 @@ You can run 'lf -help' to see descriptions of command line options.
 
 The following commands are provided by lf:
 
-    quit                     (default 'q')
-    up                       (default 'k' and '<up>')
-    half-up                  (default '<c-u>')
-    page-up                  (default '<c-b>' and '<pgup>')
-    scroll-up                (default '<c-y>')
-    down                     (default 'j' and '<down>')
-    half-down                (default '<c-d>')
-    page-down                (default '<c-f>' and '<pgdn>')
-    scroll-down              (default '<c-e>')
-    updir                    (default 'h' and '<left>')
-    open                     (default 'l' and '<right>')
-    jump-next                (default ']')
-    jump-prev                (default '[')
-    top                      (default 'gg' and '<home>')
-    bottom                   (default 'G' and '<end>')
-    high                     (default 'H')
-    middle                   (default 'M')
-    low                      (default 'L')
-    toggle
-    invert                   (default 'v')
-    invert-below
-    unselect                 (default 'u')
-    glob-select
-    glob-unselect
-    calcdirsize
-    copy                     (default 'y')
-    cut                      (default 'd')
-    paste                    (default 'p')
-    clear                    (default 'c')
-    sync
-    draw
-    redraw                   (default '<c-l>')
-    load
-    reload                   (default '<c-r>')
-    echo
-    echomsg
-    echoerr
-    cd
-    select
-    delete         (modal)
-    rename         (modal)   (default 'r')
-    source
-    push
-    read           (modal)   (default ':')
-    shell          (modal)   (default '$')
-    shell-pipe     (modal)   (default '%')
-    shell-wait     (modal)   (default '!')
-    shell-async    (modal)   (default '&')
-    find           (modal)   (default 'f')
-    find-back      (modal)   (default 'F')
-    find-next                (default ';')
-    find-prev                (default ',')
-    search         (modal)   (default '/')
-    search-back    (modal)   (default '?')
-    search-next              (default 'n')
-    search-prev              (default 'N')
-    filter         (modal)
-    setfilter
-    mark-save      (modal)   (default 'm')
-    mark-load      (modal)   (default "'")
-    mark-remove    (modal)   (default '"')
-    tag
-    tag-toggle               (default 't')
-    maps
+    	quit                     (default 'q')
+    	up                       (default 'k' and '<up>')
+    	half-up                  (default '<c-u>')
+    	page-up                  (default '<c-b>' and '<pgup>')
+    	scroll-up                (default '<c-y>')
+    	down                     (default 'j' and '<down>')
+    	half-down                (default '<c-d>')
+    	page-down                (default '<c-f>' and '<pgdn>')
+    	scroll-down              (default '<c-e>')
+    	updir                    (default 'h' and '<left>')
+    	open                     (default 'l' and '<right>')
+    	jump-next                (default ']')
+    	jump-prev                (default '[')
+    	top                      (default 'gg' and '<home>')
+    	bottom                   (default 'G' and '<end>')
+    	high                     (default 'H')
+    	middle                   (default 'M')
+    	low                      (default 'L')
+    	toggle
+    	invert                   (default 'v')
+    	invert-below
+    	unselect                 (default 'u')
+    	glob-select
+    	glob-unselect
+    	calcdirsize
+    	copy                     (default 'y')
+    	cut                      (default 'd')
+    	paste                    (default 'p')
+    	clear                    (default 'c')
+    	sync
+    	draw
+    	redraw                   (default '<c-l>')
+    	load
+    	reload                   (default '<c-r>')
+    	echo
+    	echomsg
+    	echoerr
+    	cd
+    	select
+    	delete         (modal)
+        mkdir          (modal)   (default 'n')
+    	rename         (modal)   (default 'r')
+    	source
+    	push
+    	read           (modal)   (default ':')
+    	shell          (modal)   (default '$')
+    	shell-pipe     (modal)   (default '%')
+    	shell-wait     (modal)   (default '!')
+    	shell-async    (modal)   (default '&')
+    	find           (modal)   (default 'f')
+    	find-back      (modal)   (default 'F')
+    	find-next                (default ';')
+    	find-prev                (default ',')
+    	search         (modal)   (default '/')
+    	search-back    (modal)   (default '?')
+    	search-next              (default 'n')
+    	search-prev              (default 'N')
+    	filter         (modal)
+    	setfilter
+    	mark-save      (modal)   (default 'm')
+    	mark-load      (modal)   (default "'")
+    	mark-remove    (modal)   (default '"')
+    	tag
+    	tag-toggle               (default 't')
+    	maps
 
 The following command line commands are provided by lf:
 
@@ -452,6 +453,11 @@ defined to override this default.
 
 Rename the current file using the builtin method. A custom 'rename' command can
 be defined to override this default.
+
+    mkdir          (modal)   (default 'n')
+
+Create a new directory using the builtin method. A custom 'mkdir' command can be
+defined to override this default.
 
     source
 

--- a/docstring.go
+++ b/docstring.go
@@ -454,7 +454,7 @@ defined to override this default.
 Rename the current file using the builtin method. A custom 'rename' command can
 be defined to override this default.
 
-    mkdir          (modal)   (default 'n')
+    mkdir          (modal)   (default 'a')
 
 Create a new directory using the builtin method. A custom 'mkdir' command can be
 defined to override this default.

--- a/eval.go
+++ b/eval.go
@@ -1898,7 +1898,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		if !app.nav.init {
 			return
 		}
-
 		if cmd, ok := gOpts.cmds["mkdir"]; ok {
 			cmd.eval(app, e.args)
 			if gSingleMode {
@@ -1911,15 +1910,12 @@ func (e *callExpr) eval(app *app, args []string) {
 				}
 			}
 		} else {
-
 			if app.ui.cmdPrefix == ">" {
 				return
 			}
-
 			normal(app)
 			app.ui.cmdPrefix = "mkdir: "
 		}
-
 		app.ui.loadFile(app, true)
 		app.ui.loadFileInfo(app.nav)
 	case "rename":
@@ -2219,7 +2215,7 @@ func (e *callExpr) eval(app *app, args []string) {
 				app.ui.loadFile(app, true)
 			} else {
 				if err := remote("send load"); err != nil {
-					app.ui.echoerrf("rename: %s", err)
+					app.ui.echoerrf("mkdir: %s", err)
 					return
 				}
 			}

--- a/eval.go
+++ b/eval.go
@@ -2205,14 +2205,15 @@ func (e *callExpr) eval(app *app, args []string) {
 			}
 		case "mkdir: ":
 			app.ui.cmdPrefix = ""
-			filepath := filepath.Clean(replaceTilde(s))
-			if err := os.MkdirAll(filepath, os.ModePerm); err != nil {
+			app.nav.mkdirPath = filepath.Clean(replaceTilde(s))
+			if err := app.nav.mkdir(); err != nil {
 				app.ui.echoerrf("mkdir: %s", err)
 				return
 			}
 			if gSingleMode {
 				app.nav.renew()
-				app.ui.loadFile(app, true)
+				app.ui.loadFile(app, false)
+				app.ui.loadFileInfo(app.nav)
 			} else {
 				if err := remote("send load"); err != nil {
 					app.ui.echoerrf("mkdir: %s", err)

--- a/eval.go
+++ b/eval.go
@@ -2328,7 +2328,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			switch app.ui.cmdPrefix {
 			case "!", "$", "%", "&":
 				app.ui.cmdPrefix = ":"
-			case ">", "rename: ", "mkdir: ":
+			case ">", "rename: ":
 				// Don't mess with programs waiting for input.
 				// Exiting on backspace is also inconvenient for renames since the text field starts out nonempty.
 			default:

--- a/eval.go
+++ b/eval.go
@@ -2209,13 +2209,11 @@ func (e *callExpr) eval(app *app, args []string) {
 			}
 		case "mkdir: ":
 			app.ui.cmdPrefix = ""
-
-			fpath := filepath.Clean(replaceTilde(s))
-			if err := os.MkdirAll(fpath, os.ModePerm); err != nil {
+			filepath := filepath.Clean(replaceTilde(s))
+			if err := os.MkdirAll(filepath, os.ModePerm); err != nil {
 				app.ui.echoerrf("mkdir: %s", err)
 				return
 			}
-
 			if gSingleMode {
 				app.nav.renew()
 				app.ui.loadFile(app, true)

--- a/lf.1
+++ b/lf.1
@@ -71,7 +71,7 @@ The following commands are provided by lf:
     cd
     select
     delete         (modal)
-    mkdir          (modal)   (default 'n')
+    mkdir          (modal)   (default 'a')
     rename         (modal)   (default 'r')
     source
     push

--- a/lf.1
+++ b/lf.1
@@ -31,70 +31,71 @@ You can run 'lf -help' to see descriptions of command line options.
 The following commands are provided by lf:
 .PP
 .EX
-    quit                     (default 'q')
-    up                       (default 'k' and '<up>')
-    half-up                  (default '<c-u>')
-    page-up                  (default '<c-b>' and '<pgup>')
-    scroll-up                (default '<c-y>')
-    down                     (default 'j' and '<down>')
-    half-down                (default '<c-d>')
-    page-down                (default '<c-f>' and '<pgdn>')
-    scroll-down              (default '<c-e>')
-    updir                    (default 'h' and '<left>')
-    open                     (default 'l' and '<right>')
-    jump-next                (default ']')
-    jump-prev                (default '[')
-    top                      (default 'gg' and '<home>')
-    bottom                   (default 'G' and '<end>')
-    high                     (default 'H')
-    middle                   (default 'M')
-    low                      (default 'L')
-    toggle
-    invert                   (default 'v')
-    invert-below
-    unselect                 (default 'u')
-    glob-select
-    glob-unselect
-    calcdirsize
-    copy                     (default 'y')
-    cut                      (default 'd')
-    paste                    (default 'p')
-    clear                    (default 'c')
-    sync
-    draw
-    redraw                   (default '<c-l>')
-    load
-    reload                   (default '<c-r>')
-    echo
-    echomsg
-    echoerr
-    cd
-    select
-    delete         (modal)
-    rename         (modal)   (default 'r')
-    source
-    push
-    read           (modal)   (default ':')
-    shell          (modal)   (default '$')
-    shell-pipe     (modal)   (default '%')
-    shell-wait     (modal)   (default '!')
-    shell-async    (modal)   (default '&')
-    find           (modal)   (default 'f')
-    find-back      (modal)   (default 'F')
-    find-next                (default ';')
-    find-prev                (default ',')
-    search         (modal)   (default '/')
-    search-back    (modal)   (default '?')
-    search-next              (default 'n')
-    search-prev              (default 'N')
-    filter         (modal)
-    setfilter
-    mark-save      (modal)   (default 'm')
-    mark-load      (modal)   (default "'")
-    mark-remove    (modal)   (default '"')
-    tag
-    tag-toggle               (default 't')
-    maps
+    	quit                     (default 'q')
+    	up                       (default 'k' and '<up>')
+    	half-up                  (default '<c-u>')
+    	page-up                  (default '<c-b>' and '<pgup>')
+    	scroll-up                (default '<c-y>')
+    	down                     (default 'j' and '<down>')
+    	half-down                (default '<c-d>')
+    	page-down                (default '<c-f>' and '<pgdn>')
+    	scroll-down              (default '<c-e>')
+    	updir                    (default 'h' and '<left>')
+    	open                     (default 'l' and '<right>')
+    	jump-next                (default ']')
+    	jump-prev                (default '[')
+    	top                      (default 'gg' and '<home>')
+    	bottom                   (default 'G' and '<end>')
+    	high                     (default 'H')
+    	middle                   (default 'M')
+    	low                      (default 'L')
+    	toggle
+    	invert                   (default 'v')
+    	invert-below
+    	unselect                 (default 'u')
+    	glob-select
+    	glob-unselect
+    	calcdirsize
+    	copy                     (default 'y')
+    	cut                      (default 'd')
+    	paste                    (default 'p')
+    	clear                    (default 'c')
+    	sync
+    	draw
+    	redraw                   (default '<c-l>')
+    	load
+    	reload                   (default '<c-r>')
+    	echo
+    	echomsg
+    	echoerr
+    	cd
+    	select
+    	delete         (modal)
+        mkdir          (modal)   (default 'n')
+    	rename         (modal)   (default 'r')
+    	source
+    	push
+    	read           (modal)   (default ':')
+    	shell          (modal)   (default '$')
+    	shell-pipe     (modal)   (default '%')
+    	shell-wait     (modal)   (default '!')
+    	shell-async    (modal)   (default '&')
+    	find           (modal)   (default 'f')
+    	find-back      (modal)   (default 'F')
+    	find-next                (default ';')
+    	find-prev                (default ',')
+    	search         (modal)   (default '/')
+    	search-back    (modal)   (default '?')
+    	search-next              (default 'n')
+    	search-prev              (default 'N')
+    	filter         (modal)
+    	setfilter
+    	mark-save      (modal)   (default 'm')
+    	mark-load      (modal)   (default "'")
+    	mark-remove    (modal)   (default '"')
+    	tag
+    	tag-toggle               (default 't')
+    	maps
 .EE
 .PP
 The following command line commands are provided by lf:
@@ -521,6 +522,12 @@ Remove the current file or selected file(s). A custom 'delete' command can be de
 .EE
 .PP
 Rename the current file using the builtin method. A custom 'rename' command can be defined to override this default.
+.PP
+.EX
+    mkdir          (modal)   (default 'n')
+.EE
+.PP
+Create a new directory using the builtin method. A custom 'mkdir' command can be defined to override this default.
 .PP
 .EX
     source

--- a/lf.1
+++ b/lf.1
@@ -71,7 +71,7 @@ The following commands are provided by lf:
     cd
     select
     delete         (modal)
-    mkdir          (modal)   (default 'a')
+    mkdir          (modal)
     rename         (modal)   (default 'r')
     source
     push
@@ -524,7 +524,7 @@ Remove the current file or selected file(s). A custom 'delete' command can be de
 Rename the current file using the builtin method. A custom 'rename' command can be defined to override this default.
 .PP
 .EX
-    mkdir          (modal)   (default 'a')
+    mkdir          (modal)
 .EE
 .PP
 Create a new directory using the builtin method. A custom 'mkdir' command can be defined to override this default.

--- a/lf.1
+++ b/lf.1
@@ -31,71 +31,71 @@ You can run 'lf -help' to see descriptions of command line options.
 The following commands are provided by lf:
 .PP
 .EX
-    	quit                     (default 'q')
-    	up                       (default 'k' and '<up>')
-    	half-up                  (default '<c-u>')
-    	page-up                  (default '<c-b>' and '<pgup>')
-    	scroll-up                (default '<c-y>')
-    	down                     (default 'j' and '<down>')
-    	half-down                (default '<c-d>')
-    	page-down                (default '<c-f>' and '<pgdn>')
-    	scroll-down              (default '<c-e>')
-    	updir                    (default 'h' and '<left>')
-    	open                     (default 'l' and '<right>')
-    	jump-next                (default ']')
-    	jump-prev                (default '[')
-    	top                      (default 'gg' and '<home>')
-    	bottom                   (default 'G' and '<end>')
-    	high                     (default 'H')
-    	middle                   (default 'M')
-    	low                      (default 'L')
-    	toggle
-    	invert                   (default 'v')
-    	invert-below
-    	unselect                 (default 'u')
-    	glob-select
-    	glob-unselect
-    	calcdirsize
-    	copy                     (default 'y')
-    	cut                      (default 'd')
-    	paste                    (default 'p')
-    	clear                    (default 'c')
-    	sync
-    	draw
-    	redraw                   (default '<c-l>')
-    	load
-    	reload                   (default '<c-r>')
-    	echo
-    	echomsg
-    	echoerr
-    	cd
-    	select
-    	delete         (modal)
-        mkdir          (modal)   (default 'n')
-    	rename         (modal)   (default 'r')
-    	source
-    	push
-    	read           (modal)   (default ':')
-    	shell          (modal)   (default '$')
-    	shell-pipe     (modal)   (default '%')
-    	shell-wait     (modal)   (default '!')
-    	shell-async    (modal)   (default '&')
-    	find           (modal)   (default 'f')
-    	find-back      (modal)   (default 'F')
-    	find-next                (default ';')
-    	find-prev                (default ',')
-    	search         (modal)   (default '/')
-    	search-back    (modal)   (default '?')
-    	search-next              (default 'n')
-    	search-prev              (default 'N')
-    	filter         (modal)
-    	setfilter
-    	mark-save      (modal)   (default 'm')
-    	mark-load      (modal)   (default "'")
-    	mark-remove    (modal)   (default '"')
-    	tag
-    	tag-toggle               (default 't')
-    	maps
+    quit                     (default 'q')
+    up                       (default 'k' and '<up>')
+    half-up                  (default '<c-u>')
+    page-up                  (default '<c-b>' and '<pgup>')
+    scroll-up                (default '<c-y>')
+    down                     (default 'j' and '<down>')
+    half-down                (default '<c-d>')
+    page-down                (default '<c-f>' and '<pgdn>')
+    scroll-down              (default '<c-e>')
+    updir                    (default 'h' and '<left>')
+    open                     (default 'l' and '<right>')
+    jump-next                (default ']')
+    jump-prev                (default '[')
+    top                      (default 'gg' and '<home>')
+    bottom                   (default 'G' and '<end>')
+    high                     (default 'H')
+    middle                   (default 'M')
+    low                      (default 'L')
+    toggle
+    invert                   (default 'v')
+    invert-below
+    unselect                 (default 'u')
+    glob-select
+    glob-unselect
+    calcdirsize
+    copy                     (default 'y')
+    cut                      (default 'd')
+    paste                    (default 'p')
+    clear                    (default 'c')
+    sync
+    draw
+    redraw                   (default '<c-l>')
+    load
+    reload                   (default '<c-r>')
+    echo
+    echomsg
+    echoerr
+    cd
+    select
+    delete         (modal)
+    mkdir          (modal)   (default 'n')
+    rename         (modal)   (default 'r')
+    source
+    push
+    read           (modal)   (default ':')
+    shell          (modal)   (default '$')
+    shell-pipe     (modal)   (default '%')
+    shell-wait     (modal)   (default '!')
+    shell-async    (modal)   (default '&')
+    find           (modal)   (default 'f')
+    find-back      (modal)   (default 'F')
+    find-next                (default ';')
+    find-prev                (default ',')
+    search         (modal)   (default '/')
+    search-back    (modal)   (default '?')
+    search-next              (default 'n')
+    search-prev              (default 'N')
+    filter         (modal)
+    setfilter
+    mark-save      (modal)   (default 'm')
+    mark-load      (modal)   (default "'")
+    mark-remove    (modal)   (default '"')
+    tag
+    tag-toggle               (default 't')
+    maps
 .EE
 .PP
 The following command line commands are provided by lf:

--- a/lf.1
+++ b/lf.1
@@ -524,7 +524,7 @@ Remove the current file or selected file(s). A custom 'delete' command can be de
 Rename the current file using the builtin method. A custom 'rename' command can be defined to override this default.
 .PP
 .EX
-    mkdir          (modal)   (default 'n')
+    mkdir          (modal)   (default 'a')
 .EE
 .PP
 Create a new directory using the builtin method. A custom 'mkdir' command can be defined to override this default.

--- a/nav.go
+++ b/nav.go
@@ -1436,19 +1436,17 @@ func (nav *nav) del(app *app) error {
 }
 
 func (nav *nav) mkdir() error {
-	mkdirPath := nav.mkdirPath
-	if err := os.MkdirAll(mkdirPath, os.ModePerm); err != nil {
-		return err
-	}
+	mkdirPath, err := filepath.Abs(nav.mkdirPath)
 
-	lstat, err := os.Lstat(mkdirPath)
 	if err != nil {
 		return err
 	}
 
-	dir := nav.currDir()
-	dir.files = append(dir.files, &file{FileInfo: lstat})
-	dir.sel(lstat.Name(), nav.height)
+	if err := os.MkdirAll(mkdirPath, os.ModePerm); err != nil {
+		return err
+	}
+
+	nav.sel(mkdirPath)
 
 	return nil
 }

--- a/nav.go
+++ b/nav.go
@@ -1436,9 +1436,7 @@ func (nav *nav) del(app *app) error {
 }
 
 func (nav *nav) mkdir() error {
-
 	mkdirPath := nav.mkdirPath
-
 	if err := os.MkdirAll(mkdirPath, os.ModePerm); err != nil {
 		return err
 	}
@@ -1449,9 +1447,7 @@ func (nav *nav) mkdir() error {
 	}
 
 	dir := nav.currDir()
-
 	dir.files = append(dir.files, &file{FileInfo: lstat})
-
 	dir.sel(lstat.Name(), nav.height)
 
 	return nil

--- a/nav.go
+++ b/nav.go
@@ -376,6 +376,7 @@ type nav struct {
 	marks           map[string]string
 	renameOldPath   string
 	renameNewPath   string
+	mkdirPath       string
 	selections      map[string]int
 	tags            map[string]string
 	selectionInd    int
@@ -1430,6 +1431,28 @@ func (nav *nav) del(app *app) error {
 			}
 		}
 	}()
+
+	return nil
+}
+
+func (nav *nav) mkdir() error {
+
+	mkdirPath := nav.mkdirPath
+
+	if err := os.MkdirAll(mkdirPath, os.ModePerm); err != nil {
+		return err
+	}
+
+	lstat, err := os.Lstat(mkdirPath)
+	if err != nil {
+		return err
+	}
+
+	dir := nav.currDir()
+
+	dir.files = append(dir.files, &file{FileInfo: lstat})
+
+	dir.sel(lstat.Name(), nav.height)
 
 	return nil
 }

--- a/opts.go
+++ b/opts.go
@@ -195,6 +195,7 @@ func init() {
 	gOpts.keys["'"] = &callExpr{"mark-load", nil, 1}
 	gOpts.keys[`"`] = &callExpr{"mark-remove", nil, 1}
 	gOpts.keys[`r`] = &callExpr{"rename", nil, 1}
+	gOpts.keys[`n`] = &callExpr{"mkdir", nil, 1}
 	gOpts.keys["<c-n>"] = &callExpr{"cmd-history-next", nil, 1}
 	gOpts.keys["<c-p>"] = &callExpr{"cmd-history-prev", nil, 1}
 

--- a/opts.go
+++ b/opts.go
@@ -195,7 +195,6 @@ func init() {
 	gOpts.keys["'"] = &callExpr{"mark-load", nil, 1}
 	gOpts.keys[`"`] = &callExpr{"mark-remove", nil, 1}
 	gOpts.keys[`r`] = &callExpr{"rename", nil, 1}
-	gOpts.keys[`a`] = &callExpr{"mkdir", nil, 1}
 	gOpts.keys["<c-n>"] = &callExpr{"cmd-history-next", nil, 1}
 	gOpts.keys["<c-p>"] = &callExpr{"cmd-history-prev", nil, 1}
 

--- a/opts.go
+++ b/opts.go
@@ -195,7 +195,7 @@ func init() {
 	gOpts.keys["'"] = &callExpr{"mark-load", nil, 1}
 	gOpts.keys[`"`] = &callExpr{"mark-remove", nil, 1}
 	gOpts.keys[`r`] = &callExpr{"rename", nil, 1}
-	gOpts.keys[`n`] = &callExpr{"mkdir", nil, 1}
+	gOpts.keys[`a`] = &callExpr{"mkdir", nil, 1}
 	gOpts.keys["<c-n>"] = &callExpr{"cmd-history-next", nil, 1}
 	gOpts.keys["<c-p>"] = &callExpr{"cmd-history-prev", nil, 1}
 


### PR DESCRIPTION
Adds a `mkdir` command to allow the user to quickly create directories.

When using `$mkdir` the screen will flicker, and the newly created directory will not be selected by default, this can cause confusion as trying to find the directory within a big directory could be an eyesore.

To address this the user might want to create a custom command, however, users who lack the technical knowledge or just want something quick might find this cumbersome at worst.

Another issue one might encounter is that the behavior of the `mkdir` command might vary across operating systems.

This PR attempts to solve these issues.

By having a built in command everyone will have the same functionality out of the box.

You can still override the command, so users who've created their own command can still use it.

closes #887 