### PR TITLE
Prevent following symbolic links when reloading

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -621,13 +621,8 @@ func (nav *nav) reload() error {
 	nav.dirCache = make(map[string]*dir)
 	nav.regCache = make(map[string]*reg)
 
-	wd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("getting current directory: %s", err)
-	}
-
 	curr, err := nav.currFile()
-	nav.getDirs(wd)
+	nav.getDirs(nav.currDir().path)
 	if err == nil {
 		last := nav.dirs[len(nav.dirs)-1]
 		last.files = append(last.files, curr)


### PR DESCRIPTION
- Fixes #1185 

Use the internally stored path for the new current directory instead of calling  [`os.Getwd`](https://pkg.go.dev/os#Getwd), which returns inconsistent results if multiple paths exist due to symbolic links.

> If the current directory can be reached via multiple paths (due to symbolic links), Getwd may return any one of them.