### PR TITLE
Fix cursor location when printing statline

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -982,8 +982,8 @@ func (ui *ui) draw(nav *nav) {
 		maxWidth := ui.msgWin.w - 1 // leave space for cursor at the end
 		prefix := runeSliceWidthRange([]rune(ui.cmdPrefix), 0, maxWidth)
 		left := runeSliceWidthLastRange(ui.cmdAccLeft, maxWidth-runeSliceWidth(prefix)-printLength(ui.msg))
-		statLine := string(prefix) + ui.msg + string(left) + string(ui.cmdAccRight)
-		ui.msgWin.printLine(ui.screen, 0, 0, st, statLine)
+		ui.msgWin.printLine(ui.screen, 0, 0, st, string(prefix)+ui.msg)
+		ui.msgWin.print(ui.screen, runeSliceWidth(prefix)+printLength(ui.msg), 0, st, string(left)+string(ui.cmdAccRight))
 		ui.screen.ShowCursor(ui.msgWin.x+runeSliceWidth(prefix)+printLength(ui.msg)+runeSliceWidth(left), ui.msgWin.y)
 	default:
 		maxWidth := ui.msgWin.w - 1 // leave space for cursor at the end

--- a/ui.go
+++ b/ui.go
@@ -979,24 +979,19 @@ func (ui *ui) draw(nav *nav) {
 		ui.drawStatLine(nav)
 		ui.screen.HideCursor()
 	case ">":
-		prefix := ui.cmdPrefix[:min(ui.msgWin.w-1, len(ui.cmdPrefix))]
-		pos := min(runeSliceWidth(ui.cmdAccLeft), ui.msgWin.w-len(prefix)-1)
-		left := ui.cmdAccLeft[runeSliceWidth(ui.cmdAccLeft)-pos:]
-		right := ui.cmdAccRight
-		ui.msgWin.printLine(ui.screen, 0, 0, st, prefix)
-		ui.msgWin.print(ui.screen, len(prefix), 0, st, ui.msg)
-		ui.msgWin.print(ui.screen, len(prefix)+printLength(ui.msg), 0, st, string(left))
-		ui.msgWin.print(ui.screen, len(prefix)+printLength(ui.msg)+runeSliceWidth(left), 0, st, string(right))
-		ui.screen.ShowCursor(ui.msgWin.x+len(prefix)+printLength(ui.msg)+runeSliceWidth(left), ui.msgWin.y)
+		maxWidth := ui.msgWin.w - 1 // leave space for cursor at the end
+		prefix := runeSliceWidthRange([]rune(ui.cmdPrefix), 0, maxWidth)
+		left := runeSliceWidthLastRange(ui.cmdAccLeft, maxWidth-runeSliceWidth(prefix)-printLength(ui.msg))
+		statLine := string(prefix) + ui.msg + string(left) + string(ui.cmdAccRight)
+		ui.msgWin.printLine(ui.screen, 0, 0, st, statLine)
+		ui.screen.ShowCursor(ui.msgWin.x+runeSliceWidth(prefix)+printLength(ui.msg)+runeSliceWidth(left), ui.msgWin.y)
 	default:
-		prefix := ui.cmdPrefix[:min(ui.msgWin.w-1, len(ui.cmdPrefix))]
-		pos := min(runeSliceWidth(ui.cmdAccLeft), ui.msgWin.w-len(prefix)-1)
-		left := ui.cmdAccLeft[runeSliceWidth(ui.cmdAccLeft)-pos:]
-		right := ui.cmdAccRight
-		ui.msgWin.printLine(ui.screen, 0, 0, st, prefix)
-		ui.msgWin.print(ui.screen, len(prefix), 0, st, string(left))
-		ui.msgWin.print(ui.screen, len(prefix)+runeSliceWidth(left), 0, st, string(right))
-		ui.screen.ShowCursor(ui.msgWin.x+len(prefix)+runeSliceWidth(left), ui.msgWin.y)
+		maxWidth := ui.msgWin.w - 1 // leave space for cursor at the end
+		prefix := runeSliceWidthRange([]rune(ui.cmdPrefix), 0, maxWidth)
+		left := runeSliceWidthLastRange(ui.cmdAccLeft, maxWidth-runeSliceWidth(prefix))
+		statLine := string(prefix) + string(left) + string(ui.cmdAccRight)
+		ui.msgWin.printLine(ui.screen, 0, 0, st, statLine)
+		ui.screen.ShowCursor(ui.msgWin.x+runeSliceWidth(prefix)+runeSliceWidth(left), ui.msgWin.y)
 	}
 
 	if gOpts.preview {

--- a/ui.go
+++ b/ui.go
@@ -989,8 +989,7 @@ func (ui *ui) draw(nav *nav) {
 		maxWidth := ui.msgWin.w - 1 // leave space for cursor at the end
 		prefix := runeSliceWidthRange([]rune(ui.cmdPrefix), 0, maxWidth)
 		left := runeSliceWidthLastRange(ui.cmdAccLeft, maxWidth-runeSliceWidth(prefix))
-		statLine := string(prefix) + string(left) + string(ui.cmdAccRight)
-		ui.msgWin.printLine(ui.screen, 0, 0, st, statLine)
+		ui.msgWin.printLine(ui.screen, 0, 0, st, string(prefix)+string(left)+string(ui.cmdAccRight))
 		ui.screen.ShowCursor(ui.msgWin.x+runeSliceWidth(prefix)+runeSliceWidth(left), ui.msgWin.y)
 	}
 


### PR DESCRIPTION
This PR fixes a few bugs with the cursor location when printing the statline:

- The prefix can contain double-width characters when deleting a file that includes such characters in its name, and this case is not handled properly because the prefix is handled as a `string` instead of a `[]rune`.
  - Create a file containing Chinese characters such as `一二三四五六七八九十`.
  - Bring up the deletion prompt by typing `:delete`.
- The size of the `left` isn't calculated properly, as `ui.cmdAccLeft` is a `[]rune` but is indexed using cell indexes.
  - Type `:` followed by some Chinese text (e.g. `一二三四五六七八九十`) until it overflows the UI.
- The size of the shell-pipe output is not taken into account when truncating `left` for `>` prompts, so the cursor can go past the end of the screen.
  - Run `%printf 'type something: ' && read ans `
  - Type until the text overflows the UI.