### PR TITLE
Preserve attributes when moving across devices

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -36,10 +36,10 @@ func copySize(srcs []string) (int64, error) {
 	return total, nil
 }
 
-func copyFile(src, dst string, info os.FileInfo, nums chan int64) error {
+func copyFile(src, dst string, preserve []string, info os.FileInfo, nums chan int64) error {
 	var dst_mode os.FileMode = 0666
 	preserve_timestamps := false
-	for _, s := range gOpts.preserve {
+	for _, s := range preserve {
 		switch s {
 		case "timestamps":
 			preserve_timestamps = true
@@ -98,7 +98,7 @@ func copyFile(src, dst string, info os.FileInfo, nums chan int64) error {
 	return nil
 }
 
-func copyAll(srcs []string, dstDir string) (nums chan int64, errs chan error) {
+func copyAll(srcs []string, dstDir string, preserve []string) (nums chan int64, errs chan error) {
 	nums = make(chan int64, 1024)
 	errs = make(chan error, 1024)
 
@@ -149,7 +149,7 @@ func copyAll(srcs []string, dstDir string) (nums chan int64, errs chan error) {
 					}
 					nums <- info.Size()
 				} else {
-					if err := copyFile(path, newPath, info, nums); err != nil {
+					if err := copyFile(path, newPath, preserve, info, nums); err != nil {
 						errs <- fmt.Errorf("copy: %s", err)
 					}
 				}

--- a/nav.go
+++ b/nav.go
@@ -1320,7 +1320,7 @@ func (nav *nav) copyAsync(app *app, srcs []string, dstDir string) {
 
 	nav.copyTotalChan <- total
 
-	nums, errs := copyAll(srcs, dstDir)
+	nums, errs := copyAll(srcs, dstDir, gOpts.preserve)
 
 	errCount := 0
 loop:
@@ -1415,7 +1415,7 @@ func (nav *nav) moveAsync(app *app, srcs []string, dstDir string) {
 
 				nav.copyTotalChan <- total
 
-				nums, errs := copyAll([]string{src}, dstDir)
+				nums, errs := copyAll([]string{src}, dstDir, []string{"mode", "timestamps"})
 
 				oldCount := errCount
 			loop:


### PR DESCRIPTION
- Fixes #1472 

Use the fixed value `mode:timestamps` instead of the `preserve` option when moving files across devices