### PR TITLE
Use `-print-last-dir` option for `lfcd.cmd`

### DIFF
--- a/etc/lfcd.cmd
+++ b/etc/lfcd.cmd
@@ -7,9 +7,9 @@ rem You need to put this file to a folder in %PATH% variable.
 set tmpfile="%tmp%\lf.%random%.tmp"
 if exist %tmpfile% goto:tmploop
 lf -last-dir-path=%tmpfile% %*
-if not exist %tmpfile% exit
+if not exist %tmpfile% exit 1
 set /p dir=<%tmpfile%
 del /f %tmpfile%
-if not exist "%dir%" exit
-if "%dir%" == "%cd%" exit
+if not exist "%dir%" exit 1
+if "%dir%" == "%cd%" exit 1
 cd /d "%dir%"

--- a/etc/lfcd.cmd
+++ b/etc/lfcd.cmd
@@ -7,9 +7,9 @@ rem You need to put this file to a folder in %PATH% variable.
 set tmpfile="%tmp%\lf.%random%.tmp"
 if exist %tmpfile% goto:tmploop
 lf -last-dir-path=%tmpfile% %*
-if not exist %tmpfile% exit 1
+if not exist %tmpfile% exit 0
 set /p dir=<%tmpfile%
 del /f %tmpfile%
-if not exist "%dir%" exit 1
-if "%dir%" == "%cd%" exit 1
+if not exist "%dir%" exit 0
+if "%dir%" == "%cd%" exit 0
 cd /d "%dir%"

--- a/etc/lfcd.cmd
+++ b/etc/lfcd.cmd
@@ -3,13 +3,4 @@ rem Change working dir in cmd.exe to last dir in lf on exit.
 rem
 rem You need to put this file to a folder in %PATH% variable.
 
-:tmploop
-set tmpfile="%tmp%\lf.%random%.tmp"
-if exist %tmpfile% goto:tmploop
-lf -last-dir-path=%tmpfile% %*
-if not exist %tmpfile% exit 0
-set /p dir=<%tmpfile%
-del /f %tmpfile%
-if not exist "%dir%" exit 0
-if "%dir%" == "%cd%" exit 0
-cd /d "%dir%"
+for /f "usebackq tokens=*" %%d in (`lf -print-last-dir %*`) do cd %%d


### PR DESCRIPTION
The current script was existing the console itself rather than just exiting lfcd.cmd.
explicit exit code makes sure we're only exiting lfcd.cmd