### PR TITLE
Bound cursor position after terminal resize

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -1742,6 +1742,9 @@ func (e *callExpr) eval(app *app, args []string) {
 			app.nav.height = app.ui.wins[0].h
 			app.nav.regCache = make(map[string]*reg)
 		}
+		for _, dir := range app.nav.dirs {
+			dir.boundPos(app.nav.height)
+		}
 		app.ui.loadFile(app, true)
 	case "load":
 		if !app.nav.init {


### PR DESCRIPTION
It's possible for the cursor position to end up outside the bounds of the navigation panes if the terminal window is resized. To reproduce, open `lf` in a directory containing a lot of files, scroll down to the bottom, and then decrease the terminal window height.