### PR TITLE
Attempt copy+remove if permission denied when moving file

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -1351,7 +1351,7 @@ func (nav *nav) moveAsync(app *app, srcs []string, dstDir string) {
 		}
 
 		if err := os.Rename(src, dst); err != nil {
-			if errCrossDevice(err) {
+			if errCrossDevice(err) || errPermissionDenied(err) {
 				total, err := copySize([]string{src})
 				if err != nil {
 					echo.args[0] = err.Error()

--- a/os.go
+++ b/os.go
@@ -218,6 +218,10 @@ func errCrossDevice(err error) bool {
 	return err.(*os.LinkError).Err.(unix.Errno) == unix.EXDEV
 }
 
+func errPermissionDenied(err error) bool {
+	return err.(*os.LinkError).Err.(unix.Errno) == unix.EPERM
+}
+
 func exportFiles(f string, fs []string, pwd string) {
 	envFile := f
 	envFiles := strings.Join(fs, gOpts.filesep)

--- a/os_windows.go
+++ b/os_windows.go
@@ -168,6 +168,10 @@ func errCrossDevice(err error) bool {
 	return err.(*os.LinkError).Err.(windows.Errno) == 17
 }
 
+func errPermissionDenied(err error) bool {
+	return false
+}
+
 func exportFiles(f string, fs []string, pwd string) {
 	envFile := fmt.Sprintf(`"%s"`, f)
 


### PR DESCRIPTION
I mount my server to my workstation with [sshfs](https://github.com/libfuse/sshfs) and noticed when attempting to move a file across devices on the same mount, a permission denied error is given, not a cross device error.

Error:
```
mv: cannot move 'test' to 'usbhd/test': Operation not permitted
```

How I reproduce it:

1. On the server, a separate hard drive is mounted to `~/usbhd`
2. The home dir on the server is mounted on my workstation at `/tmp/nuc`
3. Navigate with lf to `/tmp/nuc` and try to move anything between home directory and the mounted disk

This PR makes the move function treat a "permission denied" error the same way as a "cross device" error. This allows me to freely move files between devices over sshfs.

I'm not sure if always attempting a copy on "permission denied" errors could cause any separate issues, but I noticed when attempting to move files owned by root, that gave me an access error (EACCES) instead.
