### PR TITLE
Clean image preview on `set preview!`

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -674,7 +674,7 @@ Set the path of a cleaner file.
 The file should be executable.
 This file is called if previewing is enabled, the previewer is set, and the previously selected file had its preview cache disabled.
 Five arguments are passed to the file, (1) current file name, (2) width, (3) height, (4) horizontal position, and (5) vertical position of preview pane respectively.
-Preview clearing is disabled when the value of this option is left empty.
+Preview cleaning is disabled when the value of this option is left empty.
 
 	cursoractivefmt   string    (default "\033[7m")
 	cursorparentfmt   string    (default "\033[7m")

--- a/docstring.go
+++ b/docstring.go
@@ -706,7 +706,7 @@ Set the path of a cleaner file. The file should be executable. This file is
 called if previewing is enabled, the previewer is set, and the previously
 selected file had its preview cache disabled. Five arguments are passed to the
 file, (1) current file name, (2) width, (3) height, (4) horizontal position,
-and (5) vertical position of preview pane respectively. Preview clearing is
+and (5) vertical position of preview pane respectively. Preview cleaning is
 disabled when the value of this option is left empty.
 
     cursoractivefmt   string    (default "\033[7m")

--- a/eval.go
+++ b/eval.go
@@ -611,12 +611,14 @@ func (e *setExpr) eval(app *app, args []string) {
 			app.ui.echoerr("preview: value should be empty, 'true', or 'false'")
 			return
 		}
+		app.ui.loadFile(app, true)
 	case "nopreview":
 		if e.val != "" {
 			app.ui.echoerrf("nopreview: unexpected value: %s", e.val)
 			return
 		}
 		gOpts.preview = false
+		app.ui.loadFile(app, true)
 	case "preview!":
 		if e.val != "" {
 			app.ui.echoerrf("preview!: unexpected value: %s", e.val)
@@ -627,6 +629,7 @@ func (e *setExpr) eval(app *app, args []string) {
 			return
 		}
 		gOpts.preview = !gOpts.preview
+		app.ui.loadFile(app, true)
 	case "previewer":
 		gOpts.previewer = replaceTilde(e.val)
 	case "promptfmt":

--- a/lf.1
+++ b/lf.1
@@ -825,7 +825,7 @@ Format string of the box drawing characters enabled by the `drawbox` option.
     cleaner        string    (default '') (not called if empty)
 .EE
 .PP
-Set the path of a cleaner file. The file should be executable. This file is called if previewing is enabled, the previewer is set, and the previously selected file had its preview cache disabled. Five arguments are passed to the file, (1) current file name, (2) width, (3) height, (4) horizontal position, and (5) vertical position of preview pane respectively. Preview clearing is disabled when the value of this option is left empty.
+Set the path of a cleaner file. The file should be executable. This file is called if previewing is enabled, the previewer is set, and the previously selected file had its preview cache disabled. Five arguments are passed to the file, (1) current file name, (2) width, (3) height, (4) horizontal position, and (5) vertical position of preview pane respectively. Preview cleaning is disabled when the value of this option is left empty.
 .PP
 .EX
     cursoractivefmt   string    (default "\e033[7m")

--- a/ui.go
+++ b/ui.go
@@ -696,12 +696,12 @@ func (ui *ui) loadFile(app *app, volatile bool) {
 		onSelect(app)
 	}
 
-	if !gOpts.preview {
-		return
-	}
-
 	if volatile {
 		app.nav.previewChan <- ""
+	}
+
+	if !gOpts.preview {
+		return
 	}
 
 	if curr.IsDir() {


### PR DESCRIPTION
After calling `set preview!`, the (`ueberzug`) image preview is not cleaned (at least in my experience).

I tried to come up with a quick fix, not sure if it the right way though. It seems to work, but maybe there is something I didn't notice, or a smarter way to do it.