### PR TITLE
feat: teach `drawbox` additional options

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -126,7 +126,7 @@ The following options can be used to customize the behavior of lf:
 	dirfirst         bool      (default true)
 	dironly          bool      (default false)
 	dirpreviews      bool      (default false)
-	drawbox          bool      (default false)
+	drawbox          string    (default "none")
 	dupfilefmt       string    (default '%f.~%n~')
 	errorfmt         string    (default "\033[7;31;47m")
 	filesep          string    (default "\n")
@@ -718,9 +718,9 @@ Show only directories.
 
 If enabled, directories will also be passed to the previewer script. This allows custom previews for directories.
 
-	drawbox        bool      (default false)
+	drawbox        string    (default "none")
 
-Draw boxes around panes with box drawing characters.
+Draw boxes around panes with box drawing characters. "outline" draws a box around all panes. "separators" draws vertical lines between all panes. "both" or "true" draws both outline and separators. "none" or "false" draws neither outline nor separators.
 
 	dupfilefmt        string      (default '%f.~%n~')
 

--- a/docstring.go
+++ b/docstring.go
@@ -129,7 +129,7 @@ The following options can be used to customize the behavior of lf:
     dirfirst         bool      (default true)
     dironly          bool      (default false)
     dirpreviews      bool      (default false)
-    drawbox          bool      (default false)
+    drawbox          string    (default "none")
     dupfilefmt       string    (default '%f.~%n~')
     errorfmt         string    (default "\033[7;31;47m")
     filesep          string    (default "\n")
@@ -759,9 +759,12 @@ Show only directories.
 If enabled, directories will also be passed to the previewer script. This allows
 custom previews for directories.
 
-    drawbox        bool      (default false)
+    drawbox        string    (default "none")
 
-Draw boxes around panes with box drawing characters.
+Draw boxes around panes with box drawing characters. "outline" draws a box
+around all panes. "separators" draws vertical lines between all panes. "both"
+or "true" draws both outline and separators. "none" or "false" draws neither
+outline nor separators.
 
     dupfilefmt        string      (default '%f.~%n~')
 

--- a/eval.go
+++ b/eval.go
@@ -192,12 +192,16 @@ func (e *setExpr) eval(app *app, args []string) {
 		}
 		gOpts.dirpreviews = !gOpts.dirpreviews
 	case "drawbox":
-		if e.val == "" || e.val == "true" {
-			gOpts.drawbox = true
-		} else if e.val == "false" {
-			gOpts.drawbox = false
+		if e.val == "" || e.val == "true" || e.val == "both" {
+			gOpts.drawbox = "both"
+		} else if e.val == "false" || e.val == "none" {
+			gOpts.drawbox = "none"
+		} else if e.val == "outline" {
+			gOpts.drawbox = "outline"
+		} else if e.val == "separators" {
+			gOpts.drawbox = "separators"
 		} else {
-			app.ui.echoerr("drawbox: value should be empty, 'true', or 'false'")
+			app.ui.echoerr("drawbox: value should be empty, 'true', 'false', 'both', 'none', 'outline', or 'separators'")
 			return
 		}
 		app.ui.renew()
@@ -211,7 +215,7 @@ func (e *setExpr) eval(app *app, args []string) {
 			app.ui.echoerrf("nodrawbox: unexpected value: %s", e.val)
 			return
 		}
-		gOpts.drawbox = false
+		gOpts.drawbox = "none"
 		app.ui.renew()
 		if app.nav.height != app.ui.wins[0].h {
 			app.nav.height = app.ui.wins[0].h
@@ -223,7 +227,11 @@ func (e *setExpr) eval(app *app, args []string) {
 			app.ui.echoerrf("drawbox!: unexpected value: %s", e.val)
 			return
 		}
-		gOpts.drawbox = !gOpts.drawbox
+		if gOpts.drawbox == "none" {
+			gOpts.drawbox = "both"
+		} else {
+			gOpts.drawbox = "none"
+		}
 		app.ui.renew()
 		if app.nav.height != app.ui.wins[0].h {
 			app.nav.height = app.ui.wins[0].h

--- a/lf.1
+++ b/lf.1
@@ -145,7 +145,7 @@ The following options can be used to customize the behavior of lf:
     dirfirst         bool      (default true)
     dironly          bool      (default false)
     dirpreviews      bool      (default false)
-    drawbox          bool      (default false)
+    drawbox          string    (default "none")
     dupfilefmt       string    (default '%f.~%n~')
     errorfmt         string    (default "\e033[7;31;47m")
     filesep          string    (default "\en")
@@ -874,10 +874,10 @@ Show only directories.
 If enabled, directories will also be passed to the previewer script. This allows custom previews for directories.
 .PP
 .EX
-    drawbox        bool      (default false)
+    drawbox        string    (default "none")
 .EE
 .PP
-Draw boxes around panes with box drawing characters.
+Draw boxes around panes with box drawing characters. "outline" draws a box around all panes. "separators" draws vertical lines between all panes. "both" or "true" draws both outline and separators. "none" or "false" draws neither outline nor separators.
 .PP
 .EX
     dupfilefmt        string      (default '%f.~%n~')

--- a/opts.go
+++ b/opts.go
@@ -41,7 +41,7 @@ var gOpts struct {
 	dircounts        bool
 	dironly          bool
 	dirpreviews      bool
-	drawbox          bool
+	drawbox          string
 	dupfilefmt       string
 	globsearch       bool
 	icons            bool
@@ -188,7 +188,7 @@ func init() {
 	gOpts.dircounts = false
 	gOpts.dironly = false
 	gOpts.dirpreviews = false
-	gOpts.drawbox = false
+	gOpts.drawbox = "false"
 	gOpts.dupfilefmt = "%f.~%n~"
 	gOpts.borderfmt = "\033[0m"
 	gOpts.cursoractivefmt = "\033[7m"


### PR DESCRIPTION
Follows the pattern established by Ranger's `draw_borders` setting:

- `true` / `both`: draw an outline box around all panes, plus vertical separators between panes.
- `outline`: draw only the outline box.
- `separators`: draw only the separators.
- `false` / `none`: draw neither outline box nor separators (default).

So, this is a string option that accepts "true" and "false" strings for backwards compatibility.

Note the behavior of toggling with `:set drawbox!`: if any borders are being drawn (ie. "both", "outline" or "separators", turns them off; if no borders are being drawn (ie. "none"), turns them all on (ie. "both").

Closes: https://github.com/gokcehan/lf/issues/1438

---

Context: I'm not a Go expert and I'm new to this codebase, so this is my first PR, so any and all feedback is welcome.