### PR TITLE
Add `jumps` command for displaying the jump list

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -29,6 +29,7 @@ var (
 		"open",
 		"jump-next",
 		"jump-prev",
+		"jumps",
 		"top",
 		"bottom",
 		"high",

--- a/doc.go
+++ b/doc.go
@@ -616,7 +616,9 @@ List all key mappings in normal mode or command-line editing mode.
 
 	jumps
 
-List the contents of the jump list. A '>' is used to mark the current location in the jump list.
+List the contents of the jump list.
+Each location is marked with the count that can be used with the `jump-prev` and `jump-next` commands (e.g. use `3[` to move three spaces backwards in the jump list).
+A '>' is used to mark the current location in the jump list.
 
 # Options
 

--- a/doc.go
+++ b/doc.go
@@ -81,6 +81,7 @@ The following commands are provided by lf:
 	tag-toggle               (default 't')
 	maps
 	cmaps
+	jumps
 
 The following command line commands are provided by lf:
 
@@ -612,6 +613,10 @@ Capitalize/uppercase/lowercase the current word and jump to the next word.
 	cmaps
 
 List all key mappings in normal mode or command-line editing mode.
+
+	jumps
+
+List the contents of the jump list. A '>' is used to mark the current location in the jump list.
 
 # Options
 

--- a/doc.go
+++ b/doc.go
@@ -616,7 +616,7 @@ List all key mappings in normal mode or command-line editing mode.
 
 	jumps
 
-List the contents of the jump list.
+List the contents of the jump list, in order of the most recently visited locations.
 Each location is marked with the count that can be used with the `jump-prev` and `jump-next` commands (e.g. use `3[` to move three spaces backwards in the jump list).
 A '>' is used to mark the current location in the jump list.
 

--- a/docstring.go
+++ b/docstring.go
@@ -644,8 +644,10 @@ List all key mappings in normal mode or command-line editing mode.
 
     jumps
 
-List the contents of the jump list. A '>' is used to mark the current location
-in the jump list.
+List the contents of the jump list. Each location is marked with the count that
+can be used with the 'jump-prev' and 'jump-next' commands (e.g. use '3[' to move
+three spaces backwards in the jump list). A '>' is used to mark the current
+location in the jump list.
 
 # Options
 

--- a/docstring.go
+++ b/docstring.go
@@ -84,6 +84,7 @@ The following commands are provided by lf:
     tag-toggle               (default 't')
     maps
     cmaps
+    jumps
 
 The following command line commands are provided by lf:
 
@@ -640,6 +641,11 @@ Capitalize/uppercase/lowercase the current word and jump to the next word.
     cmaps
 
 List all key mappings in normal mode or command-line editing mode.
+
+    jumps
+
+List the contents of the jump list. A '>' is used to mark the current location
+in the jump list.
 
 # Options
 

--- a/docstring.go
+++ b/docstring.go
@@ -644,10 +644,11 @@ List all key mappings in normal mode or command-line editing mode.
 
     jumps
 
-List the contents of the jump list. Each location is marked with the count that
-can be used with the 'jump-prev' and 'jump-next' commands (e.g. use '3[' to move
-three spaces backwards in the jump list). A '>' is used to mark the current
-location in the jump list.
+List the contents of the jump list, in order of the most recently visited
+locations. Each location is marked with the count that can be used with the
+'jump-prev' and 'jump-next' commands (e.g. use '3[' to move three spaces
+backwards in the jump list). A '>' is used to mark the current location in the
+jump list.
 
 # Options
 

--- a/eval.go
+++ b/eval.go
@@ -2509,6 +2509,11 @@ func (e *callExpr) eval(app *app, args []string) {
 		io.Copy(app.cmdIn, listBinds(gOpts.cmdkeys))
 		app.cmdIn.Close()
 		cleanUp()
+	case "jumps":
+		cleanUp := app.runShell(envPager, nil, "$|")
+		io.Copy(app.cmdIn, listJumps(app.nav.jumpList, app.nav.jumpListInd))
+		app.cmdIn.Close()
+		cleanUp()
 	default:
 		cmd, ok := gOpts.cmds[e.name]
 		if !ok {

--- a/lf.1
+++ b/lf.1
@@ -760,7 +760,7 @@ List all key mappings in normal mode or command-line editing mode.
     jumps
 .EE
 .PP
-List the contents of the jump list. Each location is marked with the count that can be used with the `jump-prev` and `jump-next` commands (e.g. use `3[` to move three spaces backwards in the jump list). A '>' is used to mark the current location in the jump list.
+List the contents of the jump list, in order of the most recently visited locations. Each location is marked with the count that can be used with the `jump-prev` and `jump-next` commands (e.g. use `3[` to move three spaces backwards in the jump list). A '>' is used to mark the current location in the jump list.
 .SH OPTIONS
 This section shows information about options to customize the behavior. Character ':' is used as the separator for list options '[]int' and '[]string'.
 .PP

--- a/lf.1
+++ b/lf.1
@@ -760,7 +760,7 @@ List all key mappings in normal mode or command-line editing mode.
     jumps
 .EE
 .PP
-List the contents of the jump list. A '>' is used to mark the current location in the jump list.
+List the contents of the jump list. Each location is marked with the count that can be used with the `jump-prev` and `jump-next` commands (e.g. use `3[` to move three spaces backwards in the jump list). A '>' is used to mark the current location in the jump list.
 .SH OPTIONS
 This section shows information about options to customize the behavior. Character ':' is used as the separator for list options '[]int' and '[]string'.
 .PP

--- a/lf.1
+++ b/lf.1
@@ -96,6 +96,7 @@ The following commands are provided by lf:
     tag-toggle               (default 't')
     maps
     cmaps
+    jumps
 .EE
 .PP
 The following command line commands are provided by lf:
@@ -754,6 +755,12 @@ Capitalize/uppercase/lowercase the current word and jump to the next word.
 .EE
 .PP
 List all key mappings in normal mode or command-line editing mode.
+.PP
+.EX
+    jumps
+.EE
+.PP
+List the contents of the jump list. A '>' is used to mark the current location in the jump list.
 .SH OPTIONS
 This section shows information about options to customize the behavior. Character ':' is used as the separator for list options '[]int' and '[]string'.
 .PP

--- a/ui.go
+++ b/ui.go
@@ -1056,6 +1056,29 @@ func listBinds(binds map[string]expr) *bytes.Buffer {
 	return b
 }
 
+func listJumps(jumps []string, ind int) *bytes.Buffer {
+	t := new(tabwriter.Writer)
+	b := new(bytes.Buffer)
+
+	maxlength := len(strconv.Itoa(max(ind, len(jumps)-1-ind)))
+
+	t.Init(b, 0, gOpts.tabstop, 2, '\t', 0)
+	fmt.Fprintln(t, "  jump\tpath")
+	for i, path := range jumps {
+		switch {
+		case i < ind:
+			fmt.Fprintf(t, "  %*d\t%s\n", maxlength, ind-i, path)
+		case i > ind:
+			fmt.Fprintf(t, "  %*d\t%s\n", maxlength, i-ind, path)
+		default:
+			fmt.Fprintf(t, "> %*d\t%s\n", maxlength, 0, path)
+		}
+	}
+	t.Flush()
+
+	return b
+}
+
 func listMarks(marks map[string]string) *bytes.Buffer {
 	t := new(tabwriter.Writer)
 	b := new(bytes.Buffer)

--- a/ui.go
+++ b/ui.go
@@ -1064,14 +1064,15 @@ func listJumps(jumps []string, ind int) *bytes.Buffer {
 
 	t.Init(b, 0, gOpts.tabstop, 2, '\t', 0)
 	fmt.Fprintln(t, "  jump\tpath")
-	for i, path := range jumps {
+	// print jumps in order of most recent, Vim uses the opposite order
+	for i := len(jumps) - 1; i >= 0; i-- {
 		switch {
 		case i < ind:
-			fmt.Fprintf(t, "  %*d\t%s\n", maxlength, ind-i, path)
+			fmt.Fprintf(t, "  %*d\t%s\n", maxlength, ind-i, jumps[i])
 		case i > ind:
-			fmt.Fprintf(t, "  %*d\t%s\n", maxlength, i-ind, path)
+			fmt.Fprintf(t, "  %*d\t%s\n", maxlength, i-ind, jumps[i])
 		default:
-			fmt.Fprintf(t, "> %*d\t%s\n", maxlength, 0, path)
+			fmt.Fprintf(t, "> %*d\t%s\n", maxlength, 0, jumps[i])
 		}
 	}
 	t.Flush()


### PR DESCRIPTION
I thought it would be nice to add more functionality for displaying the internal state, now that there is some support for piping data into a pager. I have tried to keep the implementation similar to the Vim counterpart, using relative numbers (useful for jumping with a count, such as <kbd>3[</kbd>), as well as displaying a `>` for the current location in the jump list.