### PR TITLE
Add spaces to `rulerfmt` to separate from statinfo

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -156,7 +156,7 @@ The following options can be used to customize the behavior of lf:
 	relativenumber   bool      (default false)
 	reverse          bool      (default false)
 	ruler            []string  (default 'acc:progress:selection:filter:ind')
-	rulerfmt         string    (default "%a  |%p  |\033[7;31m %m \033[0m  |\033[7;33m %c \033[0m  |\033[7;35m %s \033[0m  |\033[7;34m %f \033[0m  |%i/%t")
+	rulerfmt         string    (default "  %a|  %p|  \033[7;31m %m \033[0m|  \033[7;33m %c \033[0m|  \033[7;35m %s \033[0m|  \033[7;34m %f \033[0m|  %i/%t")
 	scrolloff        int       (default 0)
 	selmode          string    (default 'all')
 	shell            string    (default 'sh' for Unix and 'cmd' for Windows)
@@ -888,7 +888,7 @@ Currently supported information types are 'acc', 'progress', 'selection', 'filte
 Names starting with `lf_` show the value of environment variables exported by lf. This is useful for displaying the current settings (e.g. `lf_selmode` displays the current setting for the `selmode` option).
 User defined options starting with `lf_user_` are also supported, so it is possible to display information set from external sources.
 
-	rulerfmt       string    (default "%a  |%p  |\033[7;31m %m \033[0m  |\033[7;33m %c \033[0m  |\033[7;35m %s \033[0m  |\033[7;34m %f \033[0m  |%i/%t")
+	rulerfmt       string    (default "  %a|  %p|  \033[7;31m %m \033[0m|  \033[7;33m %c \033[0m|  \033[7;35m %s \033[0m|  \033[7;34m %f \033[0m|  %i/%t")
 
 Format string of the ruler shown in the bottom right corner.
 Special expansions are provided, '%a' as the pressed keys, '%p' as the progress of file operations, '%m' as the number of files to be cut (moved), '%c' as the number of files to be copied, '%s' as the number of selected files, '%f' as the filter, '%i' as the position of the cursor, '%t' as the number of files shown in the current directory, '%h' as the number of files hidden in the current directory, and '%d' as the amount of free disk space remaining.

--- a/docstring.go
+++ b/docstring.go
@@ -159,7 +159,7 @@ The following options can be used to customize the behavior of lf:
     relativenumber   bool      (default false)
     reverse          bool      (default false)
     ruler            []string  (default 'acc:progress:selection:filter:ind')
-    rulerfmt         string    (default "%a  |%p  |\033[7;31m %m \033[0m  |\033[7;33m %c \033[0m  |\033[7;35m %s \033[0m  |\033[7;34m %f \033[0m  |%i/%t")
+    rulerfmt         string    (default "  %a|  %p|  \033[7;31m %m \033[0m|  \033[7;33m %c \033[0m|  \033[7;35m %s \033[0m|  \033[7;34m %f \033[0m|  %i/%t")
     scrolloff        int       (default 0)
     selmode          string    (default 'all')
     shell            string    (default 'sh' for Unix and 'cmd' for Windows)
@@ -953,7 +953,7 @@ for the 'selmode' option). User defined options starting with 'lf_user_' are
 also supported, so it is possible to display information set from external
 sources.
 
-    rulerfmt       string    (default "%a  |%p  |\033[7;31m %m \033[0m  |\033[7;33m %c \033[0m  |\033[7;35m %s \033[0m  |\033[7;34m %f \033[0m  |%i/%t")
+    rulerfmt       string    (default "  %a|  %p|  \033[7;31m %m \033[0m|  \033[7;33m %c \033[0m|  \033[7;35m %s \033[0m|  \033[7;34m %f \033[0m|  %i/%t")
 
 Format string of the ruler shown in the bottom right corner. Special expansions
 are provided, '%a' as the pressed keys, '%p' as the progress of file operations,

--- a/lf.1
+++ b/lf.1
@@ -175,7 +175,7 @@ The following options can be used to customize the behavior of lf:
     relativenumber   bool      (default false)
     reverse          bool      (default false)
     ruler            []string  (default 'acc:progress:selection:filter:ind')
-    rulerfmt         string    (default "%a  |%p  |\e033[7;31m %m \e033[0m  |\e033[7;33m %c \e033[0m  |\e033[7;35m %s \e033[0m  |\e033[7;34m %f \e033[0m  |%i/%t")
+    rulerfmt         string    (default "  %a|  %p|  \e033[7;31m %m \e033[0m|  \e033[7;33m %c \e033[0m|  \e033[7;35m %s \e033[0m|  \e033[7;34m %f \e033[0m|  %i/%t")
     scrolloff        int       (default 0)
     selmode          string    (default 'all')
     shell            string    (default 'sh' for Unix and 'cmd' for Windows)
@@ -1056,7 +1056,7 @@ Reverse the direction of sort.
 This option is deprecated in favor of using the `rulerfmt` option (see below). List of information shown in status line ruler. Currently supported information types are 'acc', 'progress', 'selection', 'filter', 'ind', 'df' and names starting with 'lf_'. `acc` shows the pressed keys (e.g. for bindings with multiple key presses or counts given to bindings). `progress` shows the progress of file operations (e.g. copying a large directory). `selection` shows the number of files that are selected, or designated for being cut/copied. `filter` shows 'F' if a filter is currently being applied. `ind` shows the current position of the cursor as well as the number of files in the current directory. `df` shows the amount of free disk space remaining. Names starting with `lf_` show the value of environment variables exported by lf. This is useful for displaying the current settings (e.g. `lf_selmode` displays the current setting for the `selmode` option). User defined options starting with `lf_user_` are also supported, so it is possible to display information set from external sources.
 .PP
 .EX
-    rulerfmt       string    (default "%a  |%p  |\e033[7;31m %m \e033[0m  |\e033[7;33m %c \e033[0m  |\e033[7;35m %s \e033[0m  |\e033[7;34m %f \e033[0m  |%i/%t")
+    rulerfmt       string    (default "  %a|  %p|  \e033[7;31m %m \e033[0m|  \e033[7;33m %c \e033[0m|  \e033[7;35m %s \e033[0m|  \e033[7;34m %f \e033[0m|  %i/%t")
 .EE
 .PP
 Format string of the ruler shown in the bottom right corner. Special expansions are provided, '%a' as the pressed keys, '%p' as the progress of file operations, '%m' as the number of files to be cut (moved), '%c' as the number of files to be copied, '%s' as the number of selected files, '%f' as the filter, '%i' as the position of the cursor, '%t' as the number of files shown in the current directory, '%h' as the number of files hidden in the current directory, and '%d' as the amount of free disk space remaining. Additional expansions are provided for environment variables exported by lf, in the form `%{lf_<name>}` (e.g. `%{lf_selmode}`). This is useful for displaying the current settings. Expansions are also provided for user defined options, in the form `%{lf_user_<name>}` (e.g. `%{lf_user_foo}`). The `|` character splits the format string into sections. Any section containing a failed expansion (result is a blank string) is discarded and not shown.

--- a/opts.go
+++ b/opts.go
@@ -234,7 +234,7 @@ func init() {
 	gOpts.history = true
 	gOpts.info = nil
 	gOpts.ruler = nil
-	gOpts.rulerfmt = "%a  |%p  |\033[7;31m %m \033[0m  |\033[7;33m %c \033[0m  |\033[7;35m %s \033[0m  |\033[7;34m %f \033[0m  |%i/%t"
+	gOpts.rulerfmt = "  %a|  %p|  \033[7;31m %m \033[0m|  \033[7;33m %c \033[0m|  \033[7;35m %s \033[0m|  \033[7;34m %f \033[0m|  %i/%t"
 	gOpts.preserve = []string{"mode"}
 	gOpts.shellopts = nil
 	gOpts.sortType = sortType{naturalSort, dirfirstSort}


### PR DESCRIPTION
Add some padding spaces to the left of the default `rulerfmt` to visually separate it from from the stat info if they are too long and collide with each other.

Before:

![image](https://github.com/gokcehan/lf/assets/50560759/96c7f9d0-3145-4ed4-98ea-66336314779e)

After:

![image](https://github.com/gokcehan/lf/assets/50560759/2e2d7934-c188-4011-8573-d81d0e3573c0)
