### PR TITLE
Support custom colors for `drawbox` characters

### DIFF
--- a/colors.go
+++ b/colors.go
@@ -81,6 +81,14 @@ func parseStyles() styleMap {
 	return sm
 }
 
+func parseEscapeSequence(s string) tcell.Style {
+	s = strings.TrimPrefix(s, "\033[")
+	if i := strings.IndexByte(s, 'm'); i >= 0 {
+		s = s[:i]
+	}
+	return applyAnsiCodes(s, tcell.StyleDefault)
+}
+
 func applyAnsiCodes(s string, st tcell.Style) tcell.Style {
 	toks := strings.Split(s, ";")
 

--- a/complete.go
+++ b/complete.go
@@ -116,6 +116,7 @@ var (
 		"autoquit",
 		"noautoquit",
 		"autoquit!",
+		"borderfmt",
 		"cursoractivefmt",
 		"cursorparentfmt",
 		"cursorpreviewfmt",

--- a/doc.go
+++ b/doc.go
@@ -117,6 +117,7 @@ The following options can be used to customize the behavior of lf:
 
 	anchorfind       bool      (default true)
 	autoquit         bool      (default false)
+	borderfmt        string    (default "\033[0m")
 	cleaner          string    (default '')
 	cursoractivefmt  string    (default "\033[7m")
 	cursorparentfmt  string    (default "\033[7m")
@@ -632,6 +633,10 @@ When this option is enabled, find command starts matching patterns from the begi
 	autoquit       bool      (default false)
 
 Automatically quit server when there are no clients left connected.
+
+	borderfmt      string    (default "\033[0m")
+
+Format string of the box drawing characters enabled by the `drawbox` option.
 
 	cleaner        string    (default '') (not called if empty)
 

--- a/docstring.go
+++ b/docstring.go
@@ -120,6 +120,7 @@ The following options can be used to customize the behavior of lf:
 
     anchorfind       bool      (default true)
     autoquit         bool      (default false)
+    borderfmt        string    (default "\033[0m")
     cleaner          string    (default '')
     cursoractivefmt  string    (default "\033[7m")
     cursorparentfmt  string    (default "\033[7m")
@@ -663,6 +664,10 @@ beginning of file names, otherwise, it can match at an arbitrary position.
     autoquit       bool      (default false)
 
 Automatically quit server when there are no clients left connected.
+
+    borderfmt      string    (default "\033[0m")
+
+Format string of the box drawing characters enabled by the 'drawbox' option.
 
     cleaner        string    (default '') (not called if empty)
 

--- a/eval.go
+++ b/eval.go
@@ -58,6 +58,8 @@ func (e *setExpr) eval(app *app, args []string) {
 			return
 		}
 		gOpts.autoquit = !gOpts.autoquit
+	case "borderfmt":
+		gOpts.borderfmt = e.val
 	case "cleaner":
 		gOpts.cleaner = replaceTilde(e.val)
 	case "cursoractivefmt":

--- a/lf.1
+++ b/lf.1
@@ -136,6 +136,7 @@ The following options can be used to customize the behavior of lf:
 .EX
     anchorfind       bool      (default true)
     autoquit         bool      (default false)
+    borderfmt        string    (default "\e033[0m")
     cleaner          string    (default '')
     cursoractivefmt  string    (default "\e033[7m")
     cursorparentfmt  string    (default "\e033[7m")
@@ -775,6 +776,12 @@ When this option is enabled, find command starts matching patterns from the begi
 .EE
 .PP
 Automatically quit server when there are no clients left connected.
+.PP
+.EX
+    borderfmt      string    (default "\e033[0m")
+.EE
+.PP
+Format string of the box drawing characters enabled by the `drawbox` option.
 .PP
 .EX
     cleaner        string    (default '') (not called if empty)

--- a/opts.go
+++ b/opts.go
@@ -30,6 +30,7 @@ type sortType struct {
 var gOpts struct {
 	anchorfind       bool
 	autoquit         bool
+	borderfmt        string
 	cursoractivefmt  string
 	cursorparentfmt  string
 	cursorpreviewfmt string
@@ -94,6 +95,7 @@ func init() {
 	gOpts.dironly = false
 	gOpts.dirpreviews = false
 	gOpts.drawbox = false
+	gOpts.borderfmt = "\033[0m"
 	gOpts.cursoractivefmt = "\033[7m"
 	gOpts.cursorparentfmt = "\033[7m"
 	gOpts.cursorpreviewfmt = "\033[4m"

--- a/ui.go
+++ b/ui.go
@@ -883,7 +883,7 @@ func (ui *ui) drawStatLine(nav *nav) {
 }
 
 func (ui *ui) drawBox() {
-	st := tcell.StyleDefault
+	st := parseEscapeSequence(gOpts.borderfmt)
 
 	w, h := ui.screen.Size()
 


### PR DESCRIPTION
Fixes #902 

Add a new `borderfmt` option to allow setting the pane borders to a custom color.

---

In addition a new utility function `parseEscapeSequence` is added, which basically converts a string to a `tcell.Style` object. I think this function is better than the existing `optionToFmtstr` function for processing some of the other formatting options like `numberfmt` and `tagfmt`.

For example, it is now possible to write this:

```go
win.print(screen, 0, i, parseEscapeSequence(gOpts.numberfmt), ln)
```

Instead of this:

```go
win.print(screen, 0, i, tcell.StyleDefault, fmt.Sprintf(optionToFmtstr(gOpts.numberfmt), ln))
```