### PR TITLE
Use $VISUAL for the `e` command instead of $EDITOR

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -179,6 +179,7 @@ The following environment variables are exported for shell commands:
 	OLDPWD
 	LF_LEVEL
 	OPENER
+	VISUAL
 	EDITOR
 	PAGER
 	SHELL
@@ -937,7 +938,7 @@ If this variable is set in the environment, use the same value. Otherwise, this 
 
 	EDITOR
 
-If this variable is set in the environment, use the same value. Otherwise, this is set to 'vi' on Unix, 'notepad' in Windows.
+If VISUAL is set in the environment, use its value. Otherwise, use the value of the environment variable EDITOR. If neither variable is set, this is set to 'vi' on Unix, 'notepad' in Windows.
 
 	PAGER
 

--- a/docstring.go
+++ b/docstring.go
@@ -182,6 +182,7 @@ The following environment variables are exported for shell commands:
     OLDPWD
     LF_LEVEL
     OPENER
+    VISUAL
     EDITOR
     PAGER
     SHELL
@@ -1001,8 +1002,9 @@ this is set to 'start' in Windows, 'open' in MacOS, 'xdg-open' in others.
 
     EDITOR
 
-If this variable is set in the environment, use the same value. Otherwise,
-this is set to 'vi' on Unix, 'notepad' in Windows.
+If VISUAL is set in the environment, use its value. Otherwise, use the value of
+the environment variable EDITOR. If neither variable is set, this is set to 'vi'
+on Unix, 'notepad' in Windows.
 
     PAGER
 

--- a/lf.1
+++ b/lf.1
@@ -200,6 +200,7 @@ The following environment variables are exported for shell commands:
     OLDPWD
     LF_LEVEL
     OPENER
+    VISUAL
     EDITOR
     PAGER
     SHELL
@@ -1136,7 +1137,7 @@ If this variable is set in the environment, use the same value. Otherwise, this 
     EDITOR
 .EE
 .PP
-If this variable is set in the environment, use the same value. Otherwise, this is set to 'vi' on Unix, 'notepad' in Windows.
+If VISUAL is set in the environment, use its value. Otherwise, use the value of the environment variable EDITOR. If neither variable is set, this is set to 'vi' on Unix, 'notepad' in Windows.
 .PP
 .EX
     PAGER

--- a/os.go
+++ b/os.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	envOpener = os.Getenv("OPENER")
-	envEditor = os.Getenv("EDITOR")
+	envEditor = os.Getenv("VISUAL")
 	envPager  = os.Getenv("PAGER")
 	envShell  = os.Getenv("SHELL")
 )
@@ -51,7 +51,10 @@ func init() {
 	}
 
 	if envEditor == "" {
-		envEditor = "vi"
+		envEditor = os.Getenv("EDITOR")
+		if envEditor == "" {
+			envEditor = "vi"
+		}
 	}
 
 	if envPager == "" {

--- a/os_windows.go
+++ b/os_windows.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	envOpener = os.Getenv("OPENER")
-	envEditor = os.Getenv("EDITOR")
+	envEditor = os.Getenv("VISUAL")
 	envPager  = os.Getenv("PAGER")
 	envShell  = os.Getenv("SHELL")
 )
@@ -45,7 +45,10 @@ func init() {
 	}
 
 	if envEditor == "" {
-		envEditor = "notepad"
+		envEditor = os.Getenv("EDITOR")
+		if envEditor == "" {
+			envEditor = "notepad"
+		}
 	}
 
 	if envPager == "" {


### PR DESCRIPTION
According to the manpage of `ksh`,
```
EDITOR  If the VISUAL parameter is not set, this parameter controls
        the command-line editing mode for interactive shells.  See the
        VISUAL parameter below for how this works.

        Note: traditionally, EDITOR was used to specify the name of an
        (old-style) line editor, such as ed(1), and VISUAL was used to
        specify a (new-style) screen editor, such as vi(1).  Hence if
        VISUAL is set, it overrides EDITOR.

...

VISUAL  If set, this parameter controls the command-line editing mode
        for interactive shells.  If the last component of the path
        specified in this parameter contains the string “vi”, “emacs”,
        or “gmacs”, the vi(1), emacs, or gmacs (Gosling emacs) editing
        mode is enabled, respectively.  See also the EDITOR parameter,
        above.
```

If vi mode is enabled in `ksh`, the `v` command will edit the current line, similarly to how `lf`'s `e` command edits the current file:

```
[n]v    Edit line n using the vi(1) editor; if n is not specified,
        the current line is edited.  The actual command executed is
        fc -e ${VISUAL:-${EDITOR:-vi}} n.
```

As you can see, $VISUAL is selected by default, $EDITOR if $VISUAL is not defined and `vi` if neither are defined.

`bash`'s `v` command has the same behavior.

Because of this, I think that `lf` should use the `$VISUAL` environment variable by default and fall back to `$EDITOR` or `vi` if it's not defined.