### PR TITLE
Prevent image preview flicker for `load` command

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -1757,7 +1757,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 		app.nav.renew()
-		app.ui.loadFile(app, true)
+		app.ui.loadFile(app, false)
 	case "reload":
 		if !app.nav.init {
 			return


### PR DESCRIPTION
- Fixes #1333 

This is a continuation from the discussion in #1281. In my opinion the `load` command should not refresh the image preview, but only check whether files/directories have been modified. In the case that there are modifications, the image preview will be refreshed through calling the `nav.checkDir` and `nav.checkReg` functions. This is the same as how the `period` timer behaves, and is also implied by the documentation:

https://github.com/gokcehan/lf/blob/2f3c170d1b5755c39f5d46d9e4f7f804d66f955c/doc.go#L823-L829

I understand the `load` command is used internally after updates such as `rename`, `delete` and  `paste`, but in each case there will be modifications to the filesystem so the image preview will be refreshed anyway as described above. For me this works fine, but I suppose it would be nice if others test it as well, preferably with image previews.