### PR TITLE
Support optional fields for `statfmt` option

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -167,7 +167,7 @@ The following options can be used to customize the behavior of lf:
 	smartcase        bool      (default true)
 	smartdia         bool      (default false)
 	sortby           string    (default 'natural')
-	statfmt          string    (default "\033[36m%p\033[0m %c %u %g %s %t %L")
+	statfmt          string    (default "\033[36m%p\033[0m| %c| %u| %g| %s| %t| -> %l")
 	tabstop          int       (default 8)
 	tagfmt           string    (default "\033[31m")
 	tempmarks        string    (default '')
@@ -925,11 +925,11 @@ This option has no effect when 'ignoredia' is disabled.
 Sort type for directories.
 Currently supported sort types are 'natural', 'name', 'size', 'time', 'ctime', 'atime', and 'ext'.
 
-	statfmt    string    (default "\033[36m%p\033[0m %c %u %g %s %t %L")
+	statfmt    string        (default "\033[36m%p\033[0m| %c| %u| %g| %s| %t| -> %l")
 
 Format string of the file info shown in the bottom left corner.
-Special expansions are provided, '%p' as the file permissions, '%c' as the link count, '%u' as the user, '%g' as the group, '%s' as the file size, '%t' as the last modified time, and '%l' as the link target if it exists (otherwise a blank string). '%L' is the same as '%l' but with an arrow '-> ' prepended.
-On Windows, the link count, user and group fields are not supported and will be replaced with a blank string if specified. The default for Windows is "\033[36m%p\033[0m %s %t %L".
+Special expansions are provided, '%p' as the file permissions, '%c' as the link count, '%u' as the user, '%g' as the group, '%s' as the file size, '%t' as the last modified time, and '%l' as the link target.
+The `|` character splits the format string into sections. Any section containing a failed expansion (result is a blank string) is discarded and not shown.
 
 	tabstop        int       (default 8)
 

--- a/docstring.go
+++ b/docstring.go
@@ -170,7 +170,7 @@ The following options can be used to customize the behavior of lf:
     smartcase        bool      (default true)
     smartdia         bool      (default false)
     sortby           string    (default 'natural')
-    statfmt          string    (default "\033[36m%p\033[0m %c %u %g %s %t %L")
+    statfmt          string    (default "\033[36m%p\033[0m| %c| %u| %g| %s| %t| -> %l")
     tabstop          int       (default 8)
     tagfmt           string    (default "\033[31m")
     tempmarks        string    (default '')
@@ -993,16 +993,14 @@ diacritic. This option has no effect when 'ignoredia' is disabled.
 Sort type for directories. Currently supported sort types are 'natural', 'name',
 'size', 'time', 'ctime', 'atime', and 'ext'.
 
-    statfmt    string    (default "\033[36m%p\033[0m %c %u %g %s %t %L")
+    statfmt    string        (default "\033[36m%p\033[0m| %c| %u| %g| %s| %t| -> %l")
 
 Format string of the file info shown in the bottom left corner. Special
 expansions are provided, '%p' as the file permissions, '%c' as the link count,
 '%u' as the user, '%g' as the group, '%s' as the file size, '%t' as the last
-modified time, and '%l' as the link target if it exists (otherwise a blank
-string). '%L' is the same as '%l' but with an arrow '-> ' prepended. On Windows,
-the link count, user and group fields are not supported and will be replaced
-with a blank string if specified. The default for Windows is "\033[36m%p\033[0m
-%s %t %L".
+modified time, and '%l' as the link target. The '|' character splits the format
+string into sections. Any section containing a failed expansion (result is a
+blank string) is discarded and not shown.
 
     tabstop        int       (default 8)
 

--- a/lf.1
+++ b/lf.1
@@ -186,7 +186,7 @@ The following options can be used to customize the behavior of lf:
     smartcase        bool      (default true)
     smartdia         bool      (default false)
     sortby           string    (default 'natural')
-    statfmt          string    (default "\e033[36m%p\e033[0m %c %u %g %s %t %L")
+    statfmt          string    (default "\e033[36m%p\e033[0m| %c| %u| %g| %s| %t| -> %l")
     tabstop          int       (default 8)
     tagfmt           string    (default "\e033[31m")
     tempmarks        string    (default '')
@@ -1102,10 +1102,10 @@ Override 'ignoredia' option when the pattern contains a character with diacritic
 Sort type for directories. Currently supported sort types are 'natural', 'name', 'size', 'time', 'ctime', 'atime', and 'ext'.
 .PP
 .EX
-    statfmt    string    (default "\e033[36m%p\e033[0m %c %u %g %s %t %L")
+    statfmt    string        (default "\e033[36m%p\e033[0m| %c| %u| %g| %s| %t| -> %l")
 .EE
 .PP
-Format string of the file info shown in the bottom left corner. Special expansions are provided, '%p' as the file permissions, '%c' as the link count, '%u' as the user, '%g' as the group, '%s' as the file size, '%t' as the last modified time, and '%l' as the link target if it exists (otherwise a blank string). '%L' is the same as '%l' but with an arrow '-> ' prepended. On Windows, the link count, user and group fields are not supported and will be replaced with a blank string if specified. The default for Windows is "\e033[36m%p\e033[0m %s %t %L".
+Format string of the file info shown in the bottom left corner. Special expansions are provided, '%p' as the file permissions, '%c' as the link count, '%u' as the user, '%g' as the group, '%s' as the file size, '%t' as the last modified time, and '%l' as the link target. The `|` character splits the format string into sections. Any section containing a failed expansion (result is a blank string) is discarded and not shown.
 .PP
 .EX
     tabstop        int       (default 8)

--- a/opts.go
+++ b/opts.go
@@ -132,6 +132,7 @@ func init() {
 	gOpts.selmode = "all"
 	gOpts.shell = gDefaultShell
 	gOpts.shellflag = gDefaultShellFlag
+	gOpts.statfmt = "\033[36m%p\033[0m| %c| %u| %g| %s| %t| -> %l"
 	gOpts.timefmt = time.ANSIC
 	gOpts.infotimefmtnew = "Jan _2 15:04"
 	gOpts.infotimefmtold = "Jan _2  2006"

--- a/os.go
+++ b/os.go
@@ -170,8 +170,6 @@ func setDefaults() {
 
 	gOpts.cmds["doc"] = &execExpr{"$", `"$lf" -doc | $PAGER`}
 	gOpts.keys["<f-1>"] = &callExpr{"doc", nil, 1}
-
-	gOpts.statfmt = "\033[36m%p\033[0m %c %u %g %s %t %L"
 }
 
 func setUserUmask() {

--- a/os_windows.go
+++ b/os_windows.go
@@ -136,8 +136,6 @@ func setDefaults() {
 
 	gOpts.cmds["doc"] = &execExpr{"!", "%lf% -doc | %PAGER%"}
 	gOpts.keys["<f-1>"] = &callExpr{"doc", nil, 1}
-
-	gOpts.statfmt = "\033[36m%p\033[0m %s %t %L"
 }
 
 func setUserUmask() {}

--- a/ui.go
+++ b/ui.go
@@ -721,10 +721,10 @@ func (ui *ui) loadFileInfo(nav *nav) {
 		return
 	}
 
-	statfmt := gOpts.statfmt
+	statfmt := strings.ReplaceAll(gOpts.statfmt, "|", "\x1f")
 	replace := func(s string, val string) {
 		if val == "" {
-			val = "<empty>"
+			val = "\x00"
 		}
 		statfmt = strings.ReplaceAll(statfmt, s, val)
 	}
@@ -737,8 +737,8 @@ func (ui *ui) loadFileInfo(nav *nav) {
 	replace("%l", curr.linkTarget)
 
 	fileInfo := ""
-	for _, section := range strings.Split(statfmt, "|") {
-		if !strings.Contains(section, "<empty>") {
+	for _, section := range strings.Split(statfmt, "\x1f") {
+		if !strings.Contains(section, "\x00") {
 			fileInfo += section
 		}
 	}

--- a/ui.go
+++ b/ui.go
@@ -721,20 +721,28 @@ func (ui *ui) loadFileInfo(nav *nav) {
 		return
 	}
 
-	linkTargetArrow := ""
-	if curr.linkTarget != "" {
-		linkTargetArrow = "-> " + curr.linkTarget
+	statfmt := gOpts.statfmt
+	replace := func(s string, val string) {
+		if val == "" {
+			val = "<empty>"
+		}
+		statfmt = strings.ReplaceAll(statfmt, s, val)
+	}
+	replace("%p", curr.Mode().String())
+	replace("%c", linkCount(curr))
+	replace("%u", userName(curr))
+	replace("%g", groupName(curr))
+	replace("%s", humanize(curr.Size()))
+	replace("%t", curr.ModTime().Format(gOpts.timefmt))
+	replace("%l", curr.linkTarget)
+
+	fileInfo := ""
+	for _, section := range strings.Split(statfmt, "|") {
+		if !strings.Contains(section, "<empty>") {
+			fileInfo += section
+		}
 	}
 
-	fileInfo := gOpts.statfmt
-	fileInfo = strings.Replace(fileInfo, "%p", curr.Mode().String(), -1)
-	fileInfo = strings.Replace(fileInfo, "%c", linkCount(curr), -1)
-	fileInfo = strings.Replace(fileInfo, "%u", userName(curr), -1)
-	fileInfo = strings.Replace(fileInfo, "%g", groupName(curr), -1)
-	fileInfo = strings.Replace(fileInfo, "%s", humanize(curr.Size()), -1)
-	fileInfo = strings.Replace(fileInfo, "%t", curr.ModTime().Format(gOpts.timefmt), -1)
-	fileInfo = strings.Replace(fileInfo, "%l", curr.linkTarget, -1)
-	fileInfo = strings.Replace(fileInfo, "%L", linkTargetArrow, -1)
 	ui.echo(fileInfo)
 }
 


### PR DESCRIPTION
For the `statfmt` option, I finally found a way to support display text *depending on whether a field exists or not*. The idea is to divide the format string into sections, and if any section contains a failed expansion (blank string), then the section is discarded and not shown.

Benefits:

- There is no need to have separate placeholders for the link target (`%l`), and the link target with an arrow (`%L`).
- There is no need to have a separate default for Windows just because some fields don't exist.
- Formatting/spacing can be 'tied' to a field, and if it doesn't exist then it won't show up in the final result.

In the example given in #1288, the `\033[36m %l \033[0m` part for displaying the link target would show as two cyan spaces if there wasn't one, which is not ideal. With optional fields supported, this can now work:

```
set statfmt "\033[7;31m %p \033[32m %c \033[33m %u %g \033[34m %s \033[35m %t |\033[36m %l |\033[0m" 
```

There are a couple of limitations now, though I don't think it will matter in practice:

- The `|` character cannot appear in the format string, as it now has a special meaning.
- Results of expansions now cannot contain a null byte (`\x00`) or a unit separator byte (`x1f`) as they now have a special meaning (failed expansion, and field delimiter, respectively).