### PR TITLE
Remove environment exports from preview thread

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -673,7 +673,7 @@ Format string of the box drawing characters enabled by the `drawbox` option.
 Set the path of a cleaner file.
 The file should be executable.
 This file is called if previewing is enabled, the previewer is set, and the previously selected file had its preview cache disabled.
-Five arguments are passed to the file, (1) current file name, (2) width, (3) height, (4) horizontal position, and (5) vertical position of preview pane respectively.
+The following arguments are passed to the file, (1) current file name, (2) width, (3) height, (4) horizontal position, (5) vertical position of preview pane and (6) next file name to be previewed respectively.
 Preview cleaning is disabled when the value of this option is left empty.
 
 	cursoractivefmt   string    (default "\033[7m")
@@ -844,7 +844,7 @@ Files containing the null character (U+0000) in the read portion are considered 
 
 Set the path of a previewer file to filter the content of regular files for previewing.
 The file should be executable.
-Five arguments are passed to the file, (1) current file name, (2) width, (3) height, (4) horizontal position, and (5) vertical position of preview pane respectively.
+The following arguments are passed to the file, (1) current file name, (2) width, (3) height, (4) horizontal position, and (5) vertical position of preview pane respectively.
 SIGPIPE signal is sent when enough lines are read.
 If the previewer returns a non-zero exit code, then the preview cache for the given file is disabled.
 This means that if the file is selected in the future, the previewer is called once again.

--- a/docstring.go
+++ b/docstring.go
@@ -704,10 +704,11 @@ Format string of the box drawing characters enabled by the 'drawbox' option.
 
 Set the path of a cleaner file. The file should be executable. This file is
 called if previewing is enabled, the previewer is set, and the previously
-selected file had its preview cache disabled. Five arguments are passed to the
-file, (1) current file name, (2) width, (3) height, (4) horizontal position,
-and (5) vertical position of preview pane respectively. Preview cleaning is
-disabled when the value of this option is left empty.
+selected file had its preview cache disabled. The following arguments are passed
+to the file, (1) current file name, (2) width, (3) height, (4) horizontal
+position, (5) vertical position of preview pane and (6) next file name to be
+previewed respectively. Preview cleaning is disabled when the value of this
+option is left empty.
 
     cursoractivefmt   string    (default "\033[7m")
     cursorparentfmt   string    (default "\033[7m")
@@ -899,8 +900,8 @@ files and displayed as 'binary'.
     previewer      string    (default '') (not filtered if empty)
 
 Set the path of a previewer file to filter the content of regular files for
-previewing. The file should be executable. Five arguments are passed to the
-file, (1) current file name, (2) width, (3) height, (4) horizontal position,
+previewing. The file should be executable. The following arguments are passed to
+the file, (1) current file name, (2) width, (3) height, (4) horizontal position,
 and (5) vertical position of preview pane respectively. SIGPIPE signal is sent
 when enough lines are read. If the previewer returns a non-zero exit code,
 then the preview cache for the given file is disabled. This means that if the

--- a/lf.1
+++ b/lf.1
@@ -825,7 +825,7 @@ Format string of the box drawing characters enabled by the `drawbox` option.
     cleaner        string    (default '') (not called if empty)
 .EE
 .PP
-Set the path of a cleaner file. The file should be executable. This file is called if previewing is enabled, the previewer is set, and the previously selected file had its preview cache disabled. Five arguments are passed to the file, (1) current file name, (2) width, (3) height, (4) horizontal position, and (5) vertical position of preview pane respectively. Preview cleaning is disabled when the value of this option is left empty.
+Set the path of a cleaner file. The file should be executable. This file is called if previewing is enabled, the previewer is set, and the previously selected file had its preview cache disabled. The following arguments are passed to the file, (1) current file name, (2) width, (3) height, (4) horizontal position, (5) vertical position of preview pane and (6) next file name to be previewed respectively. Preview cleaning is disabled when the value of this option is left empty.
 .PP
 .EX
     cursoractivefmt   string    (default "\e033[7m")
@@ -1021,7 +1021,7 @@ Show previews of files and directories at the right most pane. If the file has m
     previewer      string    (default '') (not filtered if empty)
 .EE
 .PP
-Set the path of a previewer file to filter the content of regular files for previewing. The file should be executable. Five arguments are passed to the file, (1) current file name, (2) width, (3) height, (4) horizontal position, and (5) vertical position of preview pane respectively. SIGPIPE signal is sent when enough lines are read. If the previewer returns a non-zero exit code, then the preview cache for the given file is disabled. This means that if the file is selected in the future, the previewer is called once again. Preview filtering is disabled and files are displayed as they are when the value of this option is left empty.
+Set the path of a previewer file to filter the content of regular files for previewing. The file should be executable. The following arguments are passed to the file, (1) current file name, (2) width, (3) height, (4) horizontal position, and (5) vertical position of preview pane respectively. SIGPIPE signal is sent when enough lines are read. If the previewer returns a non-zero exit code, then the preview cache for the given file is disabled. This means that if the file is selected in the future, the previewer is called once again. Preview filtering is disabled and files are displayed as they are when the value of this option is left empty.
 .PP
 .EX
     promptfmt      string    (default "\e033[32;1m%u@%h\e033[0m:\e033[34;1m%d\e033[0m\e033[1m%f\e033[0m")

--- a/nav.go
+++ b/nav.go
@@ -702,13 +702,12 @@ func (nav *nav) previewLoop(ui *ui) {
 		}
 		win := ui.wins[len(ui.wins)-1]
 		if clear && len(gOpts.previewer) != 0 && len(gOpts.cleaner) != 0 && nav.volatilePreview {
-			nav.exportFiles()
-			exportOpts()
 			cmd := exec.Command(gOpts.cleaner, prev,
 				strconv.Itoa(win.w),
 				strconv.Itoa(win.h),
 				strconv.Itoa(win.x),
-				strconv.Itoa(win.y))
+				strconv.Itoa(win.y),
+				path)
 			if err := cmd.Run(); err != nil {
 				log.Printf("cleaning preview: %s", err)
 			}
@@ -747,8 +746,6 @@ func (nav *nav) previewDir(dir *dir, win *win) {
 	var reader io.Reader
 
 	if len(gOpts.previewer) != 0 {
-		nav.exportFiles()
-		exportOpts()
 		cmd := exec.Command(gOpts.previewer, dir.path,
 			strconv.Itoa(win.w),
 			strconv.Itoa(win.h),
@@ -807,8 +804,6 @@ func (nav *nav) preview(path string, win *win) {
 	var reader io.Reader
 
 	if len(gOpts.previewer) != 0 {
-		nav.exportFiles()
-		exportOpts()
 		cmd := exec.Command(gOpts.previewer, path,
 			strconv.Itoa(win.w),
 			strconv.Itoa(win.h),


### PR DESCRIPTION
- Fixes #1314 
- cc #674 (may change this to `Fixes` later)

Pass the next file to be previewed directly to the `cleaner` program instead of using environment variable exports, which is not thread-safe. This can be accessed using `$6` instead of `$f`, should be labelled as a breaking change.

Exporting the options is also removed - the initial motivation was to use the `ratios` setting to determine the width of the preview, see #468 for more details. At that time, only the height was passed to the `previewer` program, see the [diff](https://github.com/gokcehan/lf/pull/468/files#diff-709f5e973a2336a6ffa87ae2b743b4a850de2c5c4c61e68a2cb0efc5352db00bL430). However this is no longer required as the preview dimensions are now passed as of #531. 