### PR TITLE
Display `statfmt` file size with fixed width

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -168,7 +168,7 @@ The following options can be used to customize the behavior of lf:
 	smartcase        bool      (default true)
 	smartdia         bool      (default false)
 	sortby           string    (default 'natural')
-	statfmt          string    (default "\033[36m%p\033[0m| %c| %u| %g| %s| %t| -> %l")
+	statfmt          string    (default "\033[36m%p\033[0m| %c| %u| %g| %S| %t| -> %l")
 	tabstop          int       (default 8)
 	tagfmt           string    (default "\033[31m")
 	tempmarks        string    (default '')
@@ -930,10 +930,10 @@ This option has no effect when 'ignoredia' is disabled.
 Sort type for directories.
 Currently supported sort types are 'natural', 'name', 'size', 'time', 'ctime', 'atime', and 'ext'.
 
-	statfmt    string        (default "\033[36m%p\033[0m| %c| %u| %g| %s| %t| -> %l")
+	statfmt    string        (default "\033[36m%p\033[0m| %c| %u| %g| %S| %t| -> %l")
 
 Format string of the file info shown in the bottom left corner.
-Special expansions are provided, '%p' as the file permissions, '%c' as the link count, '%u' as the user, '%g' as the group, '%s' as the file size, '%t' as the last modified time, and '%l' as the link target.
+Special expansions are provided, '%p' as the file permissions, '%c' as the link count, '%u' as the user, '%g' as the group, '%s' as the file size, '%S' as the file size but with a fixed width of four characters (left-padded with spaces), '%t' as the last modified time, and '%l' as the link target.
 The `|` character splits the format string into sections. Any section containing a failed expansion (result is a blank string) is discarded and not shown.
 
 	tabstop        int       (default 8)

--- a/docstring.go
+++ b/docstring.go
@@ -171,7 +171,7 @@ The following options can be used to customize the behavior of lf:
     smartcase        bool      (default true)
     smartdia         bool      (default false)
     sortby           string    (default 'natural')
-    statfmt          string    (default "\033[36m%p\033[0m| %c| %u| %g| %s| %t| -> %l")
+    statfmt          string    (default "\033[36m%p\033[0m| %c| %u| %g| %S| %t| -> %l")
     tabstop          int       (default 8)
     tagfmt           string    (default "\033[31m")
     tempmarks        string    (default '')
@@ -999,14 +999,15 @@ diacritic. This option has no effect when 'ignoredia' is disabled.
 Sort type for directories. Currently supported sort types are 'natural', 'name',
 'size', 'time', 'ctime', 'atime', and 'ext'.
 
-    statfmt    string        (default "\033[36m%p\033[0m| %c| %u| %g| %s| %t| -> %l")
+    statfmt    string        (default "\033[36m%p\033[0m| %c| %u| %g| %S| %t| -> %l")
 
 Format string of the file info shown in the bottom left corner. Special
 expansions are provided, '%p' as the file permissions, '%c' as the link count,
-'%u' as the user, '%g' as the group, '%s' as the file size, '%t' as the last
-modified time, and '%l' as the link target. The '|' character splits the format
-string into sections. Any section containing a failed expansion (result is a
-blank string) is discarded and not shown.
+'%u' as the user, '%g' as the group, '%s' as the file size, '%S' as the file
+size but with a fixed width of four characters (left-padded with spaces), '%t'
+as the last modified time, and '%l' as the link target. The '|' character splits
+the format string into sections. Any section containing a failed expansion
+(result is a blank string) is discarded and not shown.
 
     tabstop        int       (default 8)
 

--- a/lf.1
+++ b/lf.1
@@ -187,7 +187,7 @@ The following options can be used to customize the behavior of lf:
     smartcase        bool      (default true)
     smartdia         bool      (default false)
     sortby           string    (default 'natural')
-    statfmt          string    (default "\e033[36m%p\e033[0m| %c| %u| %g| %s| %t| -> %l")
+    statfmt          string    (default "\e033[36m%p\e033[0m| %c| %u| %g| %S| %t| -> %l")
     tabstop          int       (default 8)
     tagfmt           string    (default "\e033[31m")
     tempmarks        string    (default '')
@@ -1109,10 +1109,10 @@ Override 'ignoredia' option when the pattern contains a character with diacritic
 Sort type for directories. Currently supported sort types are 'natural', 'name', 'size', 'time', 'ctime', 'atime', and 'ext'.
 .PP
 .EX
-    statfmt    string        (default "\e033[36m%p\e033[0m| %c| %u| %g| %s| %t| -> %l")
+    statfmt    string        (default "\e033[36m%p\e033[0m| %c| %u| %g| %S| %t| -> %l")
 .EE
 .PP
-Format string of the file info shown in the bottom left corner. Special expansions are provided, '%p' as the file permissions, '%c' as the link count, '%u' as the user, '%g' as the group, '%s' as the file size, '%t' as the last modified time, and '%l' as the link target. The `|` character splits the format string into sections. Any section containing a failed expansion (result is a blank string) is discarded and not shown.
+Format string of the file info shown in the bottom left corner. Special expansions are provided, '%p' as the file permissions, '%c' as the link count, '%u' as the user, '%g' as the group, '%s' as the file size, '%S' as the file size but with a fixed width of four characters (left-padded with spaces), '%t' as the last modified time, and '%l' as the link target. The `|` character splits the format string into sections. Any section containing a failed expansion (result is a blank string) is discarded and not shown.
 .PP
 .EX
     tabstop        int       (default 8)

--- a/opts.go
+++ b/opts.go
@@ -134,7 +134,7 @@ func init() {
 	gOpts.selmode = "all"
 	gOpts.shell = gDefaultShell
 	gOpts.shellflag = gDefaultShellFlag
-	gOpts.statfmt = "\033[36m%p\033[0m| %c| %u| %g| %s| %t| -> %l"
+	gOpts.statfmt = "\033[36m%p\033[0m| %c| %u| %g| %S| %t| -> %l"
 	gOpts.timefmt = time.ANSIC
 	gOpts.infotimefmtnew = "Jan _2 15:04"
 	gOpts.infotimefmtold = "Jan _2  2006"

--- a/ui.go
+++ b/ui.go
@@ -743,6 +743,7 @@ func (ui *ui) loadFileInfo(nav *nav) {
 	replace("%u", userName(curr))
 	replace("%g", groupName(curr))
 	replace("%s", humanize(curr.Size()))
+	replace("%S", fmt.Sprintf("%4s", humanize(curr.Size())))
 	replace("%t", curr.ModTime().Format(gOpts.timefmt))
 	replace("%l", curr.linkTarget)
 


### PR DESCRIPTION
From https://github.com/gokcehan/lf/pull/1288#issuecomment-1699796118

Add a new `statfmt` placeholder `%S`, which displays the file size but with a fixed with of four characters.