### PR TITLE
Fix preview for files containing long lines

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -893,7 +893,7 @@ func (nav *nav) preview(path string, win *win) {
 	bufReader := bufio.NewReader(reader)
 
 	addLine := true
-	for {
+	for len(reg.lines) < win.h {
 		line, isPrefix, err := bufReader.ReadLine()
 		if err != nil {
 			break
@@ -908,9 +908,6 @@ func (nav *nav) preview(path string, win *win) {
 
 		if addLine {
 			reg.lines = append(reg.lines, string(line))
-			if len(reg.lines) == win.h {
-				break
-			}
 		}
 
 		addLine = !isPrefix

--- a/nav.go
+++ b/nav.go
@@ -908,6 +908,9 @@ func (nav *nav) preview(path string, win *win) {
 
 		if addLine {
 			reg.lines = append(reg.lines, string(line))
+			if len(reg.lines) == win.h {
+				break
+			}
 		}
 
 		addLine = !isPrefix

--- a/nav.go
+++ b/nav.go
@@ -889,7 +889,8 @@ func (nav *nav) preview(path string, win *win) {
 		}
 	}
 
-	// bufio.Scanner can't handle files containing very long lines
+	// bufio.Scanner can't handle files containing long lines if they exceed the
+	// size of its internal buffer
 	bufReader := bufio.NewReader(reader)
 
 	addLine := true

--- a/nav.go
+++ b/nav.go
@@ -889,20 +889,28 @@ func (nav *nav) preview(path string, win *win) {
 		}
 	}
 
-	buf := bufio.NewScanner(reader)
+	// bufio.Scanner can't handle files containing very long lines
+	bufReader := bufio.NewReader(reader)
 
-	for i := 0; i < win.h && buf.Scan(); i++ {
-		for _, r := range buf.Text() {
+	addLine := true
+	for {
+		line, isPrefix, err := bufReader.ReadLine()
+		if err != nil {
+			break
+		}
+
+		for _, r := range line {
 			if r == 0 {
 				reg.lines = []string{"\033[7mbinary\033[0m"}
 				return
 			}
 		}
-		reg.lines = append(reg.lines, buf.Text())
-	}
 
-	if buf.Err() != nil {
-		log.Printf("loading file: %s", buf.Err())
+		if addLine {
+			reg.lines = append(reg.lines, string(line))
+		}
+
+		addLine = !isPrefix
 	}
 }
 


### PR DESCRIPTION
- Fixes #1446 

When previewing files, reading the contents line by line using [`bufio.Scanner`](https://pkg.go.dev/bufio#Scanner) fails if a line is too long and cannot fit in the internal buffer. This PR changes the code to use [`bufio.Reader.ReadLine`](https://pkg.go.dev/bufio#Reader.ReadLine) instead which is able to filter out the excess content for each line.