### PR TITLE
Make `:maps` work on Windows and add `:cmaps`.

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -14,6 +14,7 @@ var (
 		"map",
 		"maps",
 		"cmap",
+		"cmaps",
 		"cmd",
 		"quit",
 		"up",

--- a/doc.go
+++ b/doc.go
@@ -80,6 +80,7 @@ The following commands are provided by lf:
 	tag
 	tag-toggle               (default 't')
 	maps
+	cmaps
 
 The following command line commands are provided by lf:
 
@@ -604,8 +605,9 @@ Delete the next word in forward direction.
 Capitalize/uppercase/lowercase the current word and jump to the next word.
 
 	maps
+	cmaps
 
-List all key mappings.
+List all key mappings in normal mode or command-line editing mode.
 
 # Options
 

--- a/docstring.go
+++ b/docstring.go
@@ -83,6 +83,7 @@ The following commands are provided by lf:
     tag
     tag-toggle               (default 't')
     maps
+    cmaps
 
 The following command line commands are provided by lf:
 
@@ -631,8 +632,9 @@ Delete the next word in forward direction.
 Capitalize/uppercase/lowercase the current word and jump to the next word.
 
     maps
+    cmaps
 
-List all key mappings.
+List all key mappings in normal mode or command-line editing mode.
 
 # Options
 

--- a/eval.go
+++ b/eval.go
@@ -2471,6 +2471,11 @@ func (e *callExpr) eval(app *app, args []string) {
 		io.Copy(app.cmdIn, listBinds(gOpts.keys))
 		app.cmdIn.Close()
 		cleanUp()
+	case "cmaps":
+		cleanUp := app.runShell(envPager, nil, "$|")
+		io.Copy(app.cmdIn, listBinds(gOpts.cmdkeys))
+		app.cmdIn.Close()
+		cleanUp()
 	default:
 		cmd, ok := gOpts.cmds[e.name]
 		if !ok {

--- a/eval.go
+++ b/eval.go
@@ -2467,7 +2467,7 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.ui.cmdAccLeft = acc
 		update(app)
 	case "maps":
-		cleanUp := app.runShell("$PAGER", nil, "$|")
+		cleanUp := app.runShell(envPager, nil, "$|")
 		io.Copy(app.cmdIn, listBinds(gOpts.keys))
 		app.cmdIn.Close()
 		cleanUp()

--- a/lf.1
+++ b/lf.1
@@ -95,6 +95,7 @@ The following commands are provided by lf:
     tag
     tag-toggle               (default 't')
     maps
+    cmaps
 .EE
 .PP
 The following command line commands are provided by lf:
@@ -746,9 +747,10 @@ Capitalize/uppercase/lowercase the current word and jump to the next word.
 .PP
 .EX
     maps
+    cmaps
 .EE
 .PP
-List all key mappings.
+List all key mappings in normal mode or command-line editing mode.
 .SH OPTIONS
 This section shows information about options to customize the behavior. Character ':' is used as the separator for list options '[]int' and '[]string'.
 .PP


### PR DESCRIPTION
This makes the `:maps` command from #1146 work on Windows and creates `:cmaps`.

This (as well as `:maps` itself) is based on @jackielli's work in #1146 and #1152.

I intend to refactor the code in this or a separate PR, but I thought I'd submit the critical and simple bit first. Adding `:cmaps` is also now trivial, and given the nice new naming scheme it would seem like an omission not to have it. (But I can remove it or split it in a separate PR if it needs more discussion).