### PR TITLE
Fix crash when sorting files in a directory

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -470,10 +470,11 @@ func (nav *nav) checkDir(dir *dir) {
 		dir.ignorecase != gOpts.ignorecase ||
 		dir.ignoredia != gOpts.ignoredia:
 		dir.loading = true
+		sd := *dir
 		go func() {
-			dir.sort()
-			dir.loading = false
-			nav.dirChan <- dir
+			sd.sort()
+			sd.loading = false
+			nav.dirChan <- &sd
 		}()
 	}
 }


### PR DESCRIPTION
Fixes #1200 
Fixes #502 

Sorting a directory in a separate goroutine without making a copy can cause `lf` to crash under some circumstances. This can happen either when the main goroutine also sorts the directory, on when the code is invoked twice so that two goroutines sort the same directory.
