### PR TITLE
`cmds` command to list all custom commands (aka `cmd` mappings)

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -16,6 +16,7 @@ var (
 		"cmap",
 		"cmaps",
 		"cmd",
+		"cmds",
 		"quit",
 		"up",
 		"half-up",

--- a/doc.go
+++ b/doc.go
@@ -81,6 +81,7 @@ The following commands are provided by lf:
 	tag-toggle               (default 't')
 	maps
 	cmaps
+	cmds
 	jumps
 
 The following command line commands are provided by lf:
@@ -619,6 +620,10 @@ Capitalize/uppercase/lowercase the current word and jump to the next word.
 	cmaps
 
 List all key mappings in normal mode or command-line editing mode.
+
+	cmds
+
+List all custom commands defined using the `cmd` command
 
 	jumps
 

--- a/docstring.go
+++ b/docstring.go
@@ -84,6 +84,7 @@ The following commands are provided by lf:
     tag-toggle               (default 't')
     maps
     cmaps
+    cmds
     jumps
 
 The following command line commands are provided by lf:
@@ -647,6 +648,10 @@ Capitalize/uppercase/lowercase the current word and jump to the next word.
     cmaps
 
 List all key mappings in normal mode or command-line editing mode.
+
+    cmds
+
+List all custom commands defined using the 'cmd' command
 
     jumps
 

--- a/eval.go
+++ b/eval.go
@@ -2523,6 +2523,8 @@ func (e *callExpr) eval(app *app, args []string) {
 
 		app.ui.cmdAccLeft = acc
 		update(app)
+	case "cmds":
+		app.runPagerOnText(listCmds())
 	case "maps":
 		app.runPagerOnText(listBinds(gOpts.keys))
 	case "cmaps":

--- a/lf.1
+++ b/lf.1
@@ -96,6 +96,7 @@ The following commands are provided by lf:
     tag-toggle               (default 't')
     maps
     cmaps
+    cmds
     jumps
 .EE
 .PP
@@ -763,6 +764,12 @@ Capitalize/uppercase/lowercase the current word and jump to the next word.
 .EE
 .PP
 List all key mappings in normal mode or command-line editing mode.
+.PP
+.EX
+    cmds
+.EE
+.PP
+List all custom commands defined using the `cmd` command
 .PP
 .EX
     jumps

--- a/ui.go
+++ b/ui.go
@@ -1036,7 +1036,7 @@ func findBinds(keys map[string]expr, prefix string) (binds map[string]expr, ok b
 	return
 }
 
-func listBinds(binds map[string]expr) *bytes.Buffer {
+func listExprMap(binds map[string]expr, title string) *bytes.Buffer {
 	t := new(tabwriter.Writer)
 	b := new(bytes.Buffer)
 
@@ -1047,13 +1047,21 @@ func listBinds(binds map[string]expr) *bytes.Buffer {
 	sort.Strings(keys)
 
 	t.Init(b, 0, gOpts.tabstop, 2, '\t', 0)
-	fmt.Fprintln(t, "keys\tcommand")
+	fmt.Fprintf(t, "%s\tcommand\n", title)
 	for _, k := range keys {
 		fmt.Fprintf(t, "%s\t%v\n", k, binds[k])
 	}
 	t.Flush()
 
 	return b
+}
+
+func listBinds(binds map[string]expr) *bytes.Buffer {
+	return listExprMap(binds, "keys")
+}
+
+func listCmds() *bytes.Buffer {
+	return listExprMap(gOpts.cmds, "name")
 }
 
 func listJumps(jumps []string, ind int) *bytes.Buffer {


### PR DESCRIPTION
This is a natural complement to the recently introduces `maps` and `cmaps`.

I considered using a different output format, since `cmd` definitions can be long, but I decided against it for now. `lf` already abbreviates commands that take up several lines, and we can change the output format later if needed.