### PR TITLE
Fix formatting of nlink on other platforms

### DIFF
--- a/os.go
+++ b/os.go
@@ -10,7 +10,6 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"syscall"
 
@@ -210,7 +209,7 @@ func groupName(f os.FileInfo) string {
 
 func linkCount(f os.FileInfo) string {
 	if stat, ok := f.Sys().(*syscall.Stat_t); ok {
-		return strconv.FormatUint(stat.Nlink, 10)
+		return fmt.Sprint(stat.Nlink)
 	}
 	return ""
 }


### PR DESCRIPTION
- Fixes #1294 

The formatting of the nlink was changed in #1288, see https://github.com/gokcehan/lf/blob/2ab4b14e883f7d989fbe1e0a193223263bfeeed1/os.go#L213

However this doesn't work because the value of `stat.Nlink` has a different type on other platforms, for example on [Darwin ARM 64-bit](https://cs.opensource.google/go/go/+/refs/tags/go1.20.5:src/syscall/ztypes_darwin_arm64.go;l=68) it is `uint16` instead of `uint64`, so it cannot be passed to [`strconv.FormatUint`](https://pkg.go.dev/strconv#FormatUint).