### PR TITLE
Add `cmd-delete-word-back` command

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -100,6 +100,7 @@ var (
 		"cmd-delete-home",
 		"cmd-delete-end",
 		"cmd-delete-unix-word",
+		"cmd-delete-word-back",
 		"cmd-yank",
 		"cmd-transpose",
 		"cmd-transpose-word",

--- a/doc.go
+++ b/doc.go
@@ -105,6 +105,7 @@ The following command line commands are provided by lf:
 	cmd-delete-home          (default '<c-u>')
 	cmd-delete-end           (default '<c-k>')
 	cmd-delete-unix-word     (default '<c-w>')
+	cmd-delete-word-back     
 	cmd-yank                 (default '<c-y>')
 	cmd-transpose            (default '<c-t>')
 	cmd-transpose-word       (default '<a-t>')
@@ -630,6 +631,10 @@ Move the cursor by one word in forward/backward direction.
 	cmd-delete-word          (default '<a-d>')
 
 Delete the next word in forward direction.
+
+	cmd-delete-word-back
+
+Delete the previous word in backward direction.
 
 	cmd-capitalize-word      (default '<a-c>')
 	cmd-uppercase-word       (default '<a-u>')

--- a/doc.go
+++ b/doc.go
@@ -111,7 +111,7 @@ The following command line commands are provided by lf:
 	cmd-word                 (default '<a-f>')
 	cmd-word-back            (default '<a-b>')
 	cmd-delete-word          (default '<a-d>')
-	cmd-delete-word-back     (default '<a-backspace> and <a-backspace2>')
+	cmd-delete-word-back     (default '<a-backspace>' and '<a-backspace2>')
 	cmd-capitalize-word      (default '<a-c>')
 	cmd-uppercase-word       (default '<a-u>')
 	cmd-lowercase-word       (default '<a-l>')

--- a/doc.go
+++ b/doc.go
@@ -105,7 +105,7 @@ The following command line commands are provided by lf:
 	cmd-delete-home          (default '<c-u>')
 	cmd-delete-end           (default '<c-k>')
 	cmd-delete-unix-word     (default '<c-w>')
-	cmd-delete-word-back     
+	cmd-delete-word-back     (default '<a-backspace> and <a-backspace2>')
 	cmd-yank                 (default '<c-y>')
 	cmd-transpose            (default '<c-t>')
 	cmd-transpose-word       (default '<a-t>')

--- a/doc.go
+++ b/doc.go
@@ -105,13 +105,13 @@ The following command line commands are provided by lf:
 	cmd-delete-home          (default '<c-u>')
 	cmd-delete-end           (default '<c-k>')
 	cmd-delete-unix-word     (default '<c-w>')
-	cmd-delete-word-back     (default '<a-backspace> and <a-backspace2>')
 	cmd-yank                 (default '<c-y>')
 	cmd-transpose            (default '<c-t>')
 	cmd-transpose-word       (default '<a-t>')
 	cmd-word                 (default '<a-f>')
 	cmd-word-back            (default '<a-b>')
 	cmd-delete-word          (default '<a-d>')
+	cmd-delete-word-back     (default '<a-backspace> and <a-backspace2>')
 	cmd-capitalize-word      (default '<a-c>')
 	cmd-uppercase-word       (default '<a-u>')
 	cmd-lowercase-word       (default '<a-l>')
@@ -633,7 +633,7 @@ Move the cursor by one word in forward/backward direction.
 
 Delete the next word in forward direction.
 
-	cmd-delete-word-back
+	cmd-delete-word-back     (default '<a-backspace>' and '<a-backspace2>')
 
 Delete the previous word in backward direction.
 

--- a/docstring.go
+++ b/docstring.go
@@ -114,7 +114,7 @@ The following command line commands are provided by lf:
     cmd-word                 (default '<a-f>')
     cmd-word-back            (default '<a-b>')
     cmd-delete-word          (default '<a-d>')
-    cmd-delete-word-back     (default '<a-backspace> and <a-backspace2>')
+    cmd-delete-word-back     (default '<a-backspace>' and '<a-backspace2>')
     cmd-capitalize-word      (default '<a-c>')
     cmd-uppercase-word       (default '<a-u>')
     cmd-lowercase-word       (default '<a-l>')

--- a/docstring.go
+++ b/docstring.go
@@ -108,13 +108,13 @@ The following command line commands are provided by lf:
     cmd-delete-home          (default '<c-u>')
     cmd-delete-end           (default '<c-k>')
     cmd-delete-unix-word     (default '<c-w>')
-    cmd-delete-word-back     (default '<a-backspace> and <a-backspace2>')
     cmd-yank                 (default '<c-y>')
     cmd-transpose            (default '<c-t>')
     cmd-transpose-word       (default '<a-t>')
     cmd-word                 (default '<a-f>')
     cmd-word-back            (default '<a-b>')
     cmd-delete-word          (default '<a-d>')
+    cmd-delete-word-back     (default '<a-backspace> and <a-backspace2>')
     cmd-capitalize-word      (default '<a-c>')
     cmd-uppercase-word       (default '<a-u>')
     cmd-lowercase-word       (default '<a-l>')
@@ -662,7 +662,7 @@ Move the cursor by one word in forward/backward direction.
 
 Delete the next word in forward direction.
 
-    cmd-delete-word-back
+    cmd-delete-word-back     (default '<a-backspace>' and '<a-backspace2>')
 
 Delete the previous word in backward direction.
 

--- a/docstring.go
+++ b/docstring.go
@@ -108,6 +108,7 @@ The following command line commands are provided by lf:
     cmd-delete-home          (default '<c-u>')
     cmd-delete-end           (default '<c-k>')
     cmd-delete-unix-word     (default '<c-w>')
+    cmd-delete-word-back     (default '<a-backspace> and <a-backspace2>')
     cmd-yank                 (default '<c-y>')
     cmd-transpose            (default '<c-t>')
     cmd-transpose-word       (default '<a-t>')
@@ -659,6 +660,10 @@ Move the cursor by one word in forward/backward direction.
     cmd-delete-word          (default '<a-d>')
 
 Delete the next word in forward direction.
+
+    cmd-delete-word-back
+
+Delete the previous word in backward direction.
 
     cmd-capitalize-word      (default '<a-c>')
     cmd-uppercase-word       (default '<a-u>')

--- a/eval.go
+++ b/eval.go
@@ -247,27 +247,6 @@ func (e *setExpr) eval(app *app, args []string) {
 			return
 		}
 		gOpts.findlen = n
-	case "unixwords":
-		if e.val == "" || e.val == "true" {
-			gOpts.unixwords = true
-			// TODO: Move line to somewhere else
-			gOpts.cmdkeys["<c-w>"] = &callExpr{"cmd-delete-unix-word", nil, 1}
-		} else if e.val == "false" {
-			gOpts.unixwords = false
-			// TODO: Move line to somewhere else
-			gOpts.cmdkeys["<c-w>"] = &callExpr{"cmd-delete-word-back", nil, 1}
-		} else {
-			app.ui.echoerr("unixwords: value should be empty, 'true', or 'false'")
-			return
-		}
-	case "nounixwords":
-		if e.val != "" {
-			app.ui.echoerrf("nounixwords: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.unixwords = false
-		// TODO: Move line to somewhere else
-		gOpts.cmdkeys["<c-w>"] = &callExpr{"cmd-delete-word-back", nil, 1}
 	case "globsearch":
 		if e.val == "" || e.val == "true" {
 			gOpts.globsearch = true

--- a/eval.go
+++ b/eval.go
@@ -247,6 +247,27 @@ func (e *setExpr) eval(app *app, args []string) {
 			return
 		}
 		gOpts.findlen = n
+	case "unixwords":
+		if e.val == "" || e.val == "true" {
+			gOpts.unixwords = true
+			// TODO: Move line to somewhere else
+			gOpts.cmdkeys["<c-w>"] = &callExpr{"cmd-delete-unix-word", nil, 1}
+		} else if e.val == "false" {
+			gOpts.unixwords = false
+			// TODO: Move line to somewhere else
+			gOpts.cmdkeys["<c-w>"] = &callExpr{"cmd-delete-word-back", nil, 1}
+		} else {
+			app.ui.echoerr("unixwords: value should be empty, 'true', or 'false'")
+			return
+		}
+	case "nounixwords":
+		if e.val != "" {
+			app.ui.echoerrf("nounixwords: unexpected value: %s", e.val)
+			return
+		}
+		gOpts.unixwords = false
+		// TODO: Move line to somewhere else
+		gOpts.cmdkeys["<c-w>"] = &callExpr{"cmd-delete-word-back", nil, 1}
 	case "globsearch":
 		if e.val == "" || e.val == "true" {
 			gOpts.globsearch = true

--- a/eval.go
+++ b/eval.go
@@ -2583,18 +2583,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.ui.cmdYankBuf = app.ui.cmdAccRight
 		app.ui.cmdAccRight = nil
 		update(app)
-	case "cmd-delete-word-back":
-		if len(app.ui.cmdAccLeft) == 0 {
-			return
-		}
-		locs := reWordBeg.FindAllStringSubmatchIndex(string(app.ui.cmdAccLeft), -1)
-		if locs == nil {
-			return
-		}
-		ind := locs[len(locs)-1][3]
-		app.ui.cmdYankBuf = []rune(string(app.ui.cmdAccLeft)[ind:]) // Store the word after the cursor
-		app.ui.cmdAccLeft = app.ui.cmdAccLeft[:ind] // Remove the word before the cursor
-		update(app)
 	case "cmd-delete-unix-word":
 		ind := strings.LastIndex(strings.TrimRight(string(app.ui.cmdAccLeft), " "), " ") + 1
 		app.ui.cmdYankBuf = []rune(string(app.ui.cmdAccLeft)[ind:])
@@ -2672,6 +2660,17 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 		ind := loc[3]
 		app.ui.cmdAccRight = []rune(string(app.ui.cmdAccRight)[ind:])
+		update(app)
+	case "cmd-delete-word-back":
+		if len(app.ui.cmdAccLeft) == 0 {
+			return
+		}
+		locs := reWordBeg.FindAllStringSubmatchIndex(string(app.ui.cmdAccLeft), -1)
+		if locs == nil {
+			return
+		}
+		ind := locs[len(locs)-1][3]
+		app.ui.cmdAccLeft = app.ui.cmdAccLeft[:ind]
 		update(app)
 	case "cmd-uppercase-word":
 		if len(app.ui.cmdAccRight) == 0 {

--- a/eval.go
+++ b/eval.go
@@ -2404,6 +2404,18 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.ui.cmdYankBuf = app.ui.cmdAccRight
 		app.ui.cmdAccRight = nil
 		update(app)
+	case "cmd-delete-word-back":
+		if len(app.ui.cmdAccLeft) == 0 {
+			return
+		}
+		locs := reWordBeg.FindAllStringSubmatchIndex(string(app.ui.cmdAccLeft), -1)
+		if locs == nil {
+			return
+		}
+		ind := locs[len(locs)-1][3]
+		app.ui.cmdYankBuf = []rune(string(app.ui.cmdAccLeft)[ind:]) // Store the word after the cursor
+		app.ui.cmdAccLeft = app.ui.cmdAccLeft[:ind] // Remove the word before the cursor
+		update(app)
 	case "cmd-delete-unix-word":
 		ind := strings.LastIndex(strings.TrimRight(string(app.ui.cmdAccLeft), " "), " ") + 1
 		app.ui.cmdYankBuf = []rune(string(app.ui.cmdAccLeft)[ind:])

--- a/lf.1
+++ b/lf.1
@@ -122,13 +122,13 @@ The following command line commands are provided by lf:
     cmd-delete-home          (default '<c-u>')
     cmd-delete-end           (default '<c-k>')
     cmd-delete-unix-word     (default '<c-w>')
-    cmd-delete-word-back     (default '<a-backspace> and <a-backspace2>')
     cmd-yank                 (default '<c-y>')
     cmd-transpose            (default '<c-t>')
     cmd-transpose-word       (default '<a-t>')
     cmd-word                 (default '<a-f>')
     cmd-word-back            (default '<a-b>')
     cmd-delete-word          (default '<a-d>')
+    cmd-delete-word-back     (default '<a-backspace> and <a-backspace2>')
     cmd-capitalize-word      (default '<a-c>')
     cmd-uppercase-word       (default '<a-u>')
     cmd-lowercase-word       (default '<a-l>')
@@ -778,7 +778,7 @@ Move the cursor by one word in forward/backward direction.
 Delete the next word in forward direction.
 .PP
 .EX
-    cmd-delete-word-back
+    cmd-delete-word-back     (default '<a-backspace>' and '<a-backspace2>')
 .EE
 .PP
 Delete the previous word in backward direction.

--- a/lf.1
+++ b/lf.1
@@ -122,6 +122,7 @@ The following command line commands are provided by lf:
     cmd-delete-home          (default '<c-u>')
     cmd-delete-end           (default '<c-k>')
     cmd-delete-unix-word     (default '<c-w>')
+    cmd-delete-word-back     (default '<a-backspace> and <a-backspace2>')
     cmd-yank                 (default '<c-y>')
     cmd-transpose            (default '<c-t>')
     cmd-transpose-word       (default '<a-t>')
@@ -774,6 +775,12 @@ Move the cursor by one word in forward/backward direction.
 .EE
 .PP
 Delete the next word in forward direction.
+.PP
+.EX
+    cmd-delete-word-back
+.EE
+.PP
+Delete the previous word in backward direction.
 .PP
 .EX
     cmd-capitalize-word      (default '<a-c>')

--- a/lf.1
+++ b/lf.1
@@ -128,7 +128,7 @@ The following command line commands are provided by lf:
     cmd-word                 (default '<a-f>')
     cmd-word-back            (default '<a-b>')
     cmd-delete-word          (default '<a-d>')
-    cmd-delete-word-back     (default '<a-backspace> and <a-backspace2>')
+    cmd-delete-word-back     (default '<a-backspace>' and '<a-backspace2>')
     cmd-capitalize-word      (default '<a-c>')
     cmd-uppercase-word       (default '<a-u>')
     cmd-lowercase-word       (default '<a-l>')

--- a/opts.go
+++ b/opts.go
@@ -44,7 +44,6 @@ var gOpts struct {
 	drawbox          bool
 	dupfilefmt       string
 	globsearch       bool
-	unixwords        bool
 	icons            bool
 	ignorecase       bool
 	ignoredia        bool
@@ -195,7 +194,6 @@ func init() {
 	gOpts.cursorparentfmt = "\033[7m"
 	gOpts.cursorpreviewfmt = "\033[4m"
 	gOpts.globsearch = false
-	gOpts.unixwords = true
 	gOpts.icons = false
 	gOpts.ignorecase = true
 	gOpts.ignoredia = true

--- a/opts.go
+++ b/opts.go
@@ -41,6 +41,7 @@ var gOpts struct {
 	drawbox          bool
 	dupfilefmt       string
 	globsearch       bool
+	unixwords        bool
 	icons            bool
 	ignorecase       bool
 	ignoredia        bool
@@ -106,6 +107,7 @@ func init() {
 	gOpts.cursorparentfmt = "\033[7m"
 	gOpts.cursorpreviewfmt = "\033[4m"
 	gOpts.globsearch = false
+	gOpts.unixwords = true
 	gOpts.icons = false
 	gOpts.ignorecase = true
 	gOpts.ignoredia = true
@@ -253,8 +255,7 @@ func init() {
 	gOpts.cmdkeys["<c-e>"] = &callExpr{"cmd-end", nil, 1}
 	gOpts.cmdkeys["<c-u>"] = &callExpr{"cmd-delete-home", nil, 1}
 	gOpts.cmdkeys["<c-k>"] = &callExpr{"cmd-delete-end", nil, 1}
-	gOpts.cmdkeys["<c-w>"] = &callExpr{"cmd-delete-word-back", nil, 1}
-	// gOpts.cmdkeys["<c-w>"] = &callExpr{"cmd-delete-unix-word", nil, 1}
+	gOpts.cmdkeys["<c-w>"] = &callExpr{"cmd-delete-unix-word", nil, 1}
 	gOpts.cmdkeys["<c-y>"] = &callExpr{"cmd-yank", nil, 1}
 	gOpts.cmdkeys["<c-t>"] = &callExpr{"cmd-transpose", nil, 1}
 	gOpts.cmdkeys["<c-c>"] = &callExpr{"cmd-interrupt", nil, 1}

--- a/opts.go
+++ b/opts.go
@@ -253,7 +253,8 @@ func init() {
 	gOpts.cmdkeys["<c-e>"] = &callExpr{"cmd-end", nil, 1}
 	gOpts.cmdkeys["<c-u>"] = &callExpr{"cmd-delete-home", nil, 1}
 	gOpts.cmdkeys["<c-k>"] = &callExpr{"cmd-delete-end", nil, 1}
-	gOpts.cmdkeys["<c-w>"] = &callExpr{"cmd-delete-unix-word", nil, 1}
+	gOpts.cmdkeys["<c-w>"] = &callExpr{"cmd-delete-word-back", nil, 1}
+	// gOpts.cmdkeys["<c-w>"] = &callExpr{"cmd-delete-unix-word", nil, 1}
 	gOpts.cmdkeys["<c-y>"] = &callExpr{"cmd-yank", nil, 1}
 	gOpts.cmdkeys["<c-t>"] = &callExpr{"cmd-transpose", nil, 1}
 	gOpts.cmdkeys["<c-c>"] = &callExpr{"cmd-interrupt", nil, 1}

--- a/opts.go
+++ b/opts.go
@@ -351,11 +351,11 @@ func init() {
 	gOpts.cmdkeys["<a-b>"] = &callExpr{"cmd-word-back", nil, 1}
 	gOpts.cmdkeys["<a-c>"] = &callExpr{"cmd-capitalize-word", nil, 1}
 	gOpts.cmdkeys["<a-d>"] = &callExpr{"cmd-delete-word", nil, 1}
+	gOpts.cmdkeys["<a-backspace>"] = &callExpr{"cmd-delete-word-back", nil, 1}
+	gOpts.cmdkeys["<a-backspace2>"] = &callExpr{"cmd-delete-word-back", nil, 1}
 	gOpts.cmdkeys["<a-u>"] = &callExpr{"cmd-uppercase-word", nil, 1}
 	gOpts.cmdkeys["<a-l>"] = &callExpr{"cmd-lowercase-word", nil, 1}
 	gOpts.cmdkeys["<a-t>"] = &callExpr{"cmd-transpose-word", nil, 1}
-	gOpts.cmdkeys["<a-backspace>"] = &callExpr{"cmd-delete-word-back", nil, 1}
-	gOpts.cmdkeys["<a-backspace2>"] = &callExpr{"cmd-delete-word-back", nil, 1}
 
 	gOpts.cmds = make(map[string]expr)
 	gOpts.user = make(map[string]string)

--- a/opts.go
+++ b/opts.go
@@ -352,6 +352,8 @@ func init() {
 	gOpts.cmdkeys["<a-u>"] = &callExpr{"cmd-uppercase-word", nil, 1}
 	gOpts.cmdkeys["<a-l>"] = &callExpr{"cmd-lowercase-word", nil, 1}
 	gOpts.cmdkeys["<a-t>"] = &callExpr{"cmd-transpose-word", nil, 1}
+	gOpts.cmdkeys["<a-backspace>"] = &callExpr{"cmd-delete-word-back", nil, 1}
+	gOpts.cmdkeys["<a-backspace2>"] = &callExpr{"cmd-delete-word-back", nil, 1}
 
 	gOpts.cmds = make(map[string]expr)
 	gOpts.user = make(map[string]string)


### PR DESCRIPTION
Related issues:
-  #281 
- #1406

A new command `cmd-delete-word-back` is added. 
~~A new configuration option `unixwords` is added.~~
Docs about this command added.

This is my first pull request and I am inexperienced in `go`. So any feedback or suggestions are welcome.