### PR TITLE
Add `on-redraw` hook command

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -208,6 +208,7 @@ The following special shell commands are used to customize the behavior of lf wh
 	pre-cd
 	on-cd
 	on-select
+	on-redraw
 	on-quit
 
 The following commands/keybindings are provided by default:
@@ -1109,6 +1110,10 @@ This shell command can be defined to be executed after changing a directory.
 	on-select
 
 This shell command can be defined to be executed after the selection changes.
+
+	on-redraw
+
+This shell command can be defined to be executed after the screen is redrawn or if the terminal is resized.
 
 	on-quit
 

--- a/docstring.go
+++ b/docstring.go
@@ -212,6 +212,7 @@ when defined:
     pre-cd
     on-cd
     on-select
+    on-redraw
     on-quit
 
 The following commands/keybindings are provided by default:
@@ -1201,6 +1202,11 @@ This shell command can be defined to be executed after changing a directory.
     on-select
 
 This shell command can be defined to be executed after the selection changes.
+
+    on-redraw
+
+This shell command can be defined to be executed after the screen is redrawn or
+if the terminal is resized.
 
     on-quit
 

--- a/eval.go
+++ b/eval.go
@@ -1151,6 +1151,12 @@ func onChdir(app *app) {
 	}
 }
 
+func onRedraw(app *app) {
+	if cmd, ok := gOpts.cmds["on-redraw"]; ok {
+		cmd.eval(app, nil)
+	}
+}
+
 func onSelect(app *app) {
 	if cmd, ok := gOpts.cmds["on-select"]; ok {
 		cmd.eval(app, nil)
@@ -1944,6 +1950,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			dir.boundPos(app.nav.height)
 		}
 		app.ui.loadFile(app, true)
+		onRedraw(app)
 	case "load":
 		if !app.nav.init {
 			return

--- a/lf.1
+++ b/lf.1
@@ -231,6 +231,7 @@ The following special shell commands are used to customize the behavior of lf wh
     pre-cd
     on-cd
     on-select
+    on-redraw
     on-quit
 .EE
 .PP
@@ -1331,6 +1332,12 @@ This shell command can be defined to be executed after changing a directory.
 .EE
 .PP
 This shell command can be defined to be executed after the selection changes.
+.PP
+.EX
+    on-redraw
+.EE
+.PP
+This shell command can be defined to be executed after the screen is redrawn or if the terminal is resized.
 .PP
 .EX
     on-quit


### PR DESCRIPTION
- Fixes #713

This seems like a nice feature to have, I guess nobody got around to actually implementing this.

`tcell.EventResize` events will eventually call the `redraw` command, and I think it might be useful to apply the hook on redraws as opposed to resizes, for instance if the user wants to trigger the hook manually using `<c-l>`.

Below is an example, which even triggers upon startup:

```shell
cmd on-redraw %{{
    if [ $lf_width -le 80 ]; then
        lf -remote "send $id set ratios 1:2"
    elif [ $lf_width -le 160 ]; then
        lf -remote "send $id set ratios 1:2:3"
    else
        lf -remote "send $id set ratios 1:2:3:5"
    fi
}}
```