### PR TITLE
Fix infinite loop in listMatches

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -1363,7 +1363,7 @@ func listMatches(screen tcell.Screen, matches []string, selectedInd int) *bytes.
 		wcol = max(wcol, len(m))
 	}
 	wcol += gOpts.tabstop - wcol%gOpts.tabstop
-	ncol := wtot / wcol
+	ncol := max(wtot/wcol, 1)
 
 	b.WriteString("possible matches\n")
 


### PR DESCRIPTION
This fixes an issue where listMatches could get stuck in an infinite loop if one of the matches was longer than the window width.

Fixes #1090