### PR TITLE
Added statcmd option to run external commands for file stats

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -214,6 +214,7 @@ var (
 		"sortby",
 		"statfmt",
 		"timefmt",
+		"statcmd",
 		"tempmarks",
 		"tagfmt",
 		"infotimefmtnew",

--- a/doc.go
+++ b/doc.go
@@ -167,6 +167,7 @@ The following options can be used to customize the behavior of lf:
 	smartcase        bool      (default true)
 	smartdia         bool      (default false)
 	sortby           string    (default 'natural')
+	statcmd          string    (default "")
 	statfmt          string    (default "\033[36m%p\033[0m| %c| %u| %g| %s| %t| -> %l")
 	tabstop          int       (default 8)
 	tagfmt           string    (default "\033[31m")
@@ -925,10 +926,17 @@ This option has no effect when 'ignoredia' is disabled.
 Sort type for directories.
 Currently supported sort types are 'natural', 'name', 'size', 'time', 'ctime', 'atime', and 'ext'.
 
+	statcmd    string    (default "")
+
+Command to be run when using the '%C' expansion in statfmt. The '%C' is replaced with the output of the specified command.
+lf always waits for the command to finish, before continuing. It is the users responsibility to ensure the command finishes quickly, so that lf does not hang.
+The command is run in mostly the same way, as any other shell command, with respect to the shell, shellflag and shellopts options.
+That also means you can use environment variables, like in any other shell command; most notably "$f" to access the currently selected file.
+
 	statfmt    string        (default "\033[36m%p\033[0m| %c| %u| %g| %s| %t| -> %l")
 
 Format string of the file info shown in the bottom left corner.
-Special expansions are provided, '%p' as the file permissions, '%c' as the link count, '%u' as the user, '%g' as the group, '%s' as the file size, '%t' as the last modified time, and '%l' as the link target.
+Special expansions are provided, '%p' as the file permissions, '%c' as the link count, '%u' as the user, '%g' as the group, '%s' as the file size, '%t' as the last modified time, '%l' as the link target, and '%C' as the output of the statcmd (see above).
 The `|` character splits the format string into sections. Any section containing a failed expansion (result is a blank string) is discarded and not shown.
 
 	tabstop        int       (default 8)

--- a/docstring.go
+++ b/docstring.go
@@ -170,6 +170,7 @@ The following options can be used to customize the behavior of lf:
     smartcase        bool      (default true)
     smartdia         bool      (default false)
     sortby           string    (default 'natural')
+    statcmd          string    (default "")
     statfmt          string    (default "\033[36m%p\033[0m| %c| %u| %g| %s| %t| -> %l")
     tabstop          int       (default 8)
     tagfmt           string    (default "\033[31m")
@@ -993,14 +994,26 @@ diacritic. This option has no effect when 'ignoredia' is disabled.
 Sort type for directories. Currently supported sort types are 'natural', 'name',
 'size', 'time', 'ctime', 'atime', and 'ext'.
 
+    statcmd    string    (default "")
+
+Command to be run when using the '%C' expansion in statfmt. The '%C' is replaced
+with the output of the specified command. lf always waits for the command to
+finish, before continuing. It is the users responsibility to ensure the command
+finishes quickly, so that lf does not hang. The command is run in mostly the
+same way, as any other shell command, with respect to the shell, shellflag and
+shellopts options. That also means you can use environment variables, like in
+any other shell command; most notably "$f" to access the currently selected
+file.
+
     statfmt    string        (default "\033[36m%p\033[0m| %c| %u| %g| %s| %t| -> %l")
 
 Format string of the file info shown in the bottom left corner. Special
 expansions are provided, '%p' as the file permissions, '%c' as the link count,
 '%u' as the user, '%g' as the group, '%s' as the file size, '%t' as the last
-modified time, and '%l' as the link target. The '|' character splits the format
-string into sections. Any section containing a failed expansion (result is a
-blank string) is discarded and not shown.
+modified time, '%l' as the link target, and '%C' as the output of the statcmd
+(see above). The '|' character splits the format string into sections. Any
+section containing a failed expansion (result is a blank string) is discarded
+and not shown.
 
     tabstop        int       (default 8)
 

--- a/eval.go
+++ b/eval.go
@@ -803,6 +803,8 @@ func (e *setExpr) eval(app *app, args []string) {
 		}
 		app.nav.sort()
 		app.ui.sort()
+	case "statcmd":
+		gOpts.statcmd = e.val
 	case "statfmt":
 		gOpts.statfmt = e.val
 	case "tabstop":

--- a/lf.1
+++ b/lf.1
@@ -186,6 +186,7 @@ The following options can be used to customize the behavior of lf:
     smartcase        bool      (default true)
     smartdia         bool      (default false)
     sortby           string    (default 'natural')
+    statcmd          string    (default "")
     statfmt          string    (default "\e033[36m%p\e033[0m| %c| %u| %g| %s| %t| -> %l")
     tabstop          int       (default 8)
     tagfmt           string    (default "\e033[31m")
@@ -1102,10 +1103,16 @@ Override 'ignoredia' option when the pattern contains a character with diacritic
 Sort type for directories. Currently supported sort types are 'natural', 'name', 'size', 'time', 'ctime', 'atime', and 'ext'.
 .PP
 .EX
+    statcmd    string    (default "")
+.EE
+.PP
+Command to be run when using the '%C' expansion in statfmt. The '%C' is replaced with the output of the specified command. lf always waits for the command to finish, before continuing. It is the users responsibility to ensure the command finishes quickly, so that lf does not hang. The command is run in mostly the same way, as any other shell command, with respect to the shell, shellflag and shellopts options. That also means you can use environment variables, like in any other shell command; most notably "$f" to access the currently selected file.
+.PP
+.EX
     statfmt    string        (default "\e033[36m%p\e033[0m| %c| %u| %g| %s| %t| -> %l")
 .EE
 .PP
-Format string of the file info shown in the bottom left corner. Special expansions are provided, '%p' as the file permissions, '%c' as the link count, '%u' as the user, '%g' as the group, '%s' as the file size, '%t' as the last modified time, and '%l' as the link target. The `|` character splits the format string into sections. Any section containing a failed expansion (result is a blank string) is discarded and not shown.
+Format string of the file info shown in the bottom left corner. Special expansions are provided, '%p' as the file permissions, '%c' as the link count, '%u' as the user, '%g' as the group, '%s' as the file size, '%t' as the last modified time, '%l' as the link target, and '%C' as the output of the statcmd (see above). The `|` character splits the format string into sections. Any section containing a failed expansion (result is a blank string) is discarded and not shown.
 .PP
 .EX
     tabstop        int       (default 8)

--- a/opts.go
+++ b/opts.go
@@ -70,6 +70,7 @@ var gOpts struct {
 	shellflag        string
 	statfmt          string
 	timefmt          string
+	statcmd          string
 	infotimefmtnew   string
 	infotimefmtold   string
 	truncatechar     string
@@ -136,6 +137,7 @@ func init() {
 	gOpts.timefmt = time.ANSIC
 	gOpts.infotimefmtnew = "Jan _2 15:04"
 	gOpts.infotimefmtold = "Jan _2  2006"
+	gOpts.statcmd = ""
 	gOpts.truncatechar = "~"
 	gOpts.truncatepct = 100
 	gOpts.ratios = []int{1, 2, 3}

--- a/ui.go
+++ b/ui.go
@@ -735,6 +735,22 @@ func (ui *ui) loadFileInfo(nav *nav) {
 	replace("%s", humanize(curr.Size()))
 	replace("%t", curr.ModTime().Format(gOpts.timefmt))
 	replace("%l", curr.linkTarget)
+	if strings.Contains(statfmt, "%C") {
+		if gOpts.statcmd == "" {
+			ui.echoerrf("statcmd is empty")
+			return
+		}
+		nav.exportFiles()
+		ui.exportSizes()
+		exportOpts()
+		cmd := shellCommand(gOpts.statcmd, nil)
+		out, err := cmd.Output()
+		if err != nil {
+			ui.echoerrf("statcmd: %s", err)
+			return
+		}
+		replace("%C", string(out))
+	}
 
 	fileInfo := ""
 	for _, section := range strings.Split(statfmt, "\x1f") {


### PR DESCRIPTION
I prefer to run `exa` for the file stats, since I find it's output more visually appealing than anything I could get with the `statfmt` option. Until now however, lf had no built in support to do something like that. (I used a workaround by mapping my movement keys to a %-shell command, which would then display the output from `exa` in the status line. This however did not work flawlessly in all cases and produced some screen flickering in the status line.)

To fix this, I added a new expansion character `%C` to the `statfmt` option, that runs the command in the new `statcmd` option and displays it's output. Therefor I can achieve my desired behaviour by setting `statfmt` to `%C` and `statcmd` to my desired `exa` command. But this `statcmd` has much more use cases, for example to display version control info of the current file.

The only downside is, that lf waits for the command to finish, so the user has to ensure that the command finished relatively quickly, as otherwise lf becomes very laggy.