### PR TITLE
Make duplicated file format configurable

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -140,6 +140,7 @@ var (
 		"drawbox",
 		"nodrawbox",
 		"drawbox!",
+		"dupfilefmt",
 		"globsearch",
 		"noglobsearch",
 		"globsearch!",

--- a/copy.go
+++ b/copy.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/djherbis/times"
 )
@@ -102,13 +104,19 @@ func copyAll(srcs []string, dstDir string) (nums chan int64, errs chan error) {
 
 	go func() {
 		for _, src := range srcs {
-			dst := filepath.Join(dstDir, filepath.Base(src))
+			file := filepath.Base(src)
+			dst := filepath.Join(dstDir, file)
 
 			_, err := os.Lstat(dst)
 			if !os.IsNotExist(err) {
+				ext := filepath.Ext(file)
+				fileNoExt := filepath.Base(file[:len(file)-len(ext)])
 				var newPath string
 				for i := 1; !os.IsNotExist(err); i++ {
-					newPath = fmt.Sprintf("%s.~%d~", dst, i)
+					file = strings.ReplaceAll(gOpts.dupfilefmt, "%f", fileNoExt)
+					file = strings.ReplaceAll(file, "%e", ext)
+					file = strings.ReplaceAll(file, "%n", strconv.Itoa(i))
+					newPath = filepath.Join(dstDir, file)
 					_, err = os.Lstat(newPath)
 				}
 				dst = newPath

--- a/copy.go
+++ b/copy.go
@@ -110,10 +110,11 @@ func copyAll(srcs []string, dstDir string) (nums chan int64, errs chan error) {
 			_, err := os.Lstat(dst)
 			if !os.IsNotExist(err) {
 				ext := filepath.Ext(file)
-				fileNoExt := filepath.Base(file[:len(file)-len(ext)])
+				basename := filepath.Base(file[:len(file)-len(ext)])
 				var newPath string
 				for i := 1; !os.IsNotExist(err); i++ {
-					file = strings.ReplaceAll(gOpts.dupfilefmt, "%f", fileNoExt)
+					file = strings.ReplaceAll(gOpts.dupfilefmt, "%f", basename+ext)
+					file = strings.ReplaceAll(file, "%b", basename)
 					file = strings.ReplaceAll(file, "%e", ext)
 					file = strings.ReplaceAll(file, "%n", strconv.Itoa(i))
 					newPath = filepath.Join(dstDir, file)

--- a/doc.go
+++ b/doc.go
@@ -130,6 +130,7 @@ The following options can be used to customize the behavior of lf:
 	dironly          bool      (default false)
 	dirpreviews      bool      (default false)
 	drawbox          bool      (default false)
+	dupfilefmt       string    (default '%f%e.~%n~')
 	errorfmt         string    (default "\033[7;31;47m")
 	filesep          string    (default "\n")
 	findlen          int       (default 1)
@@ -718,6 +719,11 @@ If enabled, directories will also be passed to the previewer script. This allows
 	drawbox        bool      (default false)
 
 Draw boxes around panes with box drawing characters.
+
+	dupfilefmt        string      (default '%f%e.~%n~')
+
+Format string of file name when creating duplicate files. With the default format, copying a file `abc.txt` to the same directory will result in a duplicate file called `abc.txt.~1~`.
+Special expansions are provided, '%f' as the file name, '%e' as the extension (including the dot) and '%n' as the number of duplicates.
 
 	errorfmt       string    (default "\033[7;31;47m")
 

--- a/doc.go
+++ b/doc.go
@@ -130,7 +130,7 @@ The following options can be used to customize the behavior of lf:
 	dironly          bool      (default false)
 	dirpreviews      bool      (default false)
 	drawbox          bool      (default false)
-	dupfilefmt       string    (default '%f%e.~%n~')
+	dupfilefmt       string    (default '%f.~%n~')
 	errorfmt         string    (default "\033[7;31;47m")
 	filesep          string    (default "\n")
 	findlen          int       (default 1)
@@ -720,10 +720,10 @@ If enabled, directories will also be passed to the previewer script. This allows
 
 Draw boxes around panes with box drawing characters.
 
-	dupfilefmt        string      (default '%f%e.~%n~')
+	dupfilefmt        string      (default '%f.~%n~')
 
 Format string of file name when creating duplicate files. With the default format, copying a file `abc.txt` to the same directory will result in a duplicate file called `abc.txt.~1~`.
-Special expansions are provided, '%f' as the file name, '%e' as the extension (including the dot) and '%n' as the number of duplicates.
+Special expansions are provided, '%f' as the file name, '%b' for basename (file name without extension), '%e' as the extension (including the dot) and '%n' as the number of duplicates.
 
 	errorfmt       string    (default "\033[7;31;47m")
 

--- a/docstring.go
+++ b/docstring.go
@@ -133,6 +133,7 @@ The following options can be used to customize the behavior of lf:
     dironly          bool      (default false)
     dirpreviews      bool      (default false)
     drawbox          bool      (default false)
+    dupfilefmt       string    (default '%f%e.~%n~')
     errorfmt         string    (default "\033[7;31;47m")
     filesep          string    (default "\n")
     findlen          int       (default 1)
@@ -760,6 +761,14 @@ custom previews for directories.
     drawbox        bool      (default false)
 
 Draw boxes around panes with box drawing characters.
+
+    dupfilefmt        string      (default '%f%e.~%n~')
+
+Format string of file name when creating duplicate files. With the default
+format, copying a file 'abc.txt' to the same directory will result in a
+duplicate file called 'abc.txt.~1~'. Special expansions are provided, '%f' as
+the file name, '%e' as the extension (including the dot) and '%n' as the number
+of duplicates.
 
     errorfmt       string    (default "\033[7;31;47m")
 

--- a/docstring.go
+++ b/docstring.go
@@ -133,7 +133,7 @@ The following options can be used to customize the behavior of lf:
     dironly          bool      (default false)
     dirpreviews      bool      (default false)
     drawbox          bool      (default false)
-    dupfilefmt       string    (default '%f%e.~%n~')
+    dupfilefmt       string    (default '%f.~%n~')
     errorfmt         string    (default "\033[7;31;47m")
     filesep          string    (default "\n")
     findlen          int       (default 1)
@@ -762,13 +762,13 @@ custom previews for directories.
 
 Draw boxes around panes with box drawing characters.
 
-    dupfilefmt        string      (default '%f%e.~%n~')
+    dupfilefmt        string      (default '%f.~%n~')
 
 Format string of file name when creating duplicate files. With the default
 format, copying a file 'abc.txt' to the same directory will result in a
 duplicate file called 'abc.txt.~1~'. Special expansions are provided, '%f' as
-the file name, '%e' as the extension (including the dot) and '%n' as the number
-of duplicates.
+the file name, '%b' for basename (file name without extension), '%e' as the
+extension (including the dot) and '%n' as the number of duplicates.
 
     errorfmt       string    (default "\033[7;31;47m")
 

--- a/eval.go
+++ b/eval.go
@@ -230,6 +230,8 @@ func (e *setExpr) eval(app *app, args []string) {
 			app.nav.regCache = make(map[string]*reg)
 		}
 		app.ui.loadFile(app, true)
+	case "dupfilefmt":
+		gOpts.dupfilefmt = e.val
 	case "errorfmt":
 		gOpts.errorfmt = e.val
 	case "filesep":

--- a/lf.1
+++ b/lf.1
@@ -149,7 +149,7 @@ The following options can be used to customize the behavior of lf:
     dironly          bool      (default false)
     dirpreviews      bool      (default false)
     drawbox          bool      (default false)
-    dupfilefmt       string    (default '%f%e.~%n~')
+    dupfilefmt       string    (default '%f.~%n~')
     errorfmt         string    (default "\e033[7;31;47m")
     filesep          string    (default "\en")
     findlen          int       (default 1)
@@ -878,10 +878,10 @@ If enabled, directories will also be passed to the previewer script. This allows
 Draw boxes around panes with box drawing characters.
 .PP
 .EX
-    dupfilefmt        string      (default '%f%e.~%n~')
+    dupfilefmt        string      (default '%f.~%n~')
 .EE
 .PP
-Format string of file name when creating duplicate files. With the default format, copying a file `abc.txt` to the same directory will result in a duplicate file called `abc.txt.~1~`. Special expansions are provided, '%f' as the file name, '%e' as the extension (including the dot) and '%n' as the number of duplicates.
+Format string of file name when creating duplicate files. With the default format, copying a file `abc.txt` to the same directory will result in a duplicate file called `abc.txt.~1~`. Special expansions are provided, '%f' as the file name, '%b' for basename (file name without extension), '%e' as the extension (including the dot) and '%n' as the number of duplicates.
 .PP
 .EX
     errorfmt       string    (default "\e033[7;31;47m")

--- a/lf.1
+++ b/lf.1
@@ -149,6 +149,7 @@ The following options can be used to customize the behavior of lf:
     dironly          bool      (default false)
     dirpreviews      bool      (default false)
     drawbox          bool      (default false)
+    dupfilefmt       string    (default '%f%e.~%n~')
     errorfmt         string    (default "\e033[7;31;47m")
     filesep          string    (default "\en")
     findlen          int       (default 1)
@@ -875,6 +876,12 @@ If enabled, directories will also be passed to the previewer script. This allows
 .EE
 .PP
 Draw boxes around panes with box drawing characters.
+.PP
+.EX
+    dupfilefmt        string      (default '%f%e.~%n~')
+.EE
+.PP
+Format string of file name when creating duplicate files. With the default format, copying a file `abc.txt` to the same directory will result in a duplicate file called `abc.txt.~1~`. Special expansions are provided, '%f' as the file name, '%e' as the extension (including the dot) and '%n' as the number of duplicates.
 .PP
 .EX
     errorfmt       string    (default "\e033[7;31;47m")

--- a/nav.go
+++ b/nav.go
@@ -1345,7 +1345,8 @@ func (nav *nav) moveAsync(app *app, srcs []string, dstDir string) {
 			continue
 		}
 
-		dst := filepath.Join(dstDir, filepath.Base(src))
+		file := filepath.Base(src)
+		dst := filepath.Join(dstDir, file)
 
 		dstStat, err := os.Stat(dst)
 		if os.SameFile(srcStat, dstStat) {
@@ -1354,9 +1355,14 @@ func (nav *nav) moveAsync(app *app, srcs []string, dstDir string) {
 			app.ui.exprChan <- echo
 			continue
 		} else if !os.IsNotExist(err) {
+			ext := filepath.Ext(file)
+			fileNoExt := filepath.Base(file[:len(file)-len(ext)])
 			var newPath string
 			for i := 1; !os.IsNotExist(err); i++ {
-				newPath = fmt.Sprintf("%s.~%d~", dst, i)
+				file = strings.ReplaceAll(gOpts.dupfilefmt, "%f", fileNoExt)
+				file = strings.ReplaceAll(file, "%e", ext)
+				file = strings.ReplaceAll(file, "%n", strconv.Itoa(i))
+				newPath = filepath.Join(dstDir, file)
 				_, err = os.Lstat(newPath)
 			}
 			dst = newPath

--- a/nav.go
+++ b/nav.go
@@ -1356,10 +1356,11 @@ func (nav *nav) moveAsync(app *app, srcs []string, dstDir string) {
 			continue
 		} else if !os.IsNotExist(err) {
 			ext := filepath.Ext(file)
-			fileNoExt := filepath.Base(file[:len(file)-len(ext)])
+			basename := filepath.Base(file[:len(file)-len(ext)])
 			var newPath string
 			for i := 1; !os.IsNotExist(err); i++ {
-				file = strings.ReplaceAll(gOpts.dupfilefmt, "%f", fileNoExt)
+				file = strings.ReplaceAll(gOpts.dupfilefmt, "%f", basename+ext)
+				file = strings.ReplaceAll(file, "%b", basename)
 				file = strings.ReplaceAll(file, "%e", ext)
 				file = strings.ReplaceAll(file, "%n", strconv.Itoa(i))
 				newPath = filepath.Join(dstDir, file)

--- a/opts.go
+++ b/opts.go
@@ -39,6 +39,7 @@ var gOpts struct {
 	dironly          bool
 	dirpreviews      bool
 	drawbox          bool
+	dupfilefmt       string
 	globsearch       bool
 	icons            bool
 	ignorecase       bool
@@ -98,6 +99,7 @@ func init() {
 	gOpts.dironly = false
 	gOpts.dirpreviews = false
 	gOpts.drawbox = false
+	gOpts.dupfilefmt = "%f%e.~%n~"
 	gOpts.borderfmt = "\033[0m"
 	gOpts.cursoractivefmt = "\033[7m"
 	gOpts.cursorparentfmt = "\033[7m"

--- a/opts.go
+++ b/opts.go
@@ -99,7 +99,7 @@ func init() {
 	gOpts.dironly = false
 	gOpts.dirpreviews = false
 	gOpts.drawbox = false
-	gOpts.dupfilefmt = "%f%e.~%n~"
+	gOpts.dupfilefmt = "%f.~%n~"
 	gOpts.borderfmt = "\033[0m"
 	gOpts.cursoractivefmt = "\033[7m"
 	gOpts.cursorparentfmt = "\033[7m"


### PR DESCRIPTION
This makes it possible to configure the format and order that will be used when creating duplicate files. By default, the format replicates the current behavior of putting `~1~` in the end.