### PR TITLE
Allow blank input lines for `shell-pipe` commands

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -2142,7 +2142,7 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.menuCompActive = false
 	case "cmd-enter":
 		s := string(append(app.ui.cmdAccLeft, app.ui.cmdAccRight...))
-		if len(s) == 0 && app.ui.cmdPrefix != "filter: " {
+		if len(s) == 0 && app.ui.cmdPrefix != "filter: " && app.ui.cmdPrefix != ">" {
 			return
 		}
 


### PR DESCRIPTION
- Fixes #1078 

This change allows the user to input blank lines during `shell-pipe` (`%`) commands simply by pressing <kbd>Enter</kbd>. Below is an example script to test with:

```shell
cmd test %{{
    echo "doing something..."
    sleep 1

    echo "press enter to continue"
    read dummy

    echo "continue doing something..."
    sleep 1
    echo "done"
}}
```