### PR TITLE
Expand tilde during autocompletion

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -334,7 +334,7 @@ func matchFile(s string) (matches []string, longest []rune) {
 		if isRoot(s) || filepath.Base(s) != s {
 			name = filepath.Join(filepath.Dir(unescape(s)), f.Name())
 		}
-		name = escape(name)
+		name = escape(replaceTilde(name))
 
 		item := f.Name()
 		if f.Mode().IsDir() {

--- a/eval.go
+++ b/eval.go
@@ -945,6 +945,11 @@ func doComplete(app *app) (matches []string) {
 
 func menuComplete(app *app, dir int) {
 	if !app.menuCompActive {
+		toks := tokenize(string(app.ui.cmdAccLeft))
+		for i, tok := range toks {
+			toks[i] = replaceTilde(tok)
+		}
+		app.ui.cmdAccLeft = []rune(strings.Join(toks, " "))
 		app.ui.cmdTmp = app.ui.cmdAccLeft
 		app.menuComps = doComplete(app)
 		if len(app.menuComps) > 1 {


### PR DESCRIPTION
Fixes #1175 

When typing commands like `:echo ~/foo.txt`, the autocompletion will internally expand the tilde for matching purposes, but when the command is evaluated afterwards, the tilde is not expanded. This is very confusing for users, and raises the question of why the autocompletion respects the tilde when matching in the first place.

I can see two possible solutions:

1. Recognise the tilde and expand it during the parsing stage
2. Treat the tilde as a regular character during the parsing stage, but expand all arguments just before running a command

This PR uses the first approach. While I think the second approach is easier to implement, the problem is that unconditionally tilde expanding every argument after the parsing stage means that there is no way for the user to pass a literal tilde by quoting or escaping it.