### PR TITLE
Allow lastdir/selection to be written to `stdout`

### DIFF
--- a/app.go
+++ b/app.go
@@ -593,7 +593,7 @@ func (app *app) runPagerOn(stdin io.Reader) {
 	cmd := shellCommand(envPager, nil)
 
 	cmd.Stdin = stdin
-	cmd.Stdout = os.Stdout
+	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 
 	app.runCmdSync(cmd, false)

--- a/app.go
+++ b/app.go
@@ -33,6 +33,7 @@ type app struct {
 	menuCompActive bool
 	menuComps      []string
 	menuCompInd    int
+	selectionOut   []string
 }
 
 func newApp(ui *ui, nav *nav) *app {
@@ -328,19 +329,6 @@ func (app *app) loop() {
 
 			log.Print("bye!")
 
-			if gLastDirPath != "" {
-				f, err := os.Create(gLastDirPath)
-				if err != nil {
-					log.Printf("opening last dir file: %s", err)
-				}
-				defer f.Close()
-
-				_, err = f.WriteString(app.nav.currDir().path)
-				if err != nil {
-					log.Printf("writing last dir file: %s", err)
-				}
-			}
-
 			return
 		case n := <-app.nav.copyBytesChan:
 			app.nav.copyBytes += n
@@ -519,7 +507,7 @@ func (app *app) runShell(s string, args []string, prefix string) {
 	switch prefix {
 	case "$", "!":
 		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
+		cmd.Stdout = os.Stderr
 		cmd.Stderr = os.Stderr
 
 		app.runCmdSync(cmd, prefix == "!")

--- a/client.go
+++ b/client.go
@@ -61,6 +61,42 @@ func run() {
 	app.loop()
 
 	app.ui.screen.Fini()
+
+	if gLastDirPath != "" {
+		writeLastDir(gLastDirPath, app.nav.currDir().path)
+	}
+
+	if gSelectionPath != "" && len(app.selectionOut) > 0 {
+		writeSelection(gSelectionPath, app.selectionOut)
+	}
+}
+
+func writeLastDir(filename string, lastDir string) {
+	f, err := os.Create(filename)
+	if err != nil {
+		log.Printf("opening last dir file: %s", err)
+		return
+	}
+	defer f.Close()
+
+	_, err = f.WriteString(lastDir)
+	if err != nil {
+		log.Printf("writing last dir file: %s", err)
+	}
+}
+
+func writeSelection(filename string, selection []string) {
+	f, err := os.Create(filename)
+	if err != nil {
+		log.Printf("opening selection file: %s", err)
+		return
+	}
+	defer f.Close()
+
+	_, err = f.WriteString(strings.Join(selection, "\n"))
+	if err != nil {
+		log.Printf("writing selection file: %s", err)
+	}
 }
 
 func readExpr() <-chan expr {

--- a/eval.go
+++ b/eval.go
@@ -1447,27 +1447,8 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 
 		if gSelectionPath != "" {
-			out, err := os.Create(gSelectionPath)
-			if err != nil {
-				log.Printf("opening selection file: %s", err)
-				return
-			}
-			defer out.Close()
-
-			var path string
-			if list, err := app.nav.currFileOrSelections(); err == nil {
-				path = strings.Join(list, "\n")
-			} else {
-				return
-			}
-
-			_, err = out.WriteString(path)
-			if err != nil {
-				log.Printf("writing selection file: %s", err)
-			}
-
+			app.selectionOut, _ = app.nav.currFileOrSelections()
 			app.quitChan <- struct{}{}
-
 			return
 		}
 

--- a/ui.go
+++ b/ui.go
@@ -1446,8 +1446,8 @@ func (ui *ui) exportSizes() {
 }
 
 func anyKey() {
-	fmt.Print(gOpts.waitmsg)
-	defer fmt.Print("\n")
+	fmt.Fprint(os.Stderr, gOpts.waitmsg)
+	defer fmt.Fprint(os.Stderr, "\n")
 	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
- Fixes #1393 

In order for `lf` to successfully write information to `/dev/stdout` when using the `-last-dir-path`/`-selection-path` options, the following changes needs to be made:

- Writing the information needs to happen after the `tcell` screen is cleaned up, as pointed out in https://github.com/gokcehan/lf/issues/472#issuecomment-694864802.
- The output of shell commands needs to be connected to `stderr` instead of `stdout` so as not to conflict with the actual information being written. It might be possible in future to change the output of shell commands with a setting, but I think hardcoding it to `stderr` should suffice for now.

This change makes scripting with `lf` much easier, as there is no longer any need to create a temporary file to store the information and read it afterwards. For example the `lfcd` command can be changed from this:

```shell
lfcd () {
    tmp="$(mktemp)"
    # `command` is needed in case `lfcd` is aliased to `lf`
    command lf -last-dir-path="$tmp" "$@"
    if [ -f "$tmp" ]; then
        dir="$(cat "$tmp")"
        rm -f "$tmp"
        if [ -d "$dir" ]; then
            if [ "$dir" != "$(pwd)" ]; then
                cd "$dir"
            fi
        fi
    fi
}
```

To this:

```shell
lfcd() {
    # `command` is needed in case `lfcd` is aliased to `lf`
    cd "$(command lf -last-dir-path /dev/stdout "$@")"
}
```