### PR TITLE
Force sync when writing to cut/copy buffer file

### DIFF
--- a/app.go
+++ b/app.go
@@ -164,6 +164,7 @@ func saveFiles(list []string, cp bool) error {
 		fmt.Fprintln(files, f)
 	}
 
+	files.Sync()
 	return nil
 }
 


### PR DESCRIPTION
- Fixes #1470 

This change syncs `~/.local/share/lf/files` to the disk immediately after writing to it, to minimize the time window in which another instance of `lf` opens the file in between and finds that it is empty.