### PR TITLE
Fix statusbar spacing

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -490,7 +490,7 @@ func (e *setExpr) eval(app *app, args []string) {
 		toks := strings.Split(e.val, ":")
 		for _, s := range toks {
 			switch s {
-			case "df", "acc", "progress", "selection", "ind", "tot":
+			case "df", "acc", "progress", "selection", "ind":
 			default:
 				app.ui.echoerr("ruler: should consist of 'df', 'acc', 'progress', 'selection', or 'ind' separated with colon")
 				return

--- a/os.go
+++ b/os.go
@@ -239,5 +239,5 @@ func diskFree(wd string) string {
 	}
 
 	// Available blocks * size per block = available space in bytes
-	return " df: " + humanize(int64(uint64(stat.Bavail)*uint64(stat.Bsize)))
+	return "df: " + humanize(int64(uint64(stat.Bavail)*uint64(stat.Bsize)))
 }

--- a/os_windows.go
+++ b/os_windows.go
@@ -198,5 +198,5 @@ func diskFree(wd string) string {
 		log.Printf("diskfree: %s", err)
 		return ""
 	}
-	return " df: " + humanize(int64(free))
+	return "df: " + humanize(int64(free))
 }

--- a/ui.go
+++ b/ui.go
@@ -815,7 +815,7 @@ func (ui *ui) drawStatLine(nav *nav) {
 	ind := min(dir.ind+1, tot)
 	acc := string(ui.keyCount) + string(ui.keyAcc)
 
-	var selection string
+	selection := []string{}
 
 	if len(nav.saves) > 0 {
 		copy := 0
@@ -828,55 +828,58 @@ func (ui *ui) drawStatLine(nav *nav) {
 			}
 		}
 		if copy > 0 {
-			selection += fmt.Sprintf("  \033[33;7m %d \033[0m", copy)
+			selection = append(selection, fmt.Sprintf("\033[33;7m %d \033[0m", copy))
 		}
 		if move > 0 {
-			selection += fmt.Sprintf("  \033[31;7m %d \033[0m", move)
+			selection = append(selection, fmt.Sprintf("\033[31;7m %d \033[0m", move))
 		}
 	}
 
 	currSelections := nav.currSelections()
 	if len(currSelections) > 0 {
-		selection += fmt.Sprintf("  \033[35;7m %d \033[0m", len(currSelections))
+		selection = append(selection, fmt.Sprintf("\033[35;7m %d \033[0m", len(currSelections)))
 	}
 
 	if len(dir.filter) != 0 {
-		selection += "  \033[34;7m F \033[0m"
+		selection = append(selection, "\033[34;7m F \033[0m")
 	}
 
-	var progress string
+	progress := []string{}
 
 	if nav.copyTotal > 0 {
 		percentage := int((100 * float64(nav.copyBytes)) / float64(nav.copyTotal))
-		progress += fmt.Sprintf("  [%d%%]", percentage)
+		progress = append(progress, fmt.Sprintf("[%d%%]", percentage))
 	}
 
 	if nav.moveTotal > 0 {
-		progress += fmt.Sprintf("  [%d/%d]", nav.moveCount, nav.moveTotal)
+		progress = append(progress, fmt.Sprintf("[%d/%d]", nav.moveCount, nav.moveTotal))
 	}
 
 	if nav.deleteTotal > 0 {
-		progress += fmt.Sprintf("  [%d/%d]", nav.deleteCount, nav.deleteTotal)
+		progress = append(progress, fmt.Sprintf("[%d/%d]", nav.deleteCount, nav.deleteTotal))
 	}
 
-	ruler := ""
+	ruler := []string{}
 	for _, s := range gOpts.ruler {
 		switch s {
 		case "df":
-			ruler = fmt.Sprintf("%s%s", ruler, diskFree(dir.path))
+			df := diskFree(dir.path)
+			if df != "" {
+				ruler = append(ruler, df)
+			}
 		case "acc":
-			ruler = fmt.Sprintf("%s%s", ruler, acc)
+			ruler = append(ruler, acc)
 		case "progress":
-			ruler = fmt.Sprintf("%s%s", ruler, progress)
+			ruler = append(ruler, progress...)
 		case "selection":
-			ruler = fmt.Sprintf("%s%s", ruler, selection)
+			ruler = append(ruler, selection...)
 		case "ind":
-			ruler = fmt.Sprintf("%s  %d/%d", ruler, ind, tot)
+			ruler = append(ruler, fmt.Sprintf("%d/%d", ind, tot))
 		}
 
 	}
 
-	ui.msgWin.printRight(ui.screen, 0, st, ruler)
+	ui.msgWin.printRight(ui.screen, 0, st, strings.Join(ruler, "  "))
 }
 
 func (ui *ui) drawBox() {


### PR DESCRIPTION
I saw #1168 had been merged recently so I decided to try it out.

While the different components can be customised, I noticed that the spacing between them sometimes have issues because they stilll follow the previous implementation where the statusbar contents were fixed. For example with `set ruler 'ind:acc'` there is no spacing between the two components because the previous implementation always had `acc` on the left hand side. I have changed the code to store all the components (without any spacing) into an array and then finally join them into a single string at the end.

Also the `ruler` option currently allows `tot` to be specified, altthough it isn't a valid field. I assume it was added by accident.