### PR TITLE
Add support for displaying lf options in the ruler

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -829,13 +829,14 @@ Reverse the direction of sort.
 	ruler          []string  (default 'acc:progress:selection:filter:ind')
 
 List of information shown in status line ruler.
-Currently supported information types are 'acc', 'progress', 'selection', 'ind' and 'df'.
+Currently supported information types are 'acc', 'progress', 'selection', 'filter', 'ind', 'df' and names starting with 'lf_'.
 `acc` shows the pressed keys (e.g. for bindings with multiple key presses or counts given to bindings).
 `progress` shows the progress of file operations (e.g. copying a large directory).
 `selection` shows the number of files that are selected, or designated for being cut/copied.
 `filter` shows 'F' if a filter is currently being applied.
 `ind` shows the current position of the cursor as well as the number of files in the current directory.
 `df` shows the amount of free disk space remaining.
+Names starting with `lf_` show the value of environment variables exported by lf. This is useful for displaying the current settings (e.g. `lf_selmode` displays the current setting for the `selmode` option).
 
 	selmode        string    (default 'all')
 

--- a/docstring.go
+++ b/docstring.go
@@ -886,14 +886,17 @@ Reverse the direction of sort.
     ruler          []string  (default 'acc:progress:selection:filter:ind')
 
 List of information shown in status line ruler. Currently supported information
-types are 'acc', 'progress', 'selection', 'ind' and 'df'. 'acc' shows the
-pressed keys (e.g. for bindings with multiple key presses or counts given to
-bindings). 'progress' shows the progress of file operations (e.g. copying a
-large directory). 'selection' shows the number of files that are selected,
-or designated for being cut/copied. 'filter' shows 'F' if a filter is currently
-being applied. 'ind' shows the current position of the cursor as well as the
-number of files in the current directory. 'df' shows the amount of free disk
-space remaining.
+types are 'acc', 'progress', 'selection', 'filter', 'ind', 'df' and names
+starting with 'lf_'. 'acc' shows the pressed keys (e.g. for bindings with
+multiple key presses or counts given to bindings). 'progress' shows the progress
+of file operations (e.g. copying a large directory). 'selection' shows the
+number of files that are selected, or designated for being cut/copied. 'filter'
+shows 'F' if a filter is currently being applied. 'ind' shows the current
+position of the cursor as well as the number of files in the current directory.
+'df' shows the amount of free disk space remaining. Names starting with 'lf_'
+show the value of environment variables exported by lf. This is useful for
+displaying the current settings (e.g. 'lf_selmode' displays the current setting
+for the 'selmode' option).
 
     selmode        string    (default 'all')
 

--- a/eval.go
+++ b/eval.go
@@ -492,8 +492,10 @@ func (e *setExpr) eval(app *app, args []string) {
 			switch s {
 			case "df", "acc", "progress", "selection", "filter", "ind":
 			default:
-				app.ui.echoerr("ruler: should consist of 'df', 'acc', 'progress', 'selection', 'filter' or 'ind' separated with colon")
-				return
+				if !strings.HasPrefix(s, "lf_") {
+					app.ui.echoerr("ruler: should consist of 'df', 'acc', 'progress', 'selection', 'filter', 'ind' or start with 'lf_' separated with colon")
+					return
+				}
 			}
 		}
 		gOpts.ruler = toks

--- a/lf.1
+++ b/lf.1
@@ -994,7 +994,7 @@ Reverse the direction of sort.
     ruler          []string  (default 'acc:progress:selection:filter:ind')
 .EE
 .PP
-List of information shown in status line ruler. Currently supported information types are 'acc', 'progress', 'selection', 'ind' and 'df'. `acc` shows the pressed keys (e.g. for bindings with multiple key presses or counts given to bindings). `progress` shows the progress of file operations (e.g. copying a large directory). `selection` shows the number of files that are selected, or designated for being cut/copied. `filter` shows 'F' if a filter is currently being applied. `ind` shows the current position of the cursor as well as the number of files in the current directory. `df` shows the amount of free disk space remaining.
+List of information shown in status line ruler. Currently supported information types are 'acc', 'progress', 'selection', 'filter', 'ind', 'df' and names starting with 'lf_'. `acc` shows the pressed keys (e.g. for bindings with multiple key presses or counts given to bindings). `progress` shows the progress of file operations (e.g. copying a large directory). `selection` shows the number of files that are selected, or designated for being cut/copied. `filter` shows 'F' if a filter is currently being applied. `ind` shows the current position of the cursor as well as the number of files in the current directory. `df` shows the amount of free disk space remaining. Names starting with `lf_` show the value of environment variables exported by lf. This is useful for displaying the current settings (e.g. `lf_selmode` displays the current setting for the `selmode` option).
 .PP
 .EX
     selmode        string    (default 'all')

--- a/ui.go
+++ b/ui.go
@@ -804,6 +804,23 @@ func (ui *ui) drawPromptLine(nav *nav) {
 	ui.promptWin.print(ui.screen, 0, 0, st, prompt)
 }
 
+func addStatLineVar(ruler []string, name string) []string {
+	if !strings.HasPrefix(name, "lf_") {
+		return ruler
+	}
+
+	val := os.Getenv(name)
+	if val == "" {
+		return ruler
+	}
+
+	if strings.HasPrefix(name, "lf_user_") {
+		return append(ruler, val)
+	} else {
+		return append(ruler, fmt.Sprintf("%s=%s", strings.TrimPrefix(name, "lf_"), val))
+	}
+}
+
 func (ui *ui) drawStatLine(nav *nav) {
 	st := tcell.StyleDefault
 
@@ -855,6 +872,8 @@ func (ui *ui) drawStatLine(nav *nav) {
 		progress = append(progress, fmt.Sprintf("[%d/%d]", nav.deleteCount, nav.deleteTotal))
 	}
 
+	exportOpts()
+
 	ruler := []string{}
 	for _, s := range gOpts.ruler {
 		switch s {
@@ -875,8 +894,9 @@ func (ui *ui) drawStatLine(nav *nav) {
 			}
 		case "ind":
 			ruler = append(ruler, fmt.Sprintf("%d/%d", ind, tot))
+		default:
+			ruler = addStatLineVar(ruler, s)
 		}
-
 	}
 
 	ui.msgWin.printRight(ui.screen, 0, st, strings.Join(ruler, "  "))


### PR DESCRIPTION
Fixes #112 
Fixes #310 
Fixes #1103 
Fixes #1174 

## Summary

This change enhances the `ruler` option to allow fields starting with `lf_`, which will resolve the corresponding environment variables exported by `lf`. Built-in options are displayed in the format `<name>=<value>`, for example `hidden=true`, while user-defined options (added in #865) are displayed as is.

## Examples

### Built-in options

Display the current value of the `selmode` option (requested in #1174):

```
set ruler acc:lf_selmode:ind
```

### User-defined options

User-defined options can be used to store arbitrary data in `lf` to be displayed in the ruler. This can be done by creating a script that calls something like `lf -remote "send set user_test 'hello world'"` and then running that script periodically (e.g. using `cron`).

Display the amount of free disk space remaining (requested in #1103):

```shell
#!/bin/sh

diskfree=$(df -h --out=avail . | awk 'NR == 2 { print $1 }')
lf -remote "send set user_df $diskfree"
```

Displaying the time, with a blue background:

```shell
#!/bin/sh

lf -remote "send set user_time \"\033[44m $(date +%R) \033[0m\""
```

## Replacing the builtin `df` functionality

Because this change can now handle calculating free disk space externally, it leaves the question of whether it's worth keeping the `df` functionality added in #1168. On one hand, it does provide convenience for users, and removing it would be a breaking change, but on the other hand it adds more maintenance burden to the project (all the `df_<platform>.go` files), and contradicts with the minimalistic design of `lf`. I am leaning towards removing the `df` functionality since it is still relatively new, but I can understand if others prefer to keep it.