### PR TITLE
Fix typo in misc tests

### DIFF
--- a/misc_test.go
+++ b/misc_test.go
@@ -69,7 +69,7 @@ func TestRuneSliceWidthRange(t *testing.T) {
 
 	for _, test := range tests {
 		if got := runeSliceWidthRange(test.rs, test.beg, test.end); !reflect.DeepEqual(got, test.exp) {
-			t.Errorf("at input '%v' expected '%v' but got '%v'", test.rs, test.rs, got)
+			t.Errorf("at input '%v' expected '%v' but got '%v'", test.rs, test.exp, got)
 		}
 	}
 }


### PR DESCRIPTION
If the unit test fails, it prints out the input twice instead of the expected value.

---

BTW I was having a look at the `runeSliceWidthRange` function because @raslop was working on this in #1029. Unfortunately the current implementation in the master branch does appear to be slightly buggy if you consider the following test cases:

```go
{[]rune{'世', '界', '世', '界'}, 3, 3, []rune{}},
{[]rune{'世', '界', '世', '界'}, 4, 7, []rune{'世'}},
{[]rune{'世', '界', '世', '界'}, 4, 8, []rune{'世', '界'}},
```

In particular the current implementation panics when the beginning and end indexes are the same and happen to be in the middle of a rune, and also the case where the end occurs after the start of the last rune isn't handled properly. The following is a more robust implementation that does handle the above cases in addition to the existing cases:

```go
func runeSliceWidthRange(rs []rune, beg, end int) []rune {
        if beg == end {
                return []rune{}
        }

        curr := 0
        b := 0
        foundb := false
        for i, r := range rs {
                w := runewidth.RuneWidth(r)
                if curr >= beg && !foundb {
                        b = i
                        foundb = true
                }
                if curr == end || curr+w > end {
                        return rs[b:i]
                }
                curr += w
        }

        return rs[b:]
}
```

That being said, `runeSliceWidthRange` is currently called in only a few places when truncating long filenames, and for these cases the filename input is sufficiently long so these edge cases don't matter, so I can understand if you don't want to make any changes to the existing code.

Anyway the suggestion about `runeSliceWidthRange` is a separate thing, and can be addressed later if at all. At the very least the change for correcting the test case error reporting should be merged.