### PR TITLE
Improve API for parsing escape sequences

### DIFF
--- a/colors.go
+++ b/colors.go
@@ -86,6 +86,10 @@ func parseEscapeSequence(s string) tcell.Style {
 }
 
 func parseApplyEscapeSequence(s string, st tcell.Style) tcell.Style {
+	if s == "" {
+		return st
+	}
+
 	s = strings.TrimPrefix(s, "\033[")
 	if i := strings.IndexByte(s, 'm'); i >= 0 {
 		s = s[:i]

--- a/colors.go
+++ b/colors.go
@@ -82,11 +82,15 @@ func parseStyles() styleMap {
 }
 
 func parseEscapeSequence(s string) tcell.Style {
+	return parseApplyEscapeSequence(s, tcell.StyleDefault)
+}
+
+func parseApplyEscapeSequence(s string, st tcell.Style) tcell.Style {
 	s = strings.TrimPrefix(s, "\033[")
 	if i := strings.IndexByte(s, 'm'); i >= 0 {
 		s = s[:i]
 	}
-	return applyAnsiCodes(s, tcell.StyleDefault)
+	return applyAnsiCodes(s, st)
 }
 
 func applyAnsiCodes(s string, st tcell.Style) tcell.Style {

--- a/colors.go
+++ b/colors.go
@@ -82,10 +82,10 @@ func parseStyles() styleMap {
 }
 
 func parseEscapeSequence(s string) tcell.Style {
-	return parseApplyEscapeSequence(s, tcell.StyleDefault)
+	return applyParsedEscapeSequence(s, tcell.StyleDefault)
 }
 
-func parseApplyEscapeSequence(s string, st tcell.Style) tcell.Style {
+func applyParsedEscapeSequence(s string, st tcell.Style) tcell.Style {
 	if s == "" {
 		return st
 	}

--- a/doc.go
+++ b/doc.go
@@ -664,9 +664,6 @@ The default is to make the active cursor and the parent directory cursor inverte
 
 Some other possibilities to consider for the preview or parent cursors: an empty string for no cursor, "\033[7;2m" for dimmed inverted text (visibility varies by terminal), "\033[7;90m" for inverted text with grey (aka "brightblack") background.
 
-If the format string contains the characters `%s`, it is interpreted as a format string for `fmt.Sprintf`. Such a string should end with the terminal reset sequence.
-For example, "\033[4m%s\033[0m" has the same effect as "\033[4m".
-
 	dircache       bool      (default true)
 
 Cache directory contents.
@@ -900,9 +897,6 @@ Number of space characters to show for horizontal tabulation (U+0009) character.
 	tagfmt         string    (default "\033[31m")
 
 Format string of the tags.
-
-If the format string contains the characters `%s`, it is interpreted as a format string for `fmt.Sprintf`. Such a string should end with the terminal reset sequence.
-For example, "\033[4m%s\033[0m" has the same effect as "\033[4m".
 
 	tempmarks      string    (default '')
 

--- a/docstring.go
+++ b/docstring.go
@@ -700,10 +700,6 @@ string for no cursor, "\033[7;2m" for dimmed inverted text (visibility varies
 by terminal), "\033[7;90m" for inverted text with grey (aka "brightblack")
 background.
 
-If the format string contains the characters '%s', it is interpreted as a format
-string for 'fmt.Sprintf'. Such a string should end with the terminal reset
-sequence. For example, "\033[4m%s\033[0m" has the same effect as "\033[4m".
-
     dircache       bool      (default true)
 
 Cache directory contents.
@@ -961,10 +957,6 @@ Number of space characters to show for horizontal tabulation (U+0009) character.
     tagfmt         string    (default "\033[31m")
 
 Format string of the tags.
-
-If the format string contains the characters '%s', it is interpreted as a format
-string for 'fmt.Sprintf'. Such a string should end with the terminal reset
-sequence. For example, "\033[4m%s\033[0m" has the same effect as "\033[4m".
 
     tempmarks      string    (default '')
 

--- a/lf.1
+++ b/lf.1
@@ -808,8 +808,6 @@ The default is to make the active cursor and the parent directory cursor inverte
 .PP
 Some other possibilities to consider for the preview or parent cursors: an empty string for no cursor, "\e033[7;2m" for dimmed inverted text (visibility varies by terminal), "\e033[7;90m" for inverted text with grey (aka "brightblack") background.
 .PP
-If the format string contains the characters `%s`, it is interpreted as a format string for `fmt.Sprintf`. Such a string should end with the terminal reset sequence. For example, "\e033[4m%s\e033[0m" has the same effect as "\e033[4m".
-.PP
 .EX
     dircache       bool      (default true)
 .EE
@@ -1075,8 +1073,6 @@ Number of space characters to show for horizontal tabulation (U+0009) character.
 .EE
 .PP
 Format string of the tags.
-.PP
-If the format string contains the characters `%s`, it is interpreted as a format string for `fmt.Sprintf`. Such a string should end with the terminal reset sequence. For example, "\e033[4m%s\e033[0m" has the same effect as "\e033[4m".
 .PP
 .EX
     tempmarks      string    (default '')

--- a/ui.go
+++ b/ui.go
@@ -489,11 +489,11 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, context *dirContext, dir
 		if i == dir.pos {
 			switch dirStyle.role {
 			case Active:
-				st = parseApplyEscapeSequence(gOpts.cursoractivefmt, st)
+				st = applyParsedEscapeSequence(gOpts.cursoractivefmt, st)
 			case Parent:
-				st = parseApplyEscapeSequence(gOpts.cursorparentfmt, st)
+				st = applyParsedEscapeSequence(gOpts.cursorparentfmt, st)
 			case Preview:
-				st = parseApplyEscapeSequence(gOpts.cursorpreviewfmt, st)
+				st = applyParsedEscapeSequence(gOpts.cursorpreviewfmt, st)
 			}
 		}
 

--- a/ui.go
+++ b/ui.go
@@ -426,7 +426,7 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, context *dirContext, dir
 				}
 			}
 
-			win.print(screen, 0, i, tcell.StyleDefault, fmt.Sprintf(optionToFmtstr(gOpts.numberfmt), ln))
+			win.print(screen, 0, i, parseEscapeSequence(gOpts.numberfmt), ln)
 		}
 
 		path := filepath.Join(dir.path, f.Name())
@@ -486,29 +486,26 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, context *dirContext, dir
 			}
 		}
 
-		ce := ""
 		if i == dir.pos {
 			switch dirStyle.role {
 			case Active:
-				ce = gOpts.cursoractivefmt
+				st = parseApplyEscapeSequence(gOpts.cursoractivefmt, st)
 			case Parent:
-				ce = gOpts.cursorparentfmt
+				st = parseApplyEscapeSequence(gOpts.cursorparentfmt, st)
 			case Preview:
-				ce = gOpts.cursorpreviewfmt
+				st = parseApplyEscapeSequence(gOpts.cursorpreviewfmt, st)
 			}
 		}
-		cursorescapefmt := optionToFmtstr(ce)
 
 		s = append(s, ' ')
-		styledFilename := fmt.Sprintf(cursorescapefmt, string(s))
-		win.print(screen, lnwidth+1, i, st, styledFilename)
+		win.print(screen, lnwidth+1, i, st, string(s))
 
 		tag, ok := context.tags[path]
 		if ok {
 			if i == dir.pos {
-				win.print(screen, lnwidth+1, i, st, fmt.Sprintf(cursorescapefmt, tag))
+				win.print(screen, lnwidth+1, i, st, tag)
 			} else {
-				win.print(screen, lnwidth+1, i, tcell.StyleDefault, fmt.Sprintf(optionToFmtstr(gOpts.tagfmt), tag))
+				win.print(screen, lnwidth+1, i, parseEscapeSequence(gOpts.tagfmt), tag)
 			}
 		}
 	}

--- a/ui.go
+++ b/ui.go
@@ -500,8 +500,7 @@ func (win *win) printDir(screen tcell.Screen, dir *dir, context *dirContext, dir
 		s = append(s, ' ')
 		win.print(screen, lnwidth+1, i, st, string(s))
 
-		tag, ok := context.tags[path]
-		if ok {
+		if tag, ok := context.tags[path]; ok {
 			if i == dir.pos {
 				win.print(screen, lnwidth+1, i, st, tag)
 			} else {


### PR DESCRIPTION
This builds on the work from #1251 for trying to parse escape sequences like `\033[4m` into `tcell.Style` objects. I think this makes the calling code nicer, compared to using `optionToFmtstr` and `fmt.Sprintf` to apply the styles directly to the raw string.

I also updated the docs, and I believe it's now less likely the user will try something like `set tagfmt "\033[32m(%s)\033[0m"` which attempts to wrap the tag in brackets (not possible because tags should only be a single character) but ends up messing the UI.

cc @ilyagr - I would like your opinion on this PR since you worked on this code previously. To be clear, this is just a refactoring change and there shouldn't be any change in behaviour.

---

**Edit:** To be clear, I have only changed the code relating to options that specify only style (`numberfmt`, `tagfmt`, `cursoractivefmt`, `cursorparentfmt` and `cursorpreviewfmt`), and I don't intend to make changes to any other options like `errorfmt` or `promptfmt` as they are intended to allow string formatting.

There are also pros and cons to this PR as discussed in the comments:

Pros:
- The code is cleaner from a maintenance perspective
- The configuration is simpler from a user perspective (the user doesn't have to choose between `\033[4m` and `\033[4m%s\033[0m`, only the former is officially supported)

Cons:
- This is technically a breaking change because the format string option is now parsed instead of being directly printed. Although I think it is unlikely to impact any users in general, it is still possible someone might be affected.
- The change will have to be documented in the release notes, with instructions on how to migrate (should be relatively minor though).