### PR TITLE
lfrc.example: Add example mkdir binding, "show execution result"  command

### DIFF
--- a/etc/lfrc.example
+++ b/etc/lfrc.example
@@ -26,6 +26,9 @@ set cursorpreviewfmt "\033[7;2m"
 # use enter for shell commands
 map <enter> shell
 
+# show the result of execution of previous commands
+map ` !true
+
 # execute current file (must be executable)
 map x $$f
 map X !$f
@@ -44,6 +47,9 @@ cmd open &{{
         *) for f in $fx; do $OPENER $f > /dev/null 2> /dev/null & done;;
     esac
 }}
+
+# mkdir command. See wiki if you want it to select created dir
+map a :push %mkdir<space>
 
 # define a custom 'rename' command without prompt for overwrite
 # cmd rename %[ -e $1 ] && printf "file exists" || mv $f $1


### PR DESCRIPTION
Let me know if any of this makes you unhappy; I'm happy to only do
some of these things if people prefer.

The mkdir portion is an attempt to substitute for https://github.com/gokcehan/lf/pull/1179.

Show how to map `a` to mkdir. `` ` `` maps to "show execution
result". Norton Commander & its successors map it to `<c-o>`,
but I think that's better for something opening-relatred.

Whenever a `$` command gives an unexpected error, I want to see
what happened. There are many ways to do so, but the one I added
here seems the simplest and it took me a while to think of it.
We could also have an option to have `$` commands pause like `!`
commands when there's an error.
Fixes #887 