### PR TITLE
List files even when lstat fails

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -726,6 +726,11 @@ func (ui *ui) loadFileInfo(nav *nav) {
 		return
 	}
 
+	if curr.err != nil {
+		ui.echoerrf("stat: %s", curr.err)
+		return
+	}
+
 	statfmt := strings.ReplaceAll(gOpts.statfmt, "|", "\x1f")
 	replace := func(s string, val string) {
 		if val == "" {


### PR DESCRIPTION
Implements a `fakeStat` struct with dummy values and stores the error in `file.err`, then shows the error instead of FileInfo, if the file is inaccesible.

Fixes #1359