### PR TITLE
Fix example doc doesn't work on files with spaces

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1391,18 +1391,18 @@ You can define a an 'open' command (default 'l' and '<right>') to configure file
 This command is only called when the current file is not a directory, otherwise the directory is entered instead.
 You can define it just as you would define any other command:
 
-	cmd open $vi $fx
+	cmd open $vi "$fx"
 
 It is possible to use different command types:
 
-	cmd open &xdg-open $f
+	cmd open &xdg-open "$f"
 
 You may want to use either file extensions or mime types from 'file' command:
 
 	cmd open ${{
-	    case $(file --mime-type -Lb $f) in
-	        text/*) vi $fx;;
-	        *) for f in $fx; do xdg-open $f > /dev/null 2> /dev/null & done;;
+	    case $(file --mime-type -Lb "$f") in
+	        text/*) vi "$fx";;
+	        *) for f in "$fx"; do xdg-open "$f" > /dev/null 2> /dev/null & done;;
 	    esac
 	}}
 
@@ -1412,9 +1412,9 @@ Regular shell commands (i.e. '$') drop to terminal which results in a flicker fo
 If you want to use asynchronous shell commands (i.e. '&') but also want to use the terminal when necessary (e.g. 'vi' in the above exxample), you can use a remote command:
 
 	cmd open &{{
-	    case $(file --mime-type -Lb $f) in
-	        text/*) lf -remote "send $id \$vi \$fx";;
-	        *) for f in $fx; do xdg-open $f > /dev/null 2> /dev/null & done;;
+	    case $(file --mime-type -Lb "$f") in
+	        text/*) lf -remote "send $id \$vi \"$fx\"";;
+	        *) for f in "$fx"; do xdg-open "$f" > /dev/null 2> /dev/null & done;;
 	    esac
 	}}
 

--- a/docstring.go
+++ b/docstring.go
@@ -1510,18 +1510,18 @@ opening. This command is only called when the current file is not a directory,
 otherwise the directory is entered instead. You can define it just as you would
 define any other command:
 
-    cmd open $vi $fx
+    cmd open $vi "$fx"
 
 It is possible to use different command types:
 
-    cmd open &xdg-open $f
+    cmd open &xdg-open "$f"
 
 You may want to use either file extensions or mime types from 'file' command:
 
     cmd open ${{
-        case $(file --mime-type -Lb $f) in
-            text/*) vi $fx;;
-            *) for f in $fx; do xdg-open $f > /dev/null 2> /dev/null & done;;
+        case $(file --mime-type -Lb "$f") in
+            text/*) vi "$fx";;
+            *) for f in "$fx"; do xdg-open "$f" > /dev/null 2> /dev/null & done;;
         esac
     }}
 
@@ -1535,9 +1535,9 @@ the terminal when necessary (e.g. 'vi' in the above exxample), you can use a
 remote command:
 
     cmd open &{{
-        case $(file --mime-type -Lb $f) in
-            text/*) lf -remote "send $id \$vi \$fx";;
-            *) for f in $fx; do xdg-open $f > /dev/null 2> /dev/null & done;;
+        case $(file --mime-type -Lb "$f") in
+            text/*) lf -remote "send $id \$vi \"$fx\"";;
+            *) for f in "$fx"; do xdg-open "$f" > /dev/null 2> /dev/null & done;;
         esac
     }}
 

--- a/lf.1
+++ b/lf.1
@@ -1589,22 +1589,22 @@ Some options effect both searching and finding. You can disable 'wrapscan' optio
 You can define a an 'open' command (default 'l' and '<right>') to configure file opening. This command is only called when the current file is not a directory, otherwise the directory is entered instead. You can define it just as you would define any other command:
 .PP
 .EX
-    cmd open $vi $fx
+    cmd open $vi "$fx"
 .EE
 .PP
 It is possible to use different command types:
 .PP
 .EX
-    cmd open &xdg-open $f
+    cmd open &xdg-open "$f"
 .EE
 .PP
 You may want to use either file extensions or mime types from 'file' command:
 .PP
 .EX
     cmd open ${{
-        case $(file --mime-type -Lb $f) in
-            text/*) vi $fx;;
-            *) for f in $fx; do xdg-open $f > /dev/null 2> /dev/null & done;;
+        case $(file --mime-type -Lb "$f") in
+            text/*) vi "$fx";;
+            *) for f in "$fx"; do xdg-open "$f" > /dev/null 2> /dev/null & done;;
         esac
     }}
 .EE
@@ -1615,9 +1615,9 @@ Regular shell commands (i.e. '$') drop to terminal which results in a flicker fo
 .PP
 .EX
     cmd open &{{
-        case $(file --mime-type -Lb $f) in
-            text/*) lf -remote "send $id \e$vi \e$fx";;
-            *) for f in $fx; do xdg-open $f > /dev/null 2> /dev/null & done;;
+        case $(file --mime-type -Lb "$f") in
+            text/*) lf -remote "send $id \e$vi \e"$fx\e"";;
+            *) for f in "$fx"; do xdg-open "$f" > /dev/null 2> /dev/null & done;;
         esac
     }}
 .EE


### PR DESCRIPTION
The example "Opening Files" section doesn't work when the file selected contains spaces because of the unquoted variable. I.e: opening a text file named `test file.txt` will result in nothing even though that file is a `text/plain` type.