### PR TITLE
Fix count when parsing `bottom` command

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -1462,6 +1462,8 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 		var moved bool
 		if e.count == 1 {
+			// Different from Vim, which would treat a count of 1 as meaning to
+			// move to the first line (i.e. the top)
 			moved = app.nav.bottom()
 		} else {
 			moved = app.nav.move(e.count - 1)

--- a/eval.go
+++ b/eval.go
@@ -1447,7 +1447,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 		var moved bool
-		if e.count == 0 {
+		if e.count == 1 {
 			moved = app.nav.top()
 		} else {
 			moved = app.nav.move(e.count - 1)
@@ -1461,7 +1461,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 		var moved bool
-		if e.count == 0 {
+		if e.count == 1 {
 			moved = app.nav.bottom()
 		} else {
 			moved = app.nav.move(e.count - 1)

--- a/opts.go
+++ b/opts.go
@@ -163,10 +163,10 @@ func init() {
 	gOpts.keys["l"] = &callExpr{"open", nil, 1}
 	gOpts.keys["<right>"] = &callExpr{"open", nil, 1}
 	gOpts.keys["q"] = &callExpr{"quit", nil, 1}
-	gOpts.keys["gg"] = &callExpr{"top", nil, 0}
-	gOpts.keys["<home>"] = &callExpr{"top", nil, 0}
-	gOpts.keys["G"] = &callExpr{"bottom", nil, 0}
-	gOpts.keys["<end>"] = &callExpr{"bottom", nil, 0}
+	gOpts.keys["gg"] = &callExpr{"top", nil, 1}
+	gOpts.keys["<home>"] = &callExpr{"top", nil, 1}
+	gOpts.keys["G"] = &callExpr{"bottom", nil, 1}
+	gOpts.keys["<end>"] = &callExpr{"bottom", nil, 1}
 	gOpts.keys["H"] = &callExpr{"high", nil, 1}
 	gOpts.keys["M"] = &callExpr{"middle", nil, 1}
 	gOpts.keys["L"] = &callExpr{"low", nil, 1}

--- a/parse.go
+++ b/parse.go
@@ -228,11 +228,7 @@ func (p *parser) parseExpr() expr {
 
 			s.scan()
 
-			count := 1
-			if name == "top" || name == "bottom" {
-				count = 0
-			}
-			result = &callExpr{name, args, count}
+			result = &callExpr{name, args, 1}
 		}
 	case tokenColon:
 		s.scan()

--- a/parse.go
+++ b/parse.go
@@ -228,7 +228,11 @@ func (p *parser) parseExpr() expr {
 
 			s.scan()
 
-			result = &callExpr{name, args, 1}
+			count := 1
+			if name == "top" || name == "bottom" {
+				count = 0
+			}
+			result = &callExpr{name, args, count}
 		}
 	case tokenColon:
 		s.scan()


### PR DESCRIPTION
Fixes #1239 

To reproduce, type `:bottom` into the command line, or alternatively define a custom mapping like `map b bottom` in the config file.

Since #1196, the `top` and `bottom` commands take a count which specifies which line to jump to. For this to work, the default counts for these two commands have to be changed to 0 (the usual default count for commands is 1), to enable jumping to the first line. ~This change modifies to default count to be 0 specifically for these two commands.~ **Edit:** I changed my mind to use the alternate solution below.

An alternate solution would be to have all the commands use a default count of 1, and just not allow the user to jump to the first line, since `top` does this already.