### PR TITLE
Prevent scrolling to bottom when selecting files

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -486,7 +486,9 @@ func (nav *nav) getDirs(wd string) {
 
 	for curr, base := wd, ""; !isRoot(base); curr, base = filepath.Dir(curr), filepath.Base(curr) {
 		dir := nav.loadDir(curr)
-		dir.sel(base, nav.height)
+		if base != "" {
+			dir.sel(base, nav.height)
+		}
 		dirs = append(dirs, dir)
 	}
 
@@ -1546,7 +1548,12 @@ func (nav *nav) sel(path string) error {
 		last.files = append(last.files, &file{FileInfo: lstat})
 	}
 
-	last.sel(base, nav.height)
+	for i, f := range last.files {
+		if f.Name() == base {
+			nav.move(i)
+			break
+		}
+	}
 
 	return nil
 }

--- a/nav.go
+++ b/nav.go
@@ -1542,7 +1542,7 @@ func (nav *nav) sel(path string) error {
 
 	base := filepath.Base(path)
 
-	last := nav.dirs[len(nav.dirs)-1]
+	last := nav.currDir()
 
 	if last.loading {
 		last.files = append(last.files, &file{FileInfo: lstat})


### PR DESCRIPTION
cc #1193

When selecting a file using either the mouse or the `select` command, the cursor scrolls to the bottom as a result of calling the `dir.sel` function.

I don't think it's a good idea to change how the scrolling works for `dir.sel` - it's useful for forcibly setting the position of the cursor (to the bottom) without taking into account of it's original position (this prevents the cursor from ending up out of bounds if the number of files changes, e.g. by applying a filter). Instead, the code for selecting a file is changed to use `nav.move` to achieve smoother scrolling similar to #1196.