### PR TITLE
fix: empty file previews as binary

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -850,8 +850,8 @@ func (nav *nav) preview(path string, win *win) {
 
 	prefix := make([]byte, 2)
 	if gOpts.sixel {
-		_, err := reader.Read(prefix)
-		reader = io.MultiReader(bytes.NewReader(prefix), reader)
+		n, err := reader.Read(prefix)
+		reader = io.MultiReader(bytes.NewReader(prefix[:n]), reader)
 
 		if err == nil && string(prefix) == gSixelBegin {
 			b, err := io.ReadAll(reader)


### PR DESCRIPTION
Fixes a bug where empty files are mislabeled as 'binary' in preview due to extraneous bytes being passed to the scanner

How to reproduce bug:

1. select an empty file for preview
2. preview shows up as "binary"