### PR TITLE
Export count as a variable when running commands

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -185,6 +185,7 @@ The following environment variables are exported for shell commands:
 	lf_user_{option}
 	lf_width
 	lf_height
+	lf_count
 
 The following special shell commands are used to customize the behavior of lf when defined:
 
@@ -953,6 +954,10 @@ Value of the user_{option}.
 	lf_height
 
 Width/Height of the terminal.
+
+	lf_count
+
+Value of the count associated with the current command.
 
 # Special Commands
 

--- a/docstring.go
+++ b/docstring.go
@@ -188,6 +188,7 @@ The following environment variables are exported for shell commands:
     lf_user_{option}
     lf_width
     lf_height
+    lf_count
 
 The following special shell commands are used to customize the behavior of lf
 when defined:
@@ -1020,6 +1021,10 @@ Value of the user_{option}.
     lf_height
 
 Width/Height of the terminal.
+
+    lf_count
+
+Value of the count associated with the current command.
 
 # Special Commands
 

--- a/eval.go
+++ b/eval.go
@@ -1261,6 +1261,8 @@ func insert(app *app, arg string) {
 }
 
 func (e *callExpr) eval(app *app, args []string) {
+	os.Setenv("lf_count", strconv.Itoa(e.count))
+
 	switch e.name {
 	case "up":
 		if !app.nav.init {

--- a/lf.1
+++ b/lf.1
@@ -206,6 +206,7 @@ The following environment variables are exported for shell commands:
     lf_user_{option}
     lf_width
     lf_height
+    lf_count
 .EE
 .PP
 The following special shell commands are used to customize the behavior of lf when defined:
@@ -1160,6 +1161,12 @@ Value of the user_{option}.
 .EE
 .PP
 Width/Height of the terminal.
+.PP
+.EX
+    lf_count
+.EE
+.PP
+Value of the count associated with the current command.
 .SH SPECIAL COMMANDS
 This section shows information about special shell commands.
 .PP


### PR DESCRIPTION
Fixes #1180 

This change exports the command count as the variable `lf_count` so that it can be used by shell scripts. For example, with the following config file, typing <kbd>123e</kbd> will result in printing `123`.

```
cmd echocount %echo "$lf_count"
map e echocount
```

This is similar to the `v:count` variable in Vimscript:

```vim
function! EchoCount()
    echo v:count
endfunction

nnoremap <silent> e :<c-u>call EchoCount()<cr>

" Typing '123e' will result in printing '123'
```

This feature was requested by a user, please see the discussion in #1180 for more details about their use case.