### PR TITLE
Remove test log statement during autocompletion

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -282,7 +282,6 @@ func matchExec(s string) (matches []string, longest []rune) {
 				continue
 			}
 
-			log.Print(finfo.Name())
 			words = append(words, finfo.Name())
 		}
 	}


### PR DESCRIPTION
To reproduce, type `$a<tab>` with logging enabled, and all the executables starting with 'a' will be logged. I'm quite sure this is debugging code that was accidentally committed in e1b6d38.