### PR TITLE
Export user-options on change

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -920,6 +920,7 @@ func (e *setExpr) eval(app *app, args []string) {
 		// any key with the prefix user_ is accepted as a user defined option
 		if strings.HasPrefix(e.opt, "user_") {
 			gOpts.user[e.opt[5:]] = e.val
+			os.Setenv("lf_"+e.opt, e.val)
 		} else {
 			app.ui.echoerrf("unknown option: %s", e.opt)
 		}

--- a/eval.go
+++ b/eval.go
@@ -920,6 +920,9 @@ func (e *setExpr) eval(app *app, args []string) {
 		// any key with the prefix user_ is accepted as a user defined option
 		if strings.HasPrefix(e.opt, "user_") {
 			gOpts.user[e.opt[5:]] = e.val
+			// Export user defined options immediately, so that the current values
+			// are available for some external previewer, which is started in a
+			// different thread and thus cannot export (as `setenv` is not thread-safe).
 			os.Setenv("lf_"+e.opt, e.val)
 		} else {
 			app.ui.echoerrf("unknown option: %s", e.opt)


### PR DESCRIPTION
If one has an external previewer that uses an lf user-option (e.g. "preview-mode") and some key-kindings that change this user-option (e.g. to "hex", "simple", "fancy") and send a "reload" command to lf, then the expectation after pressing the keys is, that the prewiever is called with an updated value of the user-option. Though this did not happen before this change.