### PR TITLE
Call `load` after shell-async commands

### DIFF
--- a/app.go
+++ b/app.go
@@ -591,6 +591,7 @@ func (app *app) runShell(s string, args []string, prefix string) {
 			if err := cmd.Wait(); err != nil {
 				log.Printf("running shell: %s", err)
 			}
+			app.ui.exprChan <- &callExpr{"load", nil, 1}
 		}()
 	}
 


### PR DESCRIPTION
From discussion in https://github.com/gokcehan/lf/pull/1281#issuecomment-1575342991

cc #1344 

I think it's reasonable to call `load` after a `&` command (similar to `%` commands), since it could make changes like creating files/directories.

For example:

```
map x &tar xf "$f"
```