### PR TITLE
Avoid refreshing previews for shell pipe commands

### DIFF
--- a/app.go
+++ b/app.go
@@ -526,7 +526,7 @@ func (app *app) runShell(s string, args []string, prefix string) {
 		return
 	}
 
-	// We are running the command asynchroniously
+	// We are running the command asynchronously
 	if prefix == "%" {
 		if app.ui.cmdPrefix == ">" {
 			return
@@ -548,12 +548,6 @@ func (app *app) runShell(s string, args []string, prefix string) {
 	if err = cmd.Start(); err != nil {
 		app.ui.echoerrf("running shell: %s", err)
 	}
-
-	// Asynchronous shell invocations return immediately without waiting for the
-	// command to finish, so there is no point refreshing the preview if nothing
-	// has changed yet.
-	volatile := prefix != "&"
-	app.ui.loadFile(app, volatile)
 
 	switch prefix {
 	case "%":


### PR DESCRIPTION
Follow up of #1164 

Like `shell-async` commands, `shell-pipe` commands are run in the background and can take some time to complete, so there is no point refreshing the preview immediately. When the `shell-pipe` command finishes, it internally sends a `load` command, so that should be sufficient.

For `shell` and `shell-wait` commands, the loading is handled in the `runCmdSync` function, see #1243 for details.

---

I did notice that `%` triggers the `load` command afterwards but `&` doesn't, I'm not sure if there's a reason for this though, but I think it can be addressed separately outside of this PR.