### PR TITLE
Fix load issue when deleting files

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -1171,15 +1171,6 @@ func insert(app *app, arg string) {
 				return
 			}
 			app.nav.unselect()
-			if gSingleMode {
-				app.nav.renew()
-				app.ui.loadFile(app, true)
-			} else {
-				if err := remote("send load"); err != nil {
-					app.ui.echoerrf("delete: %s", err)
-					return
-				}
-			}
 			app.ui.loadFile(app, true)
 			app.ui.loadFileInfo(app.nav)
 		}


### PR DESCRIPTION
- Fixes #792 

When deleting files, reloading the directory is already handled by the thread performing the actual deletion: https://github.com/gokcehan/lf/blob/027538eabf8a0f54e46946bdab19b90326709ce2/nav.go#L1475-L1484

The reload is also done called by the main thread - I don't know why that code exists, but it appears to be the root cause of #792. The actual analysis involved is quite complex so I won't repeat it here, but see https://github.com/gokcehan/lf/issues/792#issuecomment-1581937133 for more details.