### PR TITLE
Add support for moving to a specific line

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -324,6 +324,7 @@ Change the current working directory to the next/previous jumplist item.
 	bottom                   (default 'G' and '<end>')
 
 Move the current file selection to the top/bottom of the directory.
+A count can be specified to move to a specific line, for example use `3G` to move to the third line.
 
 	high                     (default 'H')
 	middle                   (default 'M')

--- a/docstring.go
+++ b/docstring.go
@@ -332,7 +332,9 @@ Change the current working directory to the next/previous jumplist item.
     top                      (default 'gg' and '<home>')
     bottom                   (default 'G' and '<end>')
 
-Move the current file selection to the top/bottom of the directory.
+Move the current file selection to the top/bottom of the directory. A count can
+be specified to move to a specific line, for example use '3G' to move to the
+third line.
 
     high                     (default 'H')
     middle                   (default 'M')

--- a/eval.go
+++ b/eval.go
@@ -1425,7 +1425,13 @@ func (e *callExpr) eval(app *app, args []string) {
 		if !app.nav.init {
 			return
 		}
-		if app.nav.top() {
+		var moved bool
+		if e.count == 0 {
+			moved = app.nav.top()
+		} else {
+			moved = app.nav.move(e.count - 1)
+		}
+		if moved {
 			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}
@@ -1433,7 +1439,13 @@ func (e *callExpr) eval(app *app, args []string) {
 		if !app.nav.init {
 			return
 		}
-		if app.nav.bottom() {
+		var moved bool
+		if e.count == 0 {
+			moved = app.nav.bottom()
+		} else {
+			moved = app.nav.move(e.count - 1)
+		}
+		if moved {
 			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}

--- a/lf.1
+++ b/lf.1
@@ -377,7 +377,7 @@ Change the current working directory to the next/previous jumplist item.
     bottom                   (default 'G' and '<end>')
 .EE
 .PP
-Move the current file selection to the top/bottom of the directory.
+Move the current file selection to the top/bottom of the directory. A count can be specified to move to a specific line, for example use `3G` to move to the third line.
 .PP
 .EX
     high                     (default 'H')

--- a/nav.go
+++ b/nav.go
@@ -1099,6 +1099,19 @@ func (nav *nav) low() bool {
 	return old != dir.ind
 }
 
+func (nav *nav) move(index int) bool {
+	old := nav.currDir().ind
+
+	switch {
+	case index < old:
+		return nav.up(old - index)
+	case index > old:
+		return nav.down(index - old)
+	default:
+		return false
+	}
+}
+
 func (nav *nav) toggleSelection(path string) {
 	if _, ok := nav.selections[path]; ok {
 		delete(nav.selections, path)

--- a/opts.go
+++ b/opts.go
@@ -161,10 +161,10 @@ func init() {
 	gOpts.keys["l"] = &callExpr{"open", nil, 1}
 	gOpts.keys["<right>"] = &callExpr{"open", nil, 1}
 	gOpts.keys["q"] = &callExpr{"quit", nil, 1}
-	gOpts.keys["gg"] = &callExpr{"top", nil, 1}
-	gOpts.keys["<home>"] = &callExpr{"top", nil, 1}
-	gOpts.keys["G"] = &callExpr{"bottom", nil, 1}
-	gOpts.keys["<end>"] = &callExpr{"bottom", nil, 1}
+	gOpts.keys["gg"] = &callExpr{"top", nil, 0}
+	gOpts.keys["<home>"] = &callExpr{"top", nil, 0}
+	gOpts.keys["G"] = &callExpr{"bottom", nil, 0}
+	gOpts.keys["<end>"] = &callExpr{"bottom", nil, 0}
 	gOpts.keys["H"] = &callExpr{"high", nil, 1}
 	gOpts.keys["M"] = &callExpr{"middle", nil, 1}
 	gOpts.keys["L"] = &callExpr{"low", nil, 1}


### PR DESCRIPTION
Fixes #240 
Fixes #1033 

I know there's been a few attempts in the past to implement this, such as #242 and #1040 and possibly others that I have missed. I'm not sure why those attempts appear to have been stalled, I suppose although setting `dir.ind` is straightforward, the difficult part is determining how to calculate `dir.pos` so that the amount of scrolling is minimised.

It looks possible to simply use the existing `up`/`down` functions to move to a new line (no scrolling happens if the destination is already visible, so the effect is smoother). This is already used in other functions like `findNext`/`findPrev` and `searchNext`/`searchPrev`, and I think it's better to recycle the scrolling logic in the `up`/`down` functions rather write it from scratch.