### PR TITLE
Support modifiers in special key mappings

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1146,8 +1146,9 @@ It is possible to combine special keys with modifiers:
 
 	map <a-enter> down
 
-Please note that, some key combinations are not possible due to the way terminals work (e.g. control and h combination sends a backspace key instead).
-The easiest way to find the name of a key combination is to press the key while lf is running and read the name of the key from the unknown mapping error.
+WARNING: Some key combinations will likely be intercepted by your OS, window manager, or terminal.
+Other key combinations cannot be recognized by lf due to the way terminals work (e.g. `Ctrl+h` combination sends a backspace key instead).
+The easiest way to find out the name of a key combination and whether it will work on your system is to press the key while lf is running and read the name from the "unknown mapping" error.
 
 Mouse buttons are prefixed with 'm' character:
 

--- a/doc.go
+++ b/doc.go
@@ -1142,6 +1142,10 @@ On these terminals, keys combined with the alt key are prefixed with 'a' charact
 
 	map <a-a> down
 
+It is possible to combine special keys with modifiers:
+
+	map <a-enter> down
+
 Please note that, some key combinations are not possible due to the way terminals work (e.g. control and h combination sends a backspace key instead).
 The easiest way to find the name of a key combination is to press the key while lf is running and read the name of the key from the unknown mapping error.
 

--- a/docstring.go
+++ b/docstring.go
@@ -1228,10 +1228,12 @@ It is possible to combine special keys with modifiers:
 
     map <a-enter> down
 
-Please note that, some key combinations are not possible due to the way
-terminals work (e.g. control and h combination sends a backspace key instead).
-The easiest way to find the name of a key combination is to press the key while
-lf is running and read the name of the key from the unknown mapping error.
+WARNING: Some key combinations will likely be intercepted by your OS,
+window manager, or terminal. Other key combinations cannot be recognized by lf
+due to the way terminals work (e.g. 'Ctrl+h' combination sends a backspace key
+instead). The easiest way to find out the name of a key combination and whether
+it will work on your system is to press the key while lf is running and read the
+name from the "unknown mapping" error.
 
 Mouse buttons are prefixed with 'm' character:
 

--- a/docstring.go
+++ b/docstring.go
@@ -1224,6 +1224,10 @@ the alt key are prefixed with 'a' character:
 
     map <a-a> down
 
+It is possible to combine special keys with modifiers:
+
+    map <a-enter> down
+
 Please note that, some key combinations are not possible due to the way
 terminals work (e.g. control and h combination sends a backspace key instead).
 The easiest way to find the name of a key combination is to press the key while

--- a/lf.1
+++ b/lf.1
@@ -1388,6 +1388,12 @@ Newer terminals (e.g. gnome-terminal) may prefix the key with an escape key when
     map <a-a> down
 .EE
 .PP
+It is possible to combine special keys with modifiers:
+.PP
+.EX
+    map <a-enter> down
+.EE
+.PP
 Please note that, some key combinations are not possible due to the way terminals work (e.g. control and h combination sends a backspace key instead). The easiest way to find the name of a key combination is to press the key while lf is running and read the name of the key from the unknown mapping error.
 .PP
 Mouse buttons are prefixed with 'm' character:

--- a/lf.1
+++ b/lf.1
@@ -1394,7 +1394,7 @@ It is possible to combine special keys with modifiers:
     map <a-enter> down
 .EE
 .PP
-Please note that, some key combinations are not possible due to the way terminals work (e.g. control and h combination sends a backspace key instead). The easiest way to find the name of a key combination is to press the key while lf is running and read the name of the key from the unknown mapping error.
+WARNING: Some key combinations will likely be intercepted by your OS, window manager, or terminal. Other key combinations cannot be recognized by lf due to the way terminals work (e.g. `Ctrl+h` combination sends a backspace key instead). The easiest way to find out the name of a key combination and whether it will work on your system is to press the key while lf is running and read the name from the "unknown mapping" error.
 .PP
 Mouse buttons are prefixed with 'm' character:
 .PP

--- a/misc.go
+++ b/misc.go
@@ -275,7 +275,7 @@ func naturalLess(s1, s2 string) bool {
 	}
 }
 
-var reAltKey = regexp.MustCompile(`<a-(.)>`)
+var reModKey = regexp.MustCompile(`<(c|s|a)-(.+)>`)
 
 var reWord = regexp.MustCompile(`(\pL|\pN)+`)
 var reWordBeg = regexp.MustCompile(`([^\pL\pN]|^)(\pL|\pN)`)

--- a/ui.go
+++ b/ui.go
@@ -1187,14 +1187,14 @@ func (ui *ui) readNormalEvent(ev tcell.Event, nav *nav) expr {
 				if tev.Modifiers() == tcell.ModAlt {
 					val = val[:1] + "a-" + val[1:]
 				}
-				if val == "<esc>" && string(ui.keyAcc) != "" {
-					ui.keyAcc = nil
-					ui.keyCount = nil
-					ui.menuBuf = nil
-					return draw
-				}
-				ui.keyAcc = append(ui.keyAcc, []rune(val)...)
 			}
+			if val == "<esc>" && string(ui.keyAcc) != "" {
+				ui.keyAcc = nil
+				ui.keyCount = nil
+				ui.menuBuf = nil
+				return draw
+			}
+			ui.keyAcc = append(ui.keyAcc, []rune(val)...)
 		}
 
 		if len(ui.keyAcc) == 0 {
@@ -1355,14 +1355,16 @@ func readCmdEvent(ev tcell.Event) expr {
 			}
 		} else {
 			val := gKeyVal[tev.Key()]
-			if tev.Modifiers() == tcell.ModCtrl && !strings.HasPrefix(val, "<c-") {
-				val = val[:1] + "c-" + val[1:]
-			}
-			if tev.Modifiers() == tcell.ModShift {
-				val = val[:1] + "s-" + val[1:]
-			}
-			if tev.Modifiers() == tcell.ModAlt {
-				val = val[:1] + "a-" + val[1:]
+			if len(val) > 0 && val[0] == '<' {
+				if tev.Modifiers() == tcell.ModCtrl && !strings.HasPrefix(val, "<c-") {
+					val = val[:1] + "c-" + val[1:]
+				}
+				if tev.Modifiers() == tcell.ModShift {
+					val = val[:1] + "s-" + val[1:]
+				}
+				if tev.Modifiers() == tcell.ModAlt {
+					val = val[:1] + "a-" + val[1:]
+				}
 			}
 			if expr, ok := gOpts.cmdkeys[val]; ok {
 				return expr

--- a/ui.go
+++ b/ui.go
@@ -1105,31 +1105,43 @@ func (ui *ui) pollEvent() tcell.Event {
 	case val := <-ui.keyChan:
 		var ch rune
 		var mod tcell.ModMask
-
 		k := tcell.KeyRune
 
-		if utf8.RuneCountInString(val) == 1 {
+		if key, ok := gValKey[val]; ok {
+			return tcell.NewEventKey(key, ch, mod)
+		}
+
+		switch {
+		case utf8.RuneCountInString(val) == 1:
 			ch, _ = utf8.DecodeRuneInString(val)
-		} else {
-			switch {
-			case val == "<lt>":
-				ch = '<'
-			case val == "<gt>":
-				ch = '>'
-			case val == "<space>":
-				ch = ' '
-			case reAltKey.MatchString(val):
-				match := reAltKey.FindStringSubmatch(val)[1]
-				ch, _ = utf8.DecodeRuneInString(match)
-				mod = tcell.ModMask(tcell.ModAlt)
-			default:
-				if key, ok := gValKey[val]; ok {
-					k = key
-				} else {
-					k = tcell.KeyESC
-					ui.echoerrf("unknown key: %s", val)
-				}
+		case val == "<lt>":
+			ch = '<'
+		case val == "<gt>":
+			ch = '>'
+		case val == "<space>":
+			ch = ' '
+		case reModKey.MatchString(val):
+			matches := reModKey.FindStringSubmatch(val)
+			switch matches[1] {
+			case "c":
+				mod = tcell.ModCtrl
+			case "s":
+				mod = tcell.ModShift
+			case "a":
+				mod = tcell.ModAlt
 			}
+			val = matches[2]
+			if utf8.RuneCountInString(val) == 1 {
+				ch, _ = utf8.DecodeRuneInString(val)
+				break
+			} else if key, ok := gValKey["<"+val+">"]; ok {
+				k = key
+				break
+			}
+			fallthrough
+		default:
+			k = tcell.KeyESC
+			ui.echoerrf("unknown key: %s", val)
 		}
 
 		return tcell.NewEventKey(k, ch, mod)

--- a/ui.go
+++ b/ui.go
@@ -1177,22 +1177,24 @@ func (ui *ui) readNormalEvent(ev tcell.Event, nav *nav) expr {
 			}
 		} else {
 			val := gKeyVal[tev.Key()]
-			if tev.Modifiers() == tcell.ModCtrl && !strings.HasPrefix(val, "<c-") {
-				val = val[:1] + "c-" + val[1:]
+			if len(val) > 0 && val[0] == '<' {
+				if tev.Modifiers() == tcell.ModCtrl && !strings.HasPrefix(val, "<c-") {
+					val = val[:1] + "c-" + val[1:]
+				}
+				if tev.Modifiers() == tcell.ModShift {
+					val = val[:1] + "s-" + val[1:]
+				}
+				if tev.Modifiers() == tcell.ModAlt {
+					val = val[:1] + "a-" + val[1:]
+				}
+				if val == "<esc>" && string(ui.keyAcc) != "" {
+					ui.keyAcc = nil
+					ui.keyCount = nil
+					ui.menuBuf = nil
+					return draw
+				}
+				ui.keyAcc = append(ui.keyAcc, []rune(val)...)
 			}
-			if tev.Modifiers() == tcell.ModShift {
-				val = val[:1] + "s-" + val[1:]
-			}
-			if tev.Modifiers() == tcell.ModAlt {
-				val = val[:1] + "a-" + val[1:]
-			}
-			if val == "<esc>" && string(ui.keyAcc) != "" {
-				ui.keyAcc = nil
-				ui.keyCount = nil
-				ui.menuBuf = nil
-				return draw
-			}
-			ui.keyAcc = append(ui.keyAcc, []rune(val)...)
 		}
 
 		if len(ui.keyAcc) == 0 {

--- a/ui.go
+++ b/ui.go
@@ -1177,12 +1177,6 @@ func (ui *ui) readNormalEvent(ev tcell.Event, nav *nav) expr {
 			}
 		} else {
 			val := gKeyVal[tev.Key()]
-			if val == "<esc>" && string(ui.keyAcc) != "" {
-				ui.keyAcc = nil
-				ui.keyCount = nil
-				ui.menuBuf = nil
-				return draw
-			}
 			if tev.Modifiers() == tcell.ModCtrl && !strings.HasPrefix(val, "<c-") {
 				val = val[:1] + "c-" + val[1:]
 			}
@@ -1191,6 +1185,12 @@ func (ui *ui) readNormalEvent(ev tcell.Event, nav *nav) expr {
 			}
 			if tev.Modifiers() == tcell.ModAlt {
 				val = val[:1] + "a-" + val[1:]
+			}
+			if val == "<esc>" && string(ui.keyAcc) != "" {
+				ui.keyAcc = nil
+				ui.keyCount = nil
+				ui.menuBuf = nil
+				return draw
 			}
 			ui.keyAcc = append(ui.keyAcc, []rune(val)...)
 		}

--- a/ui.go
+++ b/ui.go
@@ -1171,6 +1171,15 @@ func (ui *ui) readNormalEvent(ev tcell.Event, nav *nav) expr {
 				ui.menuBuf = nil
 				return draw
 			}
+			if tev.Modifiers() == tcell.ModCtrl && !strings.HasPrefix(val, "<c-") {
+				val = val[:1] + "c-" + val[1:]
+			}
+			if tev.Modifiers() == tcell.ModShift {
+				val = val[:1] + "s-" + val[1:]
+			}
+			if tev.Modifiers() == tcell.ModAlt {
+				val = val[:1] + "a-" + val[1:]
+			}
 			ui.keyAcc = append(ui.keyAcc, []rune(val)...)
 		}
 

--- a/ui.go
+++ b/ui.go
@@ -1341,6 +1341,15 @@ func readCmdEvent(ev tcell.Event) expr {
 			}
 		} else {
 			val := gKeyVal[tev.Key()]
+			if tev.Modifiers() == tcell.ModCtrl && !strings.HasPrefix(val, "<c-") {
+				val = val[:1] + "c-" + val[1:]
+			}
+			if tev.Modifiers() == tcell.ModShift {
+				val = val[:1] + "s-" + val[1:]
+			}
+			if tev.Modifiers() == tcell.ModAlt {
+				val = val[:1] + "a-" + val[1:]
+			}
 			if expr, ok := gOpts.cmdkeys[val]; ok {
 				return expr
 			}

--- a/ui.go
+++ b/ui.go
@@ -1150,6 +1150,21 @@ func (ui *ui) pollEvent() tcell.Event {
 	}
 }
 
+func addSpecialKeyModifier(val string, mod tcell.ModMask) string {
+	switch {
+	case !strings.HasPrefix(val, "<"):
+		return val
+	case mod == tcell.ModCtrl && !strings.HasPrefix(val, "<c-"):
+		return "<c-" + val[1:]
+	case mod == tcell.ModShift:
+		return "<s-" + val[1:]
+	case mod == tcell.ModAlt:
+		return "<a-" + val[1:]
+	default:
+		return val
+	}
+}
+
 // This function is used to read a normal event on the client side. For keys,
 // digits are interpreted as command counts but this is only done for digits
 // preceding any non-digit characters (e.g. "42y2k" as 42 times "y2k").
@@ -1177,17 +1192,7 @@ func (ui *ui) readNormalEvent(ev tcell.Event, nav *nav) expr {
 			}
 		} else {
 			val := gKeyVal[tev.Key()]
-			if len(val) > 0 && val[0] == '<' {
-				if tev.Modifiers() == tcell.ModCtrl && !strings.HasPrefix(val, "<c-") {
-					val = val[:1] + "c-" + val[1:]
-				}
-				if tev.Modifiers() == tcell.ModShift {
-					val = val[:1] + "s-" + val[1:]
-				}
-				if tev.Modifiers() == tcell.ModAlt {
-					val = val[:1] + "a-" + val[1:]
-				}
-			}
+			val = addSpecialKeyModifier(val, tev.Modifiers())
 			if val == "<esc>" && string(ui.keyAcc) != "" {
 				ui.keyAcc = nil
 				ui.keyCount = nil
@@ -1355,17 +1360,7 @@ func readCmdEvent(ev tcell.Event) expr {
 			}
 		} else {
 			val := gKeyVal[tev.Key()]
-			if len(val) > 0 && val[0] == '<' {
-				if tev.Modifiers() == tcell.ModCtrl && !strings.HasPrefix(val, "<c-") {
-					val = val[:1] + "c-" + val[1:]
-				}
-				if tev.Modifiers() == tcell.ModShift {
-					val = val[:1] + "s-" + val[1:]
-				}
-				if tev.Modifiers() == tcell.ModAlt {
-					val = val[:1] + "a-" + val[1:]
-				}
-			}
+			val = addSpecialKeyModifier(val, tev.Modifiers())
 			if expr, ok := gOpts.cmdkeys[val]; ok {
 				return expr
 			}


### PR DESCRIPTION
Fixes #205 
Fixes #1163 

Closes #943 (`tcell` can't distinguish between `<enter>` and `Shift+<enter>`)

---

For me the following mappings now work and are all distinguishable from each other:

```
map <down> echo down
map <c-down> echo ctrl down
map <a-down> echo alt down
map <s-down> echo shift down
```

`cmap` expressions are also supported:

```
cmap <a-up> cmd-menu-complete-back
cmap <a-down> cmd-menu-complete
```

`push` commands also work with these new mappings:

```
map <a-enter> echo hello world
push <a-enter>
```

It would be nice if someone could also try this out to see if they can map some new key combinations.