### PR TITLE
Add `doc` to default keybindings in documentation

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -208,11 +208,13 @@ The following special shell commands are used to customize the behavior of lf wh
 
 The following commands/keybindings are provided by default:
 
-	Unix                     Windows
-	cmd open &$OPENER "$f"   cmd open &%OPENER% %f%
-	map e $$EDITOR "$f"      map e $%EDITOR% %f%
-	map i $$PAGER "$f"       map i !%PAGER% %f%
-	map w $$SHELL            map w $%SHELL%
+	Unix                          Windows
+	cmd open &$OPENER "$f"        cmd open &%OPENER% %f%
+	map e $$EDITOR "$f"           map e $%EDITOR% %f%
+	map i $$PAGER "$f"            map i !%PAGER% %f%
+	map w $$SHELL                 map w $%SHELL%
+	cmd doc $$lf -doc | $PAGER    cmd doc !%lf% -doc | %PAGER%
+	map <f-1> doc                 map <f-1> doc
 
 The following additional keybindings are provided by default:
 

--- a/docstring.go
+++ b/docstring.go
@@ -212,11 +212,13 @@ when defined:
 
 The following commands/keybindings are provided by default:
 
-    Unix                     Windows
-    cmd open &$OPENER "$f"   cmd open &%OPENER% %f%
-    map e $$EDITOR "$f"      map e $%EDITOR% %f%
-    map i $$PAGER "$f"       map i !%PAGER% %f%
-    map w $$SHELL            map w $%SHELL%
+    Unix                          Windows
+    cmd open &$OPENER "$f"        cmd open &%OPENER% %f%
+    map e $$EDITOR "$f"           map e $%EDITOR% %f%
+    map i $$PAGER "$f"            map i !%PAGER% %f%
+    map w $$SHELL                 map w $%SHELL%
+    cmd doc $$lf -doc | $PAGER    cmd doc !%lf% -doc | %PAGER%
+    map <f-1> doc                 map <f-1> doc
 
 The following additional keybindings are provided by default:
 

--- a/lf.1
+++ b/lf.1
@@ -233,11 +233,13 @@ The following special shell commands are used to customize the behavior of lf wh
 The following commands/keybindings are provided by default:
 .PP
 .EX
-    Unix                     Windows
-    cmd open &$OPENER "$f"   cmd open &%OPENER% %f%
-    map e $$EDITOR "$f"      map e $%EDITOR% %f%
-    map i $$PAGER "$f"       map i !%PAGER% %f%
-    map w $$SHELL            map w $%SHELL%
+    Unix                          Windows
+    cmd open &$OPENER "$f"        cmd open &%OPENER% %f%
+    map e $$EDITOR "$f"           map e $%EDITOR% %f%
+    map i $$PAGER "$f"            map i !%PAGER% %f%
+    map w $$SHELL                 map w $%SHELL%
+    cmd doc $$lf -doc | $PAGER    cmd doc !%lf% -doc | %PAGER%
+    map <f-1> doc                 map <f-1> doc
 .EE
 .PP
 The following additional keybindings are provided by default:


### PR DESCRIPTION
Add the `doc` command to the list of default commands/mappings in the documentation for completeness. I think this is intended to be a literal copy of the code from [`os.go`](https://github.com/gokcehan/lf/blob/a9d90bc56044aa5edeb2b45c161af3c0099a3bed/os.go#L159-L167) and [`os_windows.go`](https://github.com/gokcehan/lf/blob/a9d90bc56044aa5edeb2b45c161af3c0099a3bed/os_windows.go#L118-L126).