### PR TITLE
Fix sixel filler character

### DIFF
--- a/sixel.go
+++ b/sixel.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	gSixelBegin  = "\033P"
-	gSixelFiller = '\u2800'
+	gSixelFiller = '\u2000'
 )
 
 type sixelScreen struct {


### PR DESCRIPTION
The sixel implementation uses the Braille pattern blank character (U+2800) as a filler character, which is problematic because U+2800 is not a proper Unicode whitespace character. This fix changes the filler character to a proper Unicode whitespace character U+2000.

Quote from https://en.wikipedia.org/wiki/Whitespace_character:
> The Braille Patterns Unicode block contains U+2800 BRAILLE PATTERN BLANK, a Braille pattern with no dots raised. Some fonts display the character as a fixed-width blank, however the Unicode standard explicitly states that it does not act as a space.

Before the fix:
![lf-before](https://github.com/gokcehan/lf/assets/106755522/850e202d-c803-4da3-b9f7-b404fdf59a49)

After the fix:
![lf-after](https://github.com/gokcehan/lf/assets/106755522/a9020d62-8fc7-474b-a4a4-6e79dfd03dff)