### PR TITLE
add 'setlocal' for directory specific options

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -11,6 +11,7 @@ import (
 var (
 	gCmdWords = []string{
 		"set",
+		"setlocal",
 		"map",
 		"maps",
 		"cmap",
@@ -221,6 +222,23 @@ var (
 		"truncatechar",
 		"truncatepct",
 	}
+
+	gLocalOptWords = []string{
+		"dirfirst",
+		"nodirfirst",
+		"dirfirst!",
+		"dironly",
+		"nodironly",
+		"dironly!",
+		"hidden",
+		"nohidden",
+		"hidden!",
+		"info",
+		"reverse",
+		"noreverse",
+		"reverse!",
+		"sortby",
+	}
 )
 
 func matchLongest(s1, s2 []rune) []rune {
@@ -407,6 +425,9 @@ func completeCmd(acc []rune) (matches []string, longestAcc []rune) {
 		}
 	case 3:
 		switch f[0] {
+		case "setlocal":
+			matches, longest = matchWord(f[2], gLocalOptWords)
+			longestAcc = append(acc[:len(acc)-len([]rune(f[len(f)-1]))], longest...)
 		case "map", "cmap":
 			matches, longest = matchCmd(f[2])
 			longestAcc = append(acc[:len(acc)-len([]rune(f[len(f)-1]))], longest...)
@@ -416,7 +437,7 @@ func completeCmd(acc []rune) (matches []string, longestAcc []rune) {
 		}
 	default:
 		switch f[0] {
-		case "set", "map", "cmap", "cmd":
+		case "set", "setlocal", "map", "cmap", "cmd":
 			longestAcc = acc
 		default:
 			matches, longest = matchFile(f[len(f)-1])

--- a/doc.go
+++ b/doc.go
@@ -1120,7 +1120,7 @@ Characters from '#' to newline are comments and ignored:
 
 	# comments start with '#'
 
-There are four special commands ('set', 'map', 'cmap', and 'cmd') for configuration.
+There are five special commands ('set', 'setlocal', 'map', 'cmap', and 'cmd') for configuration.
 
 Command 'set' is used to set an option which can be boolean, integer, or string:
 
@@ -1133,6 +1133,18 @@ Command 'set' is used to set an option which can be boolean, integer, or string:
 	set sortby time    # string value w/o quotes
 	set sortby 'time'  # string value with single quotes (whitespaces)
 	set sortby "time"  # string value with double quotes (backslash escapes)
+
+Command 'setlocal' is used to set a local option for a directory which can be boolean or string
+(Supported options are 'dirfirst', 'dironly', 'hidden', 'info', 'reverse', and 'sortby'):
+
+	setlocal /foo/bar hidden         # boolean enable
+	setlocal /foo/bar hidden true    # boolean enable
+	setlocal /foo/bar nohidden       # boolean disable
+	setlocal /foo/bar hidden false   # boolean disable
+	setlocal /foo/bar hidden!        # boolean toggle
+	setlocal /foo/bar sortby time    # string value w/o quotes
+	setlocal /foo/bar sortby 'time'  # string value with single quotes (whitespaces)
+	setlocal /foo/bar sortby "time"  # string value with double quotes (backslash escapes)
 
 Command 'map' is used to bind a key to a command which can be builtin command, custom command, or shell command:
 

--- a/doc.go
+++ b/doc.go
@@ -1134,8 +1134,9 @@ Command 'set' is used to set an option which can be boolean, integer, or string:
 	set sortby 'time'  # string value with single quotes (whitespaces)
 	set sortby "time"  # string value with double quotes (backslash escapes)
 
-Command 'setlocal' is used to set a local option for a directory which can be boolean or string
-(Supported options are 'dirfirst', 'dironly', 'hidden', 'info', 'reverse', and 'sortby'):
+Command 'setlocal' is used to set a local option for a directory which can be boolean or string.
+Currently supported local options are 'dirfirst', 'dironly', 'hidden', 'info', 'reverse', and 'sortby'.
+Adding a trailing path separator (i.e. '/' for Unix and '\' for Windows) sets the option for the given directory along with its subdirectories:
 
 	setlocal /foo/bar hidden         # boolean enable
 	setlocal /foo/bar hidden true    # boolean enable
@@ -1145,6 +1146,8 @@ Command 'setlocal' is used to set a local option for a directory which can be bo
 	setlocal /foo/bar sortby time    # string value w/o quotes
 	setlocal /foo/bar sortby 'time'  # string value with single quotes (whitespaces)
 	setlocal /foo/bar sortby "time"  # string value with double quotes (backslash escapes)
+	setlocal /foo/bar  hidden        # for only '/foo/bar' directory
+	setlocal /foo/bar/ hidden        # for '/foo/bar' and its subdirectories (e.g. '/foo/bar/baz')
 
 Command 'map' is used to bind a key to a command which can be builtin command, custom command, or shell command:
 

--- a/docstring.go
+++ b/docstring.go
@@ -1205,8 +1205,8 @@ Characters from '#' to newline are comments and ignored:
 
     # comments start with '#'
 
-There are four special commands ('set', 'map', 'cmap', and 'cmd') for
-configuration.
+There are five special commands ('set', 'setlocal', 'map', 'cmap', and 'cmd')
+for configuration.
 
 Command 'set' is used to set an option which can be boolean, integer, or string:
 
@@ -1219,6 +1219,19 @@ Command 'set' is used to set an option which can be boolean, integer, or string:
     set sortby time    # string value w/o quotes
     set sortby 'time'  # string value with single quotes (whitespaces)
     set sortby "time"  # string value with double quotes (backslash escapes)
+
+Command 'setlocal' is used to set a local option for a directory which can
+be boolean or string (Supported options are 'dirfirst', 'dironly', 'hidden',
+'info', 'reverse', and 'sortby'):
+
+    setlocal /foo/bar hidden         # boolean enable
+    setlocal /foo/bar hidden true    # boolean enable
+    setlocal /foo/bar nohidden       # boolean disable
+    setlocal /foo/bar hidden false   # boolean disable
+    setlocal /foo/bar hidden!        # boolean toggle
+    setlocal /foo/bar sortby time    # string value w/o quotes
+    setlocal /foo/bar sortby 'time'  # string value with single quotes (whitespaces)
+    setlocal /foo/bar sortby "time"  # string value with double quotes (backslash escapes)
 
 Command 'map' is used to bind a key to a command which can be builtin command,
 custom command, or shell command:

--- a/docstring.go
+++ b/docstring.go
@@ -1220,9 +1220,11 @@ Command 'set' is used to set an option which can be boolean, integer, or string:
     set sortby 'time'  # string value with single quotes (whitespaces)
     set sortby "time"  # string value with double quotes (backslash escapes)
 
-Command 'setlocal' is used to set a local option for a directory which can
-be boolean or string (Supported options are 'dirfirst', 'dironly', 'hidden',
-'info', 'reverse', and 'sortby'):
+Command 'setlocal' is used to set a local option for a directory which can be
+boolean or string. Currently supported local options are 'dirfirst', 'dironly',
+'hidden', 'info', 'reverse', and 'sortby'. Adding a trailing path separator
+(i.e. '/' for Unix and '\' for Windows) sets the option for the given directory
+along with its subdirectories:
 
     setlocal /foo/bar hidden         # boolean enable
     setlocal /foo/bar hidden true    # boolean enable
@@ -1232,6 +1234,8 @@ be boolean or string (Supported options are 'dirfirst', 'dironly', 'hidden',
     setlocal /foo/bar sortby time    # string value w/o quotes
     setlocal /foo/bar sortby 'time'  # string value with single quotes (whitespaces)
     setlocal /foo/bar sortby "time"  # string value with double quotes (backslash escapes)
+    setlocal /foo/bar  hidden        # for only '/foo/bar' directory
+    setlocal /foo/bar/ hidden        # for '/foo/bar' and its subdirectories (e.g. '/foo/bar/baz')
 
 Command 'map' is used to bind a key to a command which can be builtin command,
 custom command, or shell command:

--- a/eval.go
+++ b/eval.go
@@ -903,6 +903,50 @@ func (e *setExpr) eval(app *app, args []string) {
 	app.ui.loadFileInfo(app.nav)
 }
 
+func (e *setLocalExpr) eval(app *app, args []string) {
+	switch e.opt {
+	case "sortby":
+		var method sortMethod
+		switch e.val {
+		case "natural":
+			method = naturalSort
+		case "name":
+			method = nameSort
+		case "size":
+			method = sizeSort
+		case "time":
+			method = timeSort
+		case "ctime":
+			method = ctimeSort
+		case "atime":
+			method = atimeSort
+		case "ext":
+			method = extSort
+		default:
+			app.ui.echoerr("sortby: value should either be 'natural', 'name', 'size', 'time', 'atime', 'ctime' or 'ext'")
+			return
+		}
+
+		dir := replaceTilde(e.dir)
+		if val, ok := gLocalOpts[dir]; ok {
+			val.sortType.method = naturalSort
+		} else {
+			val := localOpts{
+				sortType: gOpts.sortType,
+			}
+			val.sortType.method = method
+			gLocalOpts[dir] = val
+		}
+
+		app.nav.sort()
+		app.ui.sort()
+	default:
+		app.ui.echoerrf("unknown option: %s", e.opt)
+		return
+	}
+	app.ui.loadFileInfo(app.nav)
+}
+
 func (e *mapExpr) eval(app *app, args []string) {
 	if e.expr == nil {
 		delete(gOpts.keys, e.keys)

--- a/eval.go
+++ b/eval.go
@@ -963,6 +963,21 @@ func (e *setLocalExpr) eval(app *app, args []string) {
 		gLocalOpts.hiddens[dir] = false
 		app.nav.sort()
 		app.ui.sort()
+	case "info":
+		if e.val == "" {
+			gLocalOpts.infos[dir] = nil
+			return
+		}
+		toks := strings.Split(e.val, ":")
+		for _, s := range toks {
+			switch s {
+			case "size", "time", "atime", "ctime":
+			default:
+				app.ui.echoerr("info: should consist of 'size', 'time', 'atime' or 'ctime' separated with colon")
+				return
+			}
+		}
+		gLocalOpts.infos[dir] = toks
 	case "reverse":
 		if e.val == "" || e.val == "true" {
 			gLocalOpts.reverses[dir] = true

--- a/eval.go
+++ b/eval.go
@@ -904,13 +904,18 @@ func (e *setExpr) eval(app *app, args []string) {
 }
 
 func (e *setLocalExpr) eval(app *app, args []string) {
-	dir := replaceTilde(e.dir)
+	path := filepath.Clean(replaceTilde(e.path))
+	if !filepath.IsAbs(path) {
+		app.ui.echoerr("setlocal: path should be absolute")
+		return
+	}
+
 	switch e.opt {
 	case "dirfirst":
 		if e.val == "" || e.val == "true" {
-			gLocalOpts.dirfirsts[dir] = true
+			gLocalOpts.dirfirsts[path] = true
 		} else if e.val == "false" {
-			gLocalOpts.dirfirsts[dir] = false
+			gLocalOpts.dirfirsts[path] = false
 		} else {
 			app.ui.echoerr("dirfirst: value should be empty, 'true', or 'false'")
 			return
@@ -922,7 +927,7 @@ func (e *setLocalExpr) eval(app *app, args []string) {
 			app.ui.echoerrf("nodirfirst: unexpected value: %s", e.val)
 			return
 		}
-		gLocalOpts.dirfirsts[dir] = false
+		gLocalOpts.dirfirsts[path] = false
 		app.nav.sort()
 		app.ui.sort()
 	case "dirfirst!":
@@ -930,19 +935,19 @@ func (e *setLocalExpr) eval(app *app, args []string) {
 			app.ui.echoerrf("dirfirst!: unexpected value: %s", e.val)
 			return
 		}
-		if val, ok := gLocalOpts.dirfirsts[dir]; ok {
-			gLocalOpts.dirfirsts[dir] = !val
+		if val, ok := gLocalOpts.dirfirsts[path]; ok {
+			gLocalOpts.dirfirsts[path] = !val
 		} else {
 			val = gOpts.sortType.option&dirfirstSort != 0
-			gLocalOpts.dirfirsts[dir] = !val
+			gLocalOpts.dirfirsts[path] = !val
 		}
 		app.nav.sort()
 		app.ui.sort()
 	case "dironly":
 		if e.val == "" || e.val == "true" {
-			gLocalOpts.dironlys[dir] = true
+			gLocalOpts.dironlys[path] = true
 		} else if e.val == "false" {
-			gLocalOpts.dironlys[dir] = false
+			gLocalOpts.dironlys[path] = false
 		} else {
 			app.ui.echoerr("dironly: value should be empty, 'true', or 'false'")
 			return
@@ -954,7 +959,7 @@ func (e *setLocalExpr) eval(app *app, args []string) {
 			app.ui.echoerrf("nodironly: unexpected value: %s", e.val)
 			return
 		}
-		gLocalOpts.dironlys[dir] = false
+		gLocalOpts.dironlys[path] = false
 		app.nav.sort()
 		app.ui.sort()
 	case "dironly!":
@@ -962,18 +967,18 @@ func (e *setLocalExpr) eval(app *app, args []string) {
 			app.ui.echoerrf("dironly!: unexpected value: %s", e.val)
 			return
 		}
-		if val, ok := gLocalOpts.dironlys[dir]; ok {
-			gLocalOpts.dironlys[dir] = !val
+		if val, ok := gLocalOpts.dironlys[path]; ok {
+			gLocalOpts.dironlys[path] = !val
 		} else {
-			gLocalOpts.dironlys[dir] = !gOpts.dironly
+			gLocalOpts.dironlys[path] = !gOpts.dironly
 		}
 		app.nav.sort()
 		app.ui.sort()
 	case "hidden":
 		if e.val == "" || e.val == "true" {
-			gLocalOpts.hiddens[dir] = true
+			gLocalOpts.hiddens[path] = true
 		} else if e.val == "false" {
-			gLocalOpts.hiddens[dir] = false
+			gLocalOpts.hiddens[path] = false
 		} else {
 			app.ui.echoerr("hidden: value should be empty, 'true', or 'false'")
 			return
@@ -985,7 +990,7 @@ func (e *setLocalExpr) eval(app *app, args []string) {
 			app.ui.echoerrf("nohidden: unexpected value: %s", e.val)
 			return
 		}
-		gLocalOpts.hiddens[dir] = false
+		gLocalOpts.hiddens[path] = false
 		app.nav.sort()
 		app.ui.sort()
 	case "hidden!":
@@ -993,17 +998,17 @@ func (e *setLocalExpr) eval(app *app, args []string) {
 			app.ui.echoerrf("hidden!: unexpected value: %s", e.val)
 			return
 		}
-		if val, ok := gLocalOpts.hiddens[dir]; ok {
-			gLocalOpts.hiddens[dir] = !val
+		if val, ok := gLocalOpts.hiddens[path]; ok {
+			gLocalOpts.hiddens[path] = !val
 		} else {
 			val = gOpts.sortType.option&hiddenSort != 0
-			gLocalOpts.hiddens[dir] = !val
+			gLocalOpts.hiddens[path] = !val
 		}
 		app.nav.sort()
 		app.ui.sort()
 	case "info":
 		if e.val == "" {
-			gLocalOpts.infos[dir] = nil
+			gLocalOpts.infos[path] = nil
 			return
 		}
 		toks := strings.Split(e.val, ":")
@@ -1015,12 +1020,12 @@ func (e *setLocalExpr) eval(app *app, args []string) {
 				return
 			}
 		}
-		gLocalOpts.infos[dir] = toks
+		gLocalOpts.infos[path] = toks
 	case "reverse":
 		if e.val == "" || e.val == "true" {
-			gLocalOpts.reverses[dir] = true
+			gLocalOpts.reverses[path] = true
 		} else if e.val == "false" {
-			gLocalOpts.reverses[dir] = false
+			gLocalOpts.reverses[path] = false
 		} else {
 			app.ui.echoerr("reverse: value should be empty, 'true', or 'false'")
 			return
@@ -1032,7 +1037,7 @@ func (e *setLocalExpr) eval(app *app, args []string) {
 			app.ui.echoerrf("noreverse: unexpected value: %s", e.val)
 			return
 		}
-		gLocalOpts.reverses[dir] = false
+		gLocalOpts.reverses[path] = false
 		app.nav.sort()
 		app.ui.sort()
 	case "reverse!":
@@ -1040,30 +1045,30 @@ func (e *setLocalExpr) eval(app *app, args []string) {
 			app.ui.echoerrf("reverse!: unexpected value: %s", e.val)
 			return
 		}
-		if val, ok := gLocalOpts.reverses[dir]; ok {
-			gLocalOpts.reverses[dir] = !val
+		if val, ok := gLocalOpts.reverses[path]; ok {
+			gLocalOpts.reverses[path] = !val
 		} else {
 			val = gOpts.sortType.option&reverseSort != 0
-			gLocalOpts.reverses[dir] = !val
+			gLocalOpts.reverses[path] = !val
 		}
 		app.nav.sort()
 		app.ui.sort()
 	case "sortby":
 		switch e.val {
 		case "natural":
-			gLocalOpts.sortMethods[dir] = naturalSort
+			gLocalOpts.sortMethods[path] = naturalSort
 		case "name":
-			gLocalOpts.sortMethods[dir] = nameSort
+			gLocalOpts.sortMethods[path] = nameSort
 		case "size":
-			gLocalOpts.sortMethods[dir] = sizeSort
+			gLocalOpts.sortMethods[path] = sizeSort
 		case "time":
-			gLocalOpts.sortMethods[dir] = timeSort
+			gLocalOpts.sortMethods[path] = timeSort
 		case "ctime":
-			gLocalOpts.sortMethods[dir] = ctimeSort
+			gLocalOpts.sortMethods[path] = ctimeSort
 		case "atime":
-			gLocalOpts.sortMethods[dir] = atimeSort
+			gLocalOpts.sortMethods[path] = atimeSort
 		case "ext":
-			gLocalOpts.sortMethods[dir] = extSort
+			gLocalOpts.sortMethods[path] = extSort
 		default:
 			app.ui.echoerr("sortby: value should either be 'natural', 'name', 'size', 'time', 'atime', 'ctime' or 'ext'")
 			return

--- a/eval.go
+++ b/eval.go
@@ -925,6 +925,25 @@ func (e *setLocalExpr) eval(app *app, args []string) {
 		gLocalOpts.dirfirsts[dir] = false
 		app.nav.sort()
 		app.ui.sort()
+	case "dironly":
+		if e.val == "" || e.val == "true" {
+			gLocalOpts.dironlys[dir] = true
+		} else if e.val == "false" {
+			gLocalOpts.dironlys[dir] = false
+		} else {
+			app.ui.echoerr("dironly: value should be empty, 'true', or 'false'")
+			return
+		}
+		app.nav.sort()
+		app.ui.sort()
+	case "nodironly":
+		if e.val != "" {
+			app.ui.echoerrf("nodironly: unexpected value: %s", e.val)
+			return
+		}
+		gLocalOpts.dironlys[dir] = false
+		app.nav.sort()
+		app.ui.sort()
 	case "hidden":
 		if e.val == "" || e.val == "true" {
 			gLocalOpts.hiddens[dir] = true

--- a/eval.go
+++ b/eval.go
@@ -904,7 +904,7 @@ func (e *setExpr) eval(app *app, args []string) {
 }
 
 func (e *setLocalExpr) eval(app *app, args []string) {
-	path := filepath.Clean(replaceTilde(e.path))
+	path := replaceTilde(e.path)
 	if !filepath.IsAbs(path) {
 		app.ui.echoerr("setlocal: path should be absolute")
 		return

--- a/eval.go
+++ b/eval.go
@@ -906,6 +906,25 @@ func (e *setExpr) eval(app *app, args []string) {
 func (e *setLocalExpr) eval(app *app, args []string) {
 	dir := replaceTilde(e.dir)
 	switch e.opt {
+	case "dirfirst":
+		if e.val == "" || e.val == "true" {
+			gLocalOpts.dirfirsts[dir] = true
+		} else if e.val == "false" {
+			gLocalOpts.dirfirsts[dir] = false
+		} else {
+			app.ui.echoerr("dirfirst: value should be empty, 'true', or 'false'")
+			return
+		}
+		app.nav.sort()
+		app.ui.sort()
+	case "nodirfirst":
+		if e.val != "" {
+			app.ui.echoerrf("nodirfirst: unexpected value: %s", e.val)
+			return
+		}
+		gLocalOpts.dirfirsts[dir] = false
+		app.nav.sort()
+		app.ui.sort()
 	case "reverse":
 		if e.val == "" || e.val == "true" {
 			gLocalOpts.reverses[dir] = true

--- a/eval.go
+++ b/eval.go
@@ -906,6 +906,25 @@ func (e *setExpr) eval(app *app, args []string) {
 func (e *setLocalExpr) eval(app *app, args []string) {
 	dir := replaceTilde(e.dir)
 	switch e.opt {
+	case "reverse":
+		if e.val == "" || e.val == "true" {
+			gLocalOpts.reverses[dir] = true
+		} else if e.val == "false" {
+			gLocalOpts.reverses[dir] = false
+		} else {
+			app.ui.echoerr("reverse: value should be empty, 'true', or 'false'")
+			return
+		}
+		app.nav.sort()
+		app.ui.sort()
+	case "noreverse":
+		if e.val != "" {
+			app.ui.echoerrf("noreverse: unexpected value: %s", e.val)
+			return
+		}
+		gLocalOpts.reverses[dir] = false
+		app.nav.sort()
+		app.ui.sort()
 	case "sortby":
 		switch e.val {
 		case "natural":

--- a/eval.go
+++ b/eval.go
@@ -925,6 +925,25 @@ func (e *setLocalExpr) eval(app *app, args []string) {
 		gLocalOpts.dirfirsts[dir] = false
 		app.nav.sort()
 		app.ui.sort()
+	case "hidden":
+		if e.val == "" || e.val == "true" {
+			gLocalOpts.hiddens[dir] = true
+		} else if e.val == "false" {
+			gLocalOpts.hiddens[dir] = false
+		} else {
+			app.ui.echoerr("hidden: value should be empty, 'true', or 'false'")
+			return
+		}
+		app.nav.sort()
+		app.ui.sort()
+	case "nohidden":
+		if e.val != "" {
+			app.ui.echoerrf("nohidden: unexpected value: %s", e.val)
+			return
+		}
+		gLocalOpts.hiddens[dir] = false
+		app.nav.sort()
+		app.ui.sort()
 	case "reverse":
 		if e.val == "" || e.val == "true" {
 			gLocalOpts.reverses[dir] = true

--- a/eval.go
+++ b/eval.go
@@ -925,6 +925,19 @@ func (e *setLocalExpr) eval(app *app, args []string) {
 		gLocalOpts.dirfirsts[dir] = false
 		app.nav.sort()
 		app.ui.sort()
+	case "dirfirst!":
+		if e.val != "" {
+			app.ui.echoerrf("dirfirst!: unexpected value: %s", e.val)
+			return
+		}
+		if val, ok := gLocalOpts.dirfirsts[dir]; ok {
+			gLocalOpts.dirfirsts[dir] = !val
+		} else {
+			val = gOpts.sortType.option&dirfirstSort != 0
+			gLocalOpts.dirfirsts[dir] = !val
+		}
+		app.nav.sort()
+		app.ui.sort()
 	case "dironly":
 		if e.val == "" || e.val == "true" {
 			gLocalOpts.dironlys[dir] = true
@@ -944,6 +957,18 @@ func (e *setLocalExpr) eval(app *app, args []string) {
 		gLocalOpts.dironlys[dir] = false
 		app.nav.sort()
 		app.ui.sort()
+	case "dironly!":
+		if e.val != "" {
+			app.ui.echoerrf("dironly!: unexpected value: %s", e.val)
+			return
+		}
+		if val, ok := gLocalOpts.dironlys[dir]; ok {
+			gLocalOpts.dironlys[dir] = !val
+		} else {
+			gLocalOpts.dironlys[dir] = !gOpts.dironly
+		}
+		app.nav.sort()
+		app.ui.sort()
 	case "hidden":
 		if e.val == "" || e.val == "true" {
 			gLocalOpts.hiddens[dir] = true
@@ -961,6 +986,19 @@ func (e *setLocalExpr) eval(app *app, args []string) {
 			return
 		}
 		gLocalOpts.hiddens[dir] = false
+		app.nav.sort()
+		app.ui.sort()
+	case "hidden!":
+		if e.val != "" {
+			app.ui.echoerrf("hidden!: unexpected value: %s", e.val)
+			return
+		}
+		if val, ok := gLocalOpts.hiddens[dir]; ok {
+			gLocalOpts.hiddens[dir] = !val
+		} else {
+			val = gOpts.sortType.option&hiddenSort != 0
+			gLocalOpts.hiddens[dir] = !val
+		}
 		app.nav.sort()
 		app.ui.sort()
 	case "info":
@@ -995,6 +1033,19 @@ func (e *setLocalExpr) eval(app *app, args []string) {
 			return
 		}
 		gLocalOpts.reverses[dir] = false
+		app.nav.sort()
+		app.ui.sort()
+	case "reverse!":
+		if e.val != "" {
+			app.ui.echoerrf("reverse!: unexpected value: %s", e.val)
+			return
+		}
+		if val, ok := gLocalOpts.reverses[dir]; ok {
+			gLocalOpts.reverses[dir] = !val
+		} else {
+			val = gOpts.sortType.option&reverseSort != 0
+			gLocalOpts.reverses[dir] = !val
+		}
 		app.nav.sort()
 		app.ui.sort()
 	case "sortby":

--- a/eval.go
+++ b/eval.go
@@ -904,40 +904,28 @@ func (e *setExpr) eval(app *app, args []string) {
 }
 
 func (e *setLocalExpr) eval(app *app, args []string) {
+	dir := replaceTilde(e.dir)
 	switch e.opt {
 	case "sortby":
-		var method sortMethod
 		switch e.val {
 		case "natural":
-			method = naturalSort
+			gLocalOpts.sortMethods[dir] = naturalSort
 		case "name":
-			method = nameSort
+			gLocalOpts.sortMethods[dir] = nameSort
 		case "size":
-			method = sizeSort
+			gLocalOpts.sortMethods[dir] = sizeSort
 		case "time":
-			method = timeSort
+			gLocalOpts.sortMethods[dir] = timeSort
 		case "ctime":
-			method = ctimeSort
+			gLocalOpts.sortMethods[dir] = ctimeSort
 		case "atime":
-			method = atimeSort
+			gLocalOpts.sortMethods[dir] = atimeSort
 		case "ext":
-			method = extSort
+			gLocalOpts.sortMethods[dir] = extSort
 		default:
 			app.ui.echoerr("sortby: value should either be 'natural', 'name', 'size', 'time', 'atime', 'ctime' or 'ext'")
 			return
 		}
-
-		dir := replaceTilde(e.dir)
-		if val, ok := gLocalOpts[dir]; ok {
-			val.sortType.method = naturalSort
-		} else {
-			val := localOpts{
-				sortType: gOpts.sortType,
-			}
-			val.sortType.method = method
-			gLocalOpts[dir] = val
-		}
-
 		app.nav.sort()
 		app.ui.sort()
 	default:

--- a/eval_test.go
+++ b/eval_test.go
@@ -192,6 +192,84 @@ var gEvalTests = []struct {
 	},
 
 	{
+		"setlocal /foo/bar hidden # trailing comments are allowed",
+		[]string{"setlocal", "/foo/bar", "hidden", "\n"},
+		[]expr{&setLocalExpr{"/foo/bar", "hidden", ""}},
+	},
+
+	{
+		"setlocal /foo/bar hidden; setlocal /foo/bar reverse",
+		[]string{"setlocal", "/foo/bar", "hidden", ";", "setlocal", "/foo/bar", "reverse", "\n"},
+		[]expr{&setLocalExpr{"/foo/bar", "hidden", ""}, &setLocalExpr{"/foo/bar", "reverse", ""}},
+	},
+
+	{
+		"setlocal /foo/bar hidden\nsetlocal /foo/bar reverse",
+		[]string{"setlocal", "/foo/bar", "hidden", "\n", "setlocal", "/foo/bar", "reverse", "\n"},
+		[]expr{&setLocalExpr{"/foo/bar", "hidden", ""}, &setLocalExpr{"/foo/bar", "reverse", ""}},
+	},
+
+	{
+		`setlocal /foo/bar info ""`,
+		[]string{"setlocal", "/foo/bar", "info", "", "\n"},
+		[]expr{&setLocalExpr{"/foo/bar", "info", ""}},
+	},
+
+	{
+		`setlocal /foo/bar info "size"`,
+		[]string{"setlocal", "/foo/bar", "info", "size", "\n"},
+		[]expr{&setLocalExpr{"/foo/bar", "info", "size"}},
+	},
+
+	{
+		"setlocal /foo/bar info size:time",
+		[]string{"setlocal", "/foo/bar", "info", "size:time", "\n"},
+		[]expr{&setLocalExpr{"/foo/bar", "info", "size:time"}},
+	},
+
+	{
+		"setlocal /foo/bar info size:time;",
+		[]string{"setlocal", "/foo/bar", "info", "size:time", ";"},
+		[]expr{&setLocalExpr{"/foo/bar", "info", "size:time"}},
+	},
+
+	{
+		":setlocal /foo/bar info size:time",
+		[]string{":", "setlocal", "/foo/bar", "info", "size:time", "\n", "\n"},
+		[]expr{&listExpr{[]expr{&setLocalExpr{"/foo/bar", "info", "size:time"}}, 1}},
+	},
+
+	{
+		":setlocal /foo/bar info size:time\nsetlocal /foo/bar hidden",
+		[]string{":", "setlocal", "/foo/bar", "info", "size:time", "\n", "\n", "setlocal", "/foo/bar", "hidden", "\n"},
+		[]expr{&listExpr{[]expr{&setLocalExpr{"/foo/bar", "info", "size:time"}}, 1}, &setLocalExpr{"/foo/bar", "hidden", ""}},
+	},
+
+	{
+		":setlocal /foo/bar info size:time;",
+		[]string{":", "setlocal", "/foo/bar", "info", "size:time", ";", "\n"},
+		[]expr{&listExpr{[]expr{&setLocalExpr{"/foo/bar", "info", "size:time"}}, 1}},
+	},
+
+	{
+		":setlocal /foo/bar info size:time;\nsetlocal /foo/bar hidden",
+		[]string{":", "setlocal", "/foo/bar", "info", "size:time", ";", "\n", "setlocal", "/foo/bar", "hidden", "\n"},
+		[]expr{&listExpr{[]expr{&setLocalExpr{"/foo/bar", "info", "size:time"}}, 1}, &setLocalExpr{"/foo/bar", "hidden", ""}},
+	},
+
+	{
+		"setlocal /foo/bar info size:time\n setlocal /foo/bar hidden",
+		[]string{"setlocal", "/foo/bar", "info", "size:time", "\n", "setlocal", "/foo/bar", "hidden", "\n"},
+		[]expr{&setLocalExpr{"/foo/bar", "info", "size:time"}, &setLocalExpr{"/foo/bar", "hidden", ""}},
+	},
+
+	{
+		"setlocal /foo/bar info size:time \nsetlocal /foo/bar hidden",
+		[]string{"setlocal", "/foo/bar", "info", "size:time", "\n", "setlocal", "/foo/bar", "hidden", "\n"},
+		[]expr{&setLocalExpr{"/foo/bar", "info", "size:time"}, &setLocalExpr{"/foo/bar", "hidden", ""}},
+	},
+
+	{
 		"map gh cd ~",
 		[]string{"map", "gh", "cd", "~", "\n"},
 		[]expr{&mapExpr{"gh", &callExpr{"cd", []string{"~"}, 1}}},

--- a/lf.1
+++ b/lf.1
@@ -1358,7 +1358,7 @@ Command 'set' is used to set an option which can be boolean, integer, or string:
     set sortby "time"  # string value with double quotes (backslash escapes)
 .EE
 .PP
-Command 'setlocal' is used to set a local option for a directory which can be boolean or string (Supported options are 'dirfirst', 'dironly', 'hidden', 'info', 'reverse', and 'sortby'):
+Command 'setlocal' is used to set a local option for a directory which can be boolean or string. Currently supported local options are 'dirfirst', 'dironly', 'hidden', 'info', 'reverse', and 'sortby'. Adding a trailing path separator (i.e. '/' for Unix and '\e' for Windows) sets the option for the given directory along with its subdirectories:
 .PP
 .EX
     setlocal /foo/bar hidden         # boolean enable
@@ -1369,6 +1369,8 @@ Command 'setlocal' is used to set a local option for a directory which can be bo
     setlocal /foo/bar sortby time    # string value w/o quotes
     setlocal /foo/bar sortby 'time'  # string value with single quotes (whitespaces)
     setlocal /foo/bar sortby "time"  # string value with double quotes (backslash escapes)
+    setlocal /foo/bar  hidden        # for only '/foo/bar' directory
+    setlocal /foo/bar/ hidden        # for '/foo/bar' and its subdirectories (e.g. '/foo/bar/baz')
 .EE
 .PP
 Command 'map' is used to bind a key to a command which can be builtin command, custom command, or shell command:

--- a/lf.1
+++ b/lf.1
@@ -1342,7 +1342,7 @@ Characters from '#' to newline are comments and ignored:
     # comments start with '#'
 .EE
 .PP
-There are four special commands ('set', 'map', 'cmap', and 'cmd') for configuration.
+There are five special commands ('set', 'setlocal', 'map', 'cmap', and 'cmd') for configuration.
 .PP
 Command 'set' is used to set an option which can be boolean, integer, or string:
 .PP
@@ -1356,6 +1356,19 @@ Command 'set' is used to set an option which can be boolean, integer, or string:
     set sortby time    # string value w/o quotes
     set sortby 'time'  # string value with single quotes (whitespaces)
     set sortby "time"  # string value with double quotes (backslash escapes)
+.EE
+.PP
+Command 'setlocal' is used to set a local option for a directory which can be boolean or string (Supported options are 'dirfirst', 'dironly', 'hidden', 'info', 'reverse', and 'sortby'):
+.PP
+.EX
+    setlocal /foo/bar hidden         # boolean enable
+    setlocal /foo/bar hidden true    # boolean enable
+    setlocal /foo/bar nohidden       # boolean disable
+    setlocal /foo/bar hidden false   # boolean disable
+    setlocal /foo/bar hidden!        # boolean toggle
+    setlocal /foo/bar sortby time    # string value w/o quotes
+    setlocal /foo/bar sortby 'time'  # string value with single quotes (whitespaces)
+    setlocal /foo/bar sortby "time"  # string value with double quotes (backslash escapes)
 .EE
 .PP
 Command 'map' is used to bind a key to a command which can be builtin command, custom command, or shell command:

--- a/nav.go
+++ b/nav.go
@@ -185,7 +185,7 @@ func normalize(s1, s2 string, ignorecase, ignoredia bool) (string, string) {
 
 func (dir *dir) sort() {
 	dir.sortType = getSortType(dir.path)
-	dir.dironly = gOpts.dironly
+	dir.dironly = getDirOnly(dir.path)
 	dir.hiddenfiles = gOpts.hiddenfiles
 	dir.ignorecase = gOpts.ignorecase
 	dir.ignoredia = gOpts.ignoredia
@@ -510,7 +510,7 @@ func (nav *nav) checkDir(dir *dir) {
 			nav.dirChan <- nd
 		}()
 	case dir.sortType != getSortType(dir.path) ||
-		dir.dironly != gOpts.dironly ||
+		dir.dironly != getDirOnly(dir.path) ||
 		!reflect.DeepEqual(dir.hiddenfiles, gOpts.hiddenfiles) ||
 		dir.ignorecase != gOpts.ignorecase ||
 		dir.ignoredia != gOpts.ignoredia:

--- a/nav.go
+++ b/nav.go
@@ -184,7 +184,7 @@ func normalize(s1, s2 string, ignorecase, ignoredia bool) (string, string) {
 }
 
 func (dir *dir) sort() {
-	dir.sortType = gOpts.sortType
+	dir.sortType = getSortType(dir.path)
 	dir.dironly = gOpts.dironly
 	dir.hiddenfiles = gOpts.hiddenfiles
 	dir.ignorecase = gOpts.ignorecase
@@ -446,7 +446,7 @@ func (nav *nav) loadDirInternal(path string) *dir {
 		loading:     true,
 		loadTime:    time.Now(),
 		path:        path,
-		sortType:    gOpts.sortType,
+		sortType:    getSortType(path),
 		hiddenfiles: gOpts.hiddenfiles,
 		ignorecase:  gOpts.ignorecase,
 		ignoredia:   gOpts.ignoredia,
@@ -509,7 +509,7 @@ func (nav *nav) checkDir(dir *dir) {
 			}
 			nav.dirChan <- nd
 		}()
-	case dir.sortType != gOpts.sortType ||
+	case dir.sortType != getSortType(dir.path) ||
 		dir.dironly != gOpts.dironly ||
 		!reflect.DeepEqual(dir.hiddenfiles, gOpts.hiddenfiles) ||
 		dir.ignorecase != gOpts.ignorecase ||

--- a/opts.go
+++ b/opts.go
@@ -107,7 +107,7 @@ func localOptPaths(path string) []string {
 	var list []string
 	list = append(list, path)
 	for curr := path; !isRoot(curr); curr = filepath.Dir(curr) {
-		list = append(list, curr + string(filepath.Separator))
+		list = append(list, curr+string(filepath.Separator))
 	}
 	return list
 }

--- a/opts.go
+++ b/opts.go
@@ -94,6 +94,7 @@ var gOpts struct {
 var gLocalOpts struct {
 	sortMethods map[string]sortMethod
 	dirfirsts   map[string]bool
+	hiddens     map[string]bool
 	reverses    map[string]bool
 }
 
@@ -112,6 +113,13 @@ func getSortType(path string) sortType {
 			option |= dirfirstSort
 		} else {
 			option &= ^dirfirstSort
+		}
+	}
+	if val, ok := gLocalOpts.hiddens[path]; ok {
+		if val {
+			option |= hiddenSort
+		} else {
+			option &= ^hiddenSort
 		}
 	}
 	if val, ok := gLocalOpts.reverses[path]; ok {
@@ -305,6 +313,7 @@ func init() {
 
 	gLocalOpts.sortMethods = make(map[string]sortMethod)
 	gLocalOpts.dirfirsts = make(map[string]bool)
+	gLocalOpts.hiddens = make(map[string]bool)
 	gLocalOpts.reverses = make(map[string]bool)
 
 	setDefaults()

--- a/opts.go
+++ b/opts.go
@@ -94,6 +94,7 @@ var gOpts struct {
 var gLocalOpts struct {
 	sortMethods map[string]sortMethod
 	dirfirsts   map[string]bool
+	dironlys    map[string]bool
 	hiddens     map[string]bool
 	reverses    map[string]bool
 }
@@ -134,6 +135,13 @@ func getSortType(path string) sortType {
 		option: option,
 	}
 	return val
+}
+
+func getDirOnly(path string) bool {
+	if val, ok := gLocalOpts.dironlys[path]; ok {
+		return val
+	}
+	return gOpts.dironly
 }
 
 func init() {
@@ -313,6 +321,7 @@ func init() {
 
 	gLocalOpts.sortMethods = make(map[string]sortMethod)
 	gLocalOpts.dirfirsts = make(map[string]bool)
+	gLocalOpts.dironlys = make(map[string]bool)
 	gLocalOpts.hiddens = make(map[string]bool)
 	gLocalOpts.reverses = make(map[string]bool)
 

--- a/opts.go
+++ b/opts.go
@@ -91,6 +91,19 @@ var gOpts struct {
 	tagfmt           string
 }
 
+type localOpts struct {
+	sortType sortType
+}
+
+var gLocalOpts map[string]localOpts = make(map[string]localOpts)
+
+func getSortType(path string) sortType {
+	if val, ok := gLocalOpts[path]; ok {
+		return val.sortType
+	}
+	return gOpts.sortType
+}
+
 func init() {
 	gOpts.anchorfind = true
 	gOpts.autoquit = false

--- a/opts.go
+++ b/opts.go
@@ -91,17 +91,25 @@ var gOpts struct {
 	tagfmt           string
 }
 
-type localOpts struct {
-	sortType sortType
+var gLocalOpts struct {
+	sortMethods map[string]sortMethod
 }
 
-var gLocalOpts map[string]localOpts = make(map[string]localOpts)
+func getSortMethod(path string) sortMethod {
+	if val, ok := gLocalOpts.sortMethods[path]; ok {
+		return val
+	}
+	return gOpts.sortType.method
+}
 
 func getSortType(path string) sortType {
-	if val, ok := gLocalOpts[path]; ok {
-		return val.sortType
+	method := getSortMethod(path)
+	option := gOpts.sortType.option
+	val := sortType{
+		method: method,
+		option: option,
 	}
-	return gOpts.sortType
+	return val
 }
 
 func init() {
@@ -278,6 +286,8 @@ func init() {
 
 	gOpts.cmds = make(map[string]expr)
 	gOpts.user = make(map[string]string)
+
+	gLocalOpts.sortMethods = make(map[string]sortMethod)
 
 	setDefaults()
 }

--- a/opts.go
+++ b/opts.go
@@ -93,6 +93,7 @@ var gOpts struct {
 
 var gLocalOpts struct {
 	sortMethods map[string]sortMethod
+	dirfirsts   map[string]bool
 	reverses    map[string]bool
 }
 
@@ -106,6 +107,13 @@ func getSortMethod(path string) sortMethod {
 func getSortType(path string) sortType {
 	method := getSortMethod(path)
 	option := gOpts.sortType.option
+	if val, ok := gLocalOpts.dirfirsts[path]; ok {
+		if val {
+			option |= dirfirstSort
+		} else {
+			option &= ^dirfirstSort
+		}
+	}
 	if val, ok := gLocalOpts.reverses[path]; ok {
 		if val {
 			option |= reverseSort
@@ -296,6 +304,7 @@ func init() {
 	gOpts.user = make(map[string]string)
 
 	gLocalOpts.sortMethods = make(map[string]sortMethod)
+	gLocalOpts.dirfirsts = make(map[string]bool)
 	gLocalOpts.reverses = make(map[string]bool)
 
 	setDefaults()

--- a/opts.go
+++ b/opts.go
@@ -93,6 +93,7 @@ var gOpts struct {
 
 var gLocalOpts struct {
 	sortMethods map[string]sortMethod
+	reverses    map[string]bool
 }
 
 func getSortMethod(path string) sortMethod {
@@ -105,6 +106,13 @@ func getSortMethod(path string) sortMethod {
 func getSortType(path string) sortType {
 	method := getSortMethod(path)
 	option := gOpts.sortType.option
+	if val, ok := gLocalOpts.reverses[path]; ok {
+		if val {
+			option |= reverseSort
+		} else {
+			option &= ^reverseSort
+		}
+	}
 	val := sortType{
 		method: method,
 		option: option,
@@ -288,6 +296,7 @@ func init() {
 	gOpts.user = make(map[string]string)
 
 	gLocalOpts.sortMethods = make(map[string]sortMethod)
+	gLocalOpts.reverses = make(map[string]bool)
 
 	setDefaults()
 }

--- a/opts.go
+++ b/opts.go
@@ -97,6 +97,7 @@ var gLocalOpts struct {
 	dironlys    map[string]bool
 	hiddens     map[string]bool
 	reverses    map[string]bool
+	infos       map[string][]string
 }
 
 func getSortMethod(path string) sortMethod {
@@ -142,6 +143,13 @@ func getDirOnly(path string) bool {
 		return val
 	}
 	return gOpts.dironly
+}
+
+func getInfo(path string) []string {
+	if val, ok := gLocalOpts.infos[path]; ok {
+		return val
+	}
+	return gOpts.info
 }
 
 func init() {
@@ -324,6 +332,7 @@ func init() {
 	gLocalOpts.dironlys = make(map[string]bool)
 	gLocalOpts.hiddens = make(map[string]bool)
 	gLocalOpts.reverses = make(map[string]bool)
+	gLocalOpts.infos = make(map[string][]string)
 
 	setDefaults()
 }

--- a/opts.go
+++ b/opts.go
@@ -1,6 +1,9 @@
 package main
 
-import "time"
+import (
+	"path/filepath"
+	"time"
+)
 
 type sortMethod byte
 
@@ -100,9 +103,20 @@ var gLocalOpts struct {
 	infos       map[string][]string
 }
 
+func localOptPaths(path string) []string {
+	var list []string
+	list = append(list, path)
+	for curr := path; !isRoot(curr); curr = filepath.Dir(curr) {
+		list = append(list, curr + string(filepath.Separator))
+	}
+	return list
+}
+
 func getSortMethod(path string) sortMethod {
-	if val, ok := gLocalOpts.sortMethods[path]; ok {
-		return val
+	for _, key := range localOptPaths(path) {
+		if val, ok := gLocalOpts.sortMethods[key]; ok {
+			return val
+		}
 	}
 	return gOpts.sortType.method
 }
@@ -110,25 +124,34 @@ func getSortMethod(path string) sortMethod {
 func getSortType(path string) sortType {
 	method := getSortMethod(path)
 	option := gOpts.sortType.option
-	if val, ok := gLocalOpts.dirfirsts[path]; ok {
-		if val {
-			option |= dirfirstSort
-		} else {
-			option &= ^dirfirstSort
+	for _, key := range localOptPaths(path) {
+		if val, ok := gLocalOpts.dirfirsts[key]; ok {
+			if val {
+				option |= dirfirstSort
+			} else {
+				option &= ^dirfirstSort
+			}
+			break
 		}
 	}
-	if val, ok := gLocalOpts.hiddens[path]; ok {
-		if val {
-			option |= hiddenSort
-		} else {
-			option &= ^hiddenSort
+	for _, key := range localOptPaths(path) {
+		if val, ok := gLocalOpts.hiddens[key]; ok {
+			if val {
+				option |= hiddenSort
+			} else {
+				option &= ^hiddenSort
+			}
+			break
 		}
 	}
-	if val, ok := gLocalOpts.reverses[path]; ok {
-		if val {
-			option |= reverseSort
-		} else {
-			option &= ^reverseSort
+	for _, key := range localOptPaths(path) {
+		if val, ok := gLocalOpts.reverses[key]; ok {
+			if val {
+				option |= reverseSort
+			} else {
+				option &= ^reverseSort
+			}
+			break
 		}
 	}
 	val := sortType{
@@ -139,15 +162,19 @@ func getSortType(path string) sortType {
 }
 
 func getDirOnly(path string) bool {
-	if val, ok := gLocalOpts.dironlys[path]; ok {
-		return val
+	for _, key := range localOptPaths(path) {
+		if val, ok := gLocalOpts.dironlys[key]; ok {
+			return val
+		}
 	}
 	return gOpts.dironly
 }
 
 func getInfo(path string) []string {
-	if val, ok := gLocalOpts.infos[path]; ok {
-		return val
+	for _, key := range localOptPaths(path) {
+		if val, ok := gLocalOpts.infos[key]; ok {
+			return val
+		}
 	}
 	return gOpts.info
 }

--- a/parse.go
+++ b/parse.go
@@ -54,12 +54,12 @@ type setExpr struct {
 func (e *setExpr) String() string { return fmt.Sprintf("set %s %s", e.opt, e.val) }
 
 type setLocalExpr struct {
-	dir string
-	opt string
-	val string
+	path string
+	opt  string
+	val  string
 }
 
-func (e *setLocalExpr) String() string { return fmt.Sprintf("setlocal %s %s %s", e.dir, e.opt, e.val) }
+func (e *setLocalExpr) String() string { return fmt.Sprintf("setlocal %s %s %s", e.path, e.opt, e.val) }
 
 type mapExpr struct {
 	keys string

--- a/ui.go
+++ b/ui.go
@@ -288,7 +288,7 @@ func infotimefmt(t time.Time) string {
 func fileInfo(f *file, d *dir) string {
 	var info string
 
-	for _, s := range gOpts.info {
+	for _, s := range getInfo(d.path) {
 		switch s {
 		case "size":
 			if !(f.IsDir() && gOpts.dircounts) {


### PR DESCRIPTION
cc #117 #171

This has been on the back of my mind for quite a while as sorting the downloads directory by time automatically is quite common in other file managers, so I decided to give this a try today. I'm pushing this as a PR to benefit from our usual review mechanism, so discussion is welcomed.

You can try this with the following example:

```
setlocal ~/Downloads sortby time
```

This is still a draft. Some things that are worth mentioning are as follows:

1. There were two approaches in my mind before I started working on this, keep the local option values in `dir` or in a global map. First approach seemed a little complicated as we want to be able to set local options even if the corresponding directories are not loaded yet. On the other hand, the second approach requires checking the global map each time an option is used, though I don't expect it to create a performance bottleneck.

2. Adding a new keyword (i.e. `setlocal`) seemed inevitable. I also thought about reusing the `set` keyword with an optional directory value, but `set` already have an optional field for boolean options, so `setlocal` seemed like the safer choice. It is possible to shorten `setlocal` to `setl` but I think it is better to be explicit in this case.

3. I have only added `sortby` so far for testing. In general, there are many options that are not applicable as a local option or they don't make much sense even if they are applicable. So I thought it would be better to add options selectively whenever they make sense. Currently, I'm thinking of only adding options related to sorting and maybe also things like `info` initially. I expect these options to cover most use-cases that users have in mind.

4. There is currently no way to remove a local option once it is set. If there is a need for it, I'm not sure how it should work yet.

5. There could be some issues related to `sortType`. If a local option in this struct is set, then I think other options in this struct will not be updated when the corresponding global option value is changed. I'm not yet sure if this is a niche case or it is worth considering. Also, I think we have some inconsistencies about the included options in `sortType`. For example, I think `dironly` could have been added to `sortOption` as well. I think the reason `ignorecase` and `ignoredia` is excluded is due to them being used in places other than sorting. I'm not sure about `hiddenfiles` but maybe it could have been added as a separate field to `sortType`. I don't remember much about why we introduced `sortType` but one possibility is to get rid of it altogether to fix the issue with `setlocal`.