### PR TITLE
LF_CONFIG_HOME environment variable 

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -282,10 +282,14 @@ History file should be located at:
 
 You can configure the default values of following variables to change these locations:
 
-	$XDG_CONFIG_HOME  ~/.config
-	$XDG_DATA_HOME    ~/.local/share
-	%ProgramData%     C:\ProgramData
-	%LOCALAPPDATA%    C:\Users\<user>\AppData\Local
+    Unix
+        $XDG_CONFIG_HOME  ~/.config
+        $XDG_DATA_HOME    ~/.local/share
+
+    Windows
+        %ProgramData%     C:\ProgramData
+        %LOCALAPPDATA%    C:\Users\<user>\AppData\Local
+        %LF_CONFIG_HOME%  If set, use this value instead of %LOCALAPPDATA%
 
 A sample configuration file can be found at
 https://github.com/gokcehan/lf/blob/master/etc/lfrc.example

--- a/docstring.go
+++ b/docstring.go
@@ -288,10 +288,14 @@ History file should be located at:
 You can configure the default values of following variables to change these
 locations:
 
-    $XDG_CONFIG_HOME  ~/.config
-    $XDG_DATA_HOME    ~/.local/share
-    %ProgramData%     C:\ProgramData
-    %LOCALAPPDATA%    C:\Users\<user>\AppData\Local
+    Unix
+        $XDG_CONFIG_HOME  ~/.config
+        $XDG_DATA_HOME    ~/.local/share
+
+    Windows
+        %ProgramData%     C:\ProgramData
+        %LOCALAPPDATA%    C:\Users\<user>\AppData\Local
+        %LF_CONFIG_HOME%  If set, use this value instead of %LOCALAPPDATA%
 
 A sample configuration file can be found at
 https://github.com/gokcehan/lf/blob/master/etc/lfrc.example

--- a/lf.1
+++ b/lf.1
@@ -329,10 +329,16 @@ History file should be located at:
 You can configure the default values of following variables to change these locations:
 .PP
 .EX
-    $XDG_CONFIG_HOME  ~/.config
-    $XDG_DATA_HOME    ~/.local/share
-    %ProgramData%     C:\eProgramData
-    %LOCALAPPDATA%    C:\eUsers\e<user>\eAppData\eLocal
+    Unix
+        $XDG_CONFIG_HOME  ~/.config
+        $XDG_DATA_HOME    ~/.local/share
+.EE
+.PP
+.EX
+    Windows
+        %ProgramData%     C:\eProgramData
+        %LOCALAPPDATA%    C:\eUsers\e<user>\eAppData\eLocal
+        %LF_CONFIG_HOME%  If set, use this value instead of %LOCALAPPDATA%
 .EE
 .PP
 A sample configuration file can be found at https://github.com/gokcehan/lf/blob/master/etc/lfrc.example

--- a/os_windows.go
+++ b/os_windows.go
@@ -68,7 +68,10 @@ func init() {
 	// remove domain prefix
 	gUser.Username = strings.Split(gUser.Username, `\`)[1]
 
-	data := os.Getenv("LOCALAPPDATA")
+	data := os.Getenv("LF_CONFIG_HOME")
+	if data == "" {
+		data = os.Getenv("LOCALAPPDATA")
+	}
 
 	gConfigPaths = []string{
 		filepath.Join(os.Getenv("ProgramData"), "lf", "lfrc"),


### PR DESCRIPTION
resolves #1209

@gokcehan,  I am submitting this PR for #1209, to add `LF_CONFIG_HOME` as an option for Windows to be an alternative to `LOCALAPPDATA` so as to not affect other installed applications.  I have not touched the Unix side yet as I didn't know if you wanted me to update that, but if you do, please let me know, and I'll add this there as well.

I have also added some documentation for `LF_CONFIG_HOME`, hopefully I did that properly, but please let me know if I need to format it differently.

Thank you