### PR TITLE
Simplify edge calculation when scrolling down

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -925,15 +925,8 @@ func (nav *nav) down(dist int) bool {
 	dir.ind = min(maxind, dir.ind)
 
 	dir.pos += dist
-	// If scrolloff is set to a large value, then the cursor should be placed in
-	// the middle. If nav.height is an even number, then there are actually two
-	// candidate rows for being the middle. To ensure a smooth scrolling
-	// experience where the cursor doesn't move when scrolling both up and down,
-	// the bottom candidate row is used in both cases, however this means that
-	// the half value has to be adjusted. For example, if the height is 10, then
-	// the cursor should be positioned at index 5, which is 5 rows away from the
-	// top row (relevant when scrolling up), but only 4 rows away from the
-	// bottom row (relevant when scrolling down).
+	// use a smaller value for half when the height is even and scrolloff is
+	// maxed in order to stay at the same row while scrolling up and down
 	half := nav.height / 2
 	if nav.height%2 == 0 {
 		half--

--- a/nav.go
+++ b/nav.go
@@ -925,11 +925,9 @@ func (nav *nav) down(dist int) bool {
 	dir.ind = min(maxind, dir.ind)
 
 	dir.pos += dist
-	edge := min(min(nav.height/2, gOpts.scrolloff), maxind-dir.ind)
-
 	// use a smaller value when the height is even and scrolloff is maxed
 	// in order to stay at the same row as much as possible while up/down
-	edge = min(edge, nav.height/2+nav.height%2-1)
+	edge := min(min((nav.height-1)/2, gOpts.scrolloff), maxind-dir.ind)
 
 	dir.pos = min(dir.pos, nav.height-edge-1)
 	dir.pos = min(dir.pos, maxind)

--- a/nav.go
+++ b/nav.go
@@ -925,9 +925,20 @@ func (nav *nav) down(dist int) bool {
 	dir.ind = min(maxind, dir.ind)
 
 	dir.pos += dist
-	// use a smaller value when the height is even and scrolloff is maxed
-	// in order to stay at the same row as much as possible while up/down
-	edge := min(min((nav.height-1)/2, gOpts.scrolloff), maxind-dir.ind)
+	// If scrolloff is set to a large value, then the cursor should be placed in
+	// the middle. If nav.height is an even number, then there are actually two
+	// candidate rows for being the middle. To ensure a smooth scrolling
+	// experience where the cursor doesn't move when scrolling both up and down,
+	// the bottom candidate row is used in both cases, however this means that
+	// the half value has to be adjusted. For example, if the height is 10, then
+	// the cursor should be positioned at index 5, which is 5 rows away from the
+	// top row (relevant when scrolling up), but only 4 rows away from the
+	// bottom row (relevant when scrolling down).
+	half := nav.height / 2
+	if nav.height%2 == 0 {
+		half--
+	}
+	edge := min(min(half, gOpts.scrolloff), maxind-dir.ind)
 
 	dir.pos = min(dir.pos, nav.height-edge-1)
 	dir.pos = min(dir.pos, maxind)


### PR DESCRIPTION
When scrolling with a very large `scrolloff` value, the cursor will be positioned in the middle of the column, and the `edge` variable represents how far the cursor is from the top/bottom row. If the height is an odd number, then this is straightforward, but if the height is an even number, then there are two candidate rows for the middle (`lf` uses the bottom one).

For example:

- If the height is 9, then the cursor should be located at index 4, and `edge` is simply 4 on both sides
- If the height is 10, then the cursor should be located at index 5, and `edge` is 5 when scrolling up, but 4 when scrolling down

As part of the calculations, the current code effectively tries to determine `min(nav.height/2, nav.height/2+nav.height%2-1)` which can be simplified (`h` to represent the height for the following):

- `h % 2 - 1` is always equal to `0` or `-1`, which means `h / 2` can never be smaller than `h / 2 + h % 2 - 1`, and therefore the calculation can be collapsed to the latter.
- `h / 2 + h % 2 - 1` means to halve and subtract 1 if the height is an even number, and integer divide by 2 if it is an odd number, so the calculation can further be simplified to `(h - 1) / 2`.