### PR TITLE
Wrap filenames in quotes only for Windows CMD

### DIFF
--- a/os_windows.go
+++ b/os_windows.go
@@ -180,5 +180,9 @@ func errCrossDevice(err error) bool {
 }
 
 func quoteString(s string) string {
-	return fmt.Sprintf(`"%s"`, s)
+	// Windows CMD requires special handling to deal with quoted arguments
+	if strings.ToLower(gOpts.shell) == "cmd" {
+		return fmt.Sprintf(`"%s"`, s)
+	}
+	return s
 }


### PR DESCRIPTION
- Fixes #1370

Filenames are wrapped in quotes when exporting them as environment variables to deal with Windows CMD, although it causes issues with PowerShell. Logic is added to check if the shell is `cmd` or not, similar to https://github.com/gokcehan/lf/blob/2620f492c27a24205ace5f5e791a0179f0489f88/os_windows.go#L104-L105