### PR TITLE
Improve windows shell handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func exportEnvVars() {
 		log.Printf("getting path to lf binary: %s", err)
 		lfPath = "lf"
 	}
-	os.Setenv("lf", lfPath)
+	os.Setenv("lf", quoteString(lfPath))
 }
 
 // used by exportOpts below

--- a/nav.go
+++ b/nav.go
@@ -655,12 +655,24 @@ func (nav *nav) exportFiles() {
 
 	var currFile string
 	if curr, err := nav.currFile(); err == nil {
-		currFile = curr.path
+		currFile = quoteString(curr.path)
 	}
 
-	currSelections := nav.currSelections()
+	var selections []string
+	for _, selection := range nav.currSelections() {
+		selections = append(selections, quoteString(selection))
+	}
+	currSelections := strings.Join(selections, gOpts.filesep)
 
-	exportFiles(currFile, currSelections, nav.currDir().path)
+	os.Setenv("f", currFile)
+	os.Setenv("fs", currSelections)
+	os.Setenv("PWD", quoteString(nav.currDir().path))
+
+	if len(selections) == 0 {
+		os.Setenv("fx", currFile)
+	} else {
+		os.Setenv("fx", currSelections)
+	}
 }
 
 func (nav *nav) dirPreviewLoop(ui *ui) {

--- a/os.go
+++ b/os.go
@@ -218,21 +218,6 @@ func errCrossDevice(err error) bool {
 	return err.(*os.LinkError).Err.(unix.Errno) == unix.EXDEV
 }
 
-func exportFiles(f string, fs []string, pwd string) {
-	envFile := f
-	envFiles := strings.Join(fs, gOpts.filesep)
-
-	os.Setenv("f", envFile)
-	os.Setenv("fs", envFiles)
-	os.Setenv("PWD", pwd)
-
-	if len(fs) == 0 {
-		os.Setenv("fx", envFile)
-	} else {
-		os.Setenv("fx", envFiles)
-	}
-}
-
 func quoteString(s string) string {
 	return s
 }

--- a/os.go
+++ b/os.go
@@ -232,3 +232,7 @@ func exportFiles(f string, fs []string, pwd string) {
 		os.Setenv("fx", envFiles)
 	}
 }
+
+func quoteString(s string) string {
+	return s
+}

--- a/os_windows.go
+++ b/os_windows.go
@@ -102,7 +102,7 @@ func detachedCommand(name string, arg ...string) *exec.Cmd {
 
 func shellCommand(s string, args []string) *exec.Cmd {
 	// Windows CMD requires special handling to deal with quoted arguments
-	if gOpts.shell == "cmd" {
+	if strings.ToLower(gOpts.shell) == "cmd" {
 		var builder strings.Builder
 		builder.WriteString(s)
 		for _, arg := range args {

--- a/os_windows.go
+++ b/os_windows.go
@@ -174,28 +174,6 @@ func errCrossDevice(err error) bool {
 	return err.(*os.LinkError).Err.(windows.Errno) == 17
 }
 
-func exportFiles(f string, fs []string, pwd string) {
-	envFile := fmt.Sprintf(`"%s"`, f)
-
-	var quotedFiles []string
-	for _, f := range fs {
-		quotedFiles = append(quotedFiles, fmt.Sprintf(`"%s"`, f))
-	}
-	envFiles := strings.Join(quotedFiles, gOpts.filesep)
-
-	envPWD := fmt.Sprintf(`"%s"`, pwd)
-
-	os.Setenv("f", envFile)
-	os.Setenv("fs", envFiles)
-	os.Setenv("PWD", envPWD)
-
-	if len(fs) == 0 {
-		os.Setenv("fx", envFile)
-	} else {
-		os.Setenv("fx", envFiles)
-	}
-}
-
 func quoteString(s string) string {
 	return fmt.Sprintf(`"%s"`, s)
 }

--- a/os_windows.go
+++ b/os_windows.go
@@ -130,6 +130,11 @@ func setDefaults() {
 	gOpts.cmds["doc"] = &execExpr{"!", "%lf% -doc | %PAGER%"}
 	gOpts.keys["<f-1>"] = &callExpr{"doc", nil, 1}
 
+	for _, key := range []string{"maps", "cmaps", "cmds", "jumps"} {
+		cmd := fmt.Sprintf(`lf -remote "query %%id%% %s" | %%PAGER%%`, key)
+		gOpts.cmds[key] = &execExpr{"!", cmd}
+	}
+
 	gOpts.statfmt = "\033[36m%p\033[0m %s %t %L"
 }
 

--- a/os_windows.go
+++ b/os_windows.go
@@ -195,3 +195,7 @@ func exportFiles(f string, fs []string, pwd string) {
 		os.Setenv("fx", envFiles)
 	}
 }
+
+func quoteString(s string) string {
+	return fmt.Sprintf(`"%s"`, s)
+}

--- a/os_windows.go
+++ b/os_windows.go
@@ -106,7 +106,7 @@ func shellCommand(s string, args []string) *exec.Cmd {
 	for _, arg := range args {
 		fmt.Fprintf(&builder, ` "%s"`, arg)
 	}
-	cmdline := fmt.Sprintf(`%s %s "%s"`, gOpts.shellopts, gOpts.shellflag, builder.String())
+	cmdline := fmt.Sprintf(`%s %s %s "%s"`, gOpts.shell, gOpts.shellopts, gOpts.shellflag, builder.String())
 
 	cmd := exec.Command(gOpts.shell)
 	cmd.SysProcAttr = &windows.SysProcAttr{CmdLine: cmdline}

--- a/os_windows.go
+++ b/os_windows.go
@@ -101,11 +101,16 @@ func detachedCommand(name string, arg ...string) *exec.Cmd {
 }
 
 func shellCommand(s string, args []string) *exec.Cmd {
-	args = append([]string{gOpts.shellflag, s}, args...)
+	var builder strings.Builder
+	builder.WriteString(s)
+	for _, arg := range args {
+		fmt.Fprintf(&builder, ` "%s"`, arg)
+	}
+	cmdline := fmt.Sprintf(`%s %s "%s"`, gOpts.shellopts, gOpts.shellflag, builder.String())
 
-	args = append(gOpts.shellopts, args...)
-
-	return exec.Command(gOpts.shell, args...)
+	cmd := exec.Command(gOpts.shell)
+	cmd.SysProcAttr = &windows.SysProcAttr{CmdLine: cmdline}
+	return cmd
 }
 
 func shellSetPG(cmd *exec.Cmd) {

--- a/os_windows.go
+++ b/os_windows.go
@@ -106,7 +106,8 @@ func shellCommand(s string, args []string) *exec.Cmd {
 	for _, arg := range args {
 		fmt.Fprintf(&builder, ` "%s"`, arg)
 	}
-	cmdline := fmt.Sprintf(`%s %s %s "%s"`, gOpts.shell, gOpts.shellopts, gOpts.shellflag, builder.String())
+	shellOpts := strings.Join(gOpts.shellopts, " ")
+	cmdline := fmt.Sprintf(`%s %s %s "%s"`, gOpts.shell, shellOpts, gOpts.shellflag, builder.String())
 
 	cmd := exec.Command(gOpts.shell)
 	cmd.SysProcAttr = &windows.SysProcAttr{CmdLine: cmdline}

--- a/os_windows.go
+++ b/os_windows.go
@@ -130,11 +130,6 @@ func setDefaults() {
 	gOpts.cmds["doc"] = &execExpr{"!", "%lf% -doc | %PAGER%"}
 	gOpts.keys["<f-1>"] = &callExpr{"doc", nil, 1}
 
-	for _, key := range []string{"maps", "cmaps", "cmds", "jumps"} {
-		cmd := fmt.Sprintf(`lf -remote "query %%id%% %s" | %%PAGER%%`, key)
-		gOpts.cmds[key] = &execExpr{"!", cmd}
-	}
-
 	gOpts.statfmt = "\033[36m%p\033[0m %s %t %L"
 }
 


### PR DESCRIPTION
Changes:

- Modify the `shellCommand` function in `os_windows.go` to handle quoted arguments with spaces. I got the idea from https://github.com/golang/go/issues/17149 to set the command line directly in `cmd.SysProcAttr`.
- Add a `quoteString` function which quotes strings depending if the OS is Windows or not. This now means that displaying the documentation via `<f-1>` or `:doc` now works even if the `lf` path contains spaces (see #1176).
- Refactor the `exportFiles` function so that all the main logic is done inside `nav.go`, and calls out to the above `quoteString` function to handle quoting.

---

The following commands now work, at least on my machine:

```
!dir "C:\Program Files" | %PAGER%
```

```
&lf -remote "send %id% toggle"
```

Executables with spaces in their path now also work (from #1276):

```
!"C:\Program Files\Go\bin\go.exe" version
!"C:\Program Files\Git\bin\git.exe" --version
```

`mkdir` with a quoted string now properly creates the directory in the current location instead of at `C:\` (from https://github.com/gokcehan/lf/pull/1309#issuecomment-1595856373):

```
$mkdir "foo bar"
```

---

I have also done some very brief testing with PowerShell, but I'm not so familiar with it so I would appreciate it if others helped to test it as well and make sure the changes are more stable. Hopefully we can avoid the situation where separate command-handling logic is required for CMD vs. PowerShell.