### PR TITLE
Separate filter from selections in the ui ruler

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -152,7 +152,7 @@ The following options can be used to customize the behavior of lf:
 	ratios           []int     (default '1:2:3')
 	relativenumber   bool      (default false)
 	reverse          bool      (default false)
-	ruler            []string  (default 'acc:progress:selection:ind')
+	ruler            []string  (default 'acc:progress:selection:filter:ind')
 	scrolloff        int       (default 0)
 	selmode          string    (default 'all')
 	shell            string    (default 'sh' for Unix and 'cmd' for Windows)
@@ -819,10 +819,16 @@ When 'number' is enabled, current line shows the absolute position, otherwise no
 
 Reverse the direction of sort.
 
-	ruler          []string  (default 'acc:progress:selection:ind')
+	ruler          []string  (default 'acc:progress:selection:filter:ind')
 
 List of information shown in status line ruler.
 Currently supported information types are 'acc', 'progress', 'selection', 'ind' and 'df'.
+`acc` shows the pressed keys (e.g. for bindings with multiple key presses or counts given to bindings).
+`progress` shows the progress of file operations (e.g. copying a large directory).
+`selection` shows the number of files that are selected, or designated for being cut/copied.
+`filter` shows 'F' if a filter is currently being applied.
+`ind` shows the current position of the cursor as well as the number of files in the current directory.
+`df` shows the amount of free disk space remaining.
 
 	selmode        string    (default 'all')
 

--- a/docstring.go
+++ b/docstring.go
@@ -155,7 +155,7 @@ The following options can be used to customize the behavior of lf:
     ratios           []int     (default '1:2:3')
     relativenumber   bool      (default false)
     reverse          bool      (default false)
-    ruler            []string  (default 'acc:progress:selection:ind')
+    ruler            []string  (default 'acc:progress:selection:filter:ind')
     scrolloff        int       (default 0)
     selmode          string    (default 'all')
     shell            string    (default 'sh' for Unix and 'cmd' for Windows)
@@ -874,10 +874,17 @@ current line shows the absolute position, otherwise nothing is shown.
 
 Reverse the direction of sort.
 
-    ruler          []string  (default 'acc:progress:selection:ind')
+    ruler          []string  (default 'acc:progress:selection:filter:ind')
 
 List of information shown in status line ruler. Currently supported information
-types are 'acc', 'progress', 'selection', 'ind' and 'df'.
+types are 'acc', 'progress', 'selection', 'ind' and 'df'. 'acc' shows the
+pressed keys (e.g. for bindings with multiple key presses or counts given to
+bindings). 'progress' shows the progress of file operations (e.g. copying a
+large directory). 'selection' shows the number of files that are selected,
+or designated for being cut/copied. 'filter' shows 'F' if a filter is currently
+being applied. 'ind' shows the current position of the cursor as well as the
+number of files in the current directory. 'df' shows the amount of free disk
+space remaining.
 
     selmode        string    (default 'all')
 

--- a/eval.go
+++ b/eval.go
@@ -490,9 +490,9 @@ func (e *setExpr) eval(app *app, args []string) {
 		toks := strings.Split(e.val, ":")
 		for _, s := range toks {
 			switch s {
-			case "df", "acc", "progress", "selection", "ind":
+			case "df", "acc", "progress", "selection", "filter", "ind":
 			default:
-				app.ui.echoerr("ruler: should consist of 'df', 'acc', 'progress', 'selection', or 'ind' separated with colon")
+				app.ui.echoerr("ruler: should consist of 'df', 'acc', 'progress', 'selection', 'filter' or 'ind' separated with colon")
 				return
 			}
 		}

--- a/lf.1
+++ b/lf.1
@@ -171,7 +171,7 @@ The following options can be used to customize the behavior of lf:
     ratios           []int     (default '1:2:3')
     relativenumber   bool      (default false)
     reverse          bool      (default false)
-    ruler            []string  (default 'acc:progress:selection:ind')
+    ruler            []string  (default 'acc:progress:selection:filter:ind')
     scrolloff        int       (default 0)
     selmode          string    (default 'all')
     shell            string    (default 'sh' for Unix and 'cmd' for Windows)
@@ -984,10 +984,10 @@ Show the position number relative to the current line. When 'number' is enabled,
 Reverse the direction of sort.
 .PP
 .EX
-    ruler          []string  (default 'acc:progress:selection:ind')
+    ruler          []string  (default 'acc:progress:selection:filter:ind')
 .EE
 .PP
-List of information shown in status line ruler. Currently supported information types are 'acc', 'progress', 'selection', 'ind' and 'df'.
+List of information shown in status line ruler. Currently supported information types are 'acc', 'progress', 'selection', 'ind' and 'df'. `acc` shows the pressed keys (e.g. for bindings with multiple key presses or counts given to bindings). `progress` shows the progress of file operations (e.g. copying a large directory). `selection` shows the number of files that are selected, or designated for being cut/copied. `filter` shows 'F' if a filter is currently being applied. `ind` shows the current position of the cursor as well as the number of files in the current directory. `df` shows the amount of free disk space remaining.
 .PP
 .EX
     selmode        string    (default 'all')

--- a/opts.go
+++ b/opts.go
@@ -133,7 +133,7 @@ func init() {
 	gOpts.hiddenfiles = []string{".*"}
 	gOpts.history = true
 	gOpts.info = nil
-	gOpts.ruler = []string{"acc", "progress", "selection", "ind"}
+	gOpts.ruler = []string{"acc", "progress", "selection", "filter", "ind"}
 	gOpts.shellopts = nil
 	gOpts.sortType = sortType{naturalSort, dirfirstSort}
 	gOpts.tempmarks = "'"

--- a/ui.go
+++ b/ui.go
@@ -840,10 +840,6 @@ func (ui *ui) drawStatLine(nav *nav) {
 		selection = append(selection, fmt.Sprintf("\033[35;7m %d \033[0m", len(currSelections)))
 	}
 
-	if len(dir.filter) != 0 {
-		selection = append(selection, "\033[34;7m F \033[0m")
-	}
-
 	progress := []string{}
 
 	if nav.copyTotal > 0 {
@@ -873,6 +869,10 @@ func (ui *ui) drawStatLine(nav *nav) {
 			ruler = append(ruler, progress...)
 		case "selection":
 			ruler = append(ruler, selection...)
+		case "filter":
+			if len(dir.filter) != 0 {
+				ruler = append(ruler, "\033[34;7m F \033[0m")
+			}
 		case "ind":
 			ruler = append(ruler, fmt.Sprintf("%d/%d", ind, tot))
 		}


### PR DESCRIPTION
Add a new "filter" keyword to the `ruler` option so that the filter indicator can be displayed independently of the selections. Also updated the documentation to explain what each of the keywords means.