### PR TITLE
Fix detection of character vs block devices

### DIFF
--- a/colors.go
+++ b/colors.go
@@ -301,10 +301,10 @@ func (sm styleMap) get(f *file) tcell.Style {
 		key = "pi"
 	case f.Mode()&os.ModeSocket != 0:
 		key = "so"
-	case f.Mode()&os.ModeDevice != 0:
-		key = "bd"
 	case f.Mode()&os.ModeCharDevice != 0:
 		key = "cd"
+	case f.Mode()&os.ModeDevice != 0:
+		key = "bd"
 	case f.Mode()&os.ModeSetuid != 0:
 		key = "su"
 	case f.Mode()&os.ModeSetgid != 0:

--- a/icons.go
+++ b/icons.go
@@ -128,10 +128,10 @@ func (im iconMap) get(f *file) string {
 		key = "pi"
 	case f.Mode()&os.ModeSocket != 0:
 		key = "so"
-	case f.Mode()&os.ModeDevice != 0:
-		key = "bd"
 	case f.Mode()&os.ModeCharDevice != 0:
 		key = "cd"
+	case f.Mode()&os.ModeDevice != 0:
+		key = "bd"
 	case f.Mode()&os.ModeSetuid != 0:
 		key = "su"
 	case f.Mode()&os.ModeSetgid != 0:


### PR DESCRIPTION
- Fixes #1468 

According to the [documentation](https://pkg.go.dev/os#pkg-constants), character devices have both the `ModeDevice` and `ModeCharDevice` bits set, causing the current code to interpret them as block devices.