### PR TITLE
Simplify run pager function

### DIFF
--- a/app.go
+++ b/app.go
@@ -602,26 +602,16 @@ func (app *app) runShell(s string, args []string, prefix string) {
 
 }
 
-func (app *app) runPagerOnText(text io.Reader) {
+func (app *app) runPager(stdin io.Reader) {
 	app.nav.exportFiles()
 	app.ui.exportSizes()
 	exportOpts()
 
 	cmd := shellCommand(envPager, nil)
 
+	cmd.Stdin = stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		app.ui.echoerrf("obtaining stdin pipe: %s", err)
-		return
-	}
-
-	go func() {
-		io.Copy(stdin, text)
-		stdin.Close()
-	}()
 
 	app.runCmdSync(cmd, false)
 }

--- a/app.go
+++ b/app.go
@@ -602,7 +602,7 @@ func (app *app) runShell(s string, args []string, prefix string) {
 
 }
 
-func (app *app) runPager(stdin io.Reader) {
+func (app *app) runPagerOn(stdin io.Reader) {
 	app.nav.exportFiles()
 	app.ui.exportSizes()
 	exportOpts()

--- a/eval.go
+++ b/eval.go
@@ -2526,11 +2526,11 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.ui.cmdAccLeft = acc
 		update(app)
 	case "maps":
-		app.runPagerOnText(listBinds(gOpts.keys))
+		app.runPager(listBinds(gOpts.keys))
 	case "cmaps":
-		app.runPagerOnText(listBinds(gOpts.cmdkeys))
+		app.runPager(listBinds(gOpts.cmdkeys))
 	case "jumps":
-		app.runPagerOnText(listJumps(app.nav.jumpList, app.nav.jumpListInd))
+		app.runPager(listJumps(app.nav.jumpList, app.nav.jumpListInd))
 	default:
 		cmd, ok := gOpts.cmds[e.name]
 		if !ok {

--- a/eval.go
+++ b/eval.go
@@ -2526,11 +2526,11 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.ui.cmdAccLeft = acc
 		update(app)
 	case "maps":
-		app.runPager(listBinds(gOpts.keys))
+		app.runPagerOn(listBinds(gOpts.keys))
 	case "cmaps":
-		app.runPager(listBinds(gOpts.cmdkeys))
+		app.runPagerOn(listBinds(gOpts.cmdkeys))
 	case "jumps":
-		app.runPager(listJumps(app.nav.jumpList, app.nav.jumpListInd))
+		app.runPagerOn(listJumps(app.nav.jumpList, app.nav.jumpListInd))
 	default:
 		cmd, ok := gOpts.cmds[e.name]
 		if !ok {


### PR DESCRIPTION
I'm not sure if there was any reason why the current implementation manages `Cmd.StdinPipe` instead of just assigning `Cmd.Stdin`.