### PR TITLE
Enable completions and add description for lfcd.fish and simplify the code

### DIFF
--- a/etc/lfcd.fish
+++ b/etc/lfcd.fish
@@ -11,7 +11,7 @@
 #
 # You may put this in a function called fish_user_key_bindings.
 
-function lfcd
+function lfcd --wraps="lf" --description="lf - Terminal file manager (changing directory on exit)"
     set tmp (mktemp)
     # `command` is needed in case `lfcd` is aliased to `lf`
     command lf -last-dir-path=$tmp $argv

--- a/etc/lfcd.fish
+++ b/etc/lfcd.fish
@@ -12,7 +12,7 @@
 # You may put this in a function called fish_user_key_bindings.
 
 function lfcd --wraps="lf" --description="lf - Terminal file manager (changing directory on exit)"
-    # `command` is needed in case `lfcd` is aliased to `lf`,
-    # and quotes will cause `cd` to fail if `lf` prints nothing to stdout due to an error
+    # `command` is needed in case `lfcd` is aliased to `lf`.
+    # Quotes will cause `cd` to not change directory if `lf` prints nothing to stdout due to an error.
     cd "$(command lf -print-last-dir $argv)"
 end

--- a/etc/lfcd.fish
+++ b/etc/lfcd.fish
@@ -13,6 +13,6 @@
 
 function lfcd --wraps="lf" --description="lf - Terminal file manager (changing directory on exit)"
     # `command` is needed in case `lfcd` is aliased to `lf`
-    command lf -print-last-dir "$argv" \
+    command lf -print-last-dir $argv \
         | read -l dir && test -n "$dir" && cd "$dir" || true
 end

--- a/etc/lfcd.fish
+++ b/etc/lfcd.fish
@@ -12,16 +12,7 @@
 # You may put this in a function called fish_user_key_bindings.
 
 function lfcd --wraps="lf" --description="lf - Terminal file manager (changing directory on exit)"
-    set tmp (mktemp)
     # `command` is needed in case `lfcd` is aliased to `lf`
-    command lf -last-dir-path=$tmp $argv
-    if test -f "$tmp"
-        set dir (cat $tmp)
-        rm -f $tmp
-        if test -d "$dir"
-            if test "$dir" != (pwd)
-                cd $dir
-            end
-        end
-    end
+    command lf -print-last-dir "$argv" \
+        | read -l dir && test -n "$dir" && cd "$dir" || true
 end

--- a/etc/lfcd.fish
+++ b/etc/lfcd.fish
@@ -13,5 +13,6 @@
 
 function lfcd --wraps="lf" --description="lf - Terminal file manager (changing directory on exit)"
     # `command` is needed in case `lfcd` is aliased to `lf`
-    cd (command lf -print-last-dir $argv)
+    set -l outdir (command lf -print-last-dir $argv)
+    and cd "$outdir"
 end

--- a/etc/lfcd.fish
+++ b/etc/lfcd.fish
@@ -12,7 +12,7 @@
 # You may put this in a function called fish_user_key_bindings.
 
 function lfcd --wraps="lf" --description="lf - Terminal file manager (changing directory on exit)"
-    # `command` is needed in case `lfcd` is aliased to `lf`
-    set -l outdir (command lf -print-last-dir $argv)
-    and cd "$outdir"
+    # `command` is needed in case `lfcd` is aliased to `lf`,
+    # and quotes will cause `cd` to fail if `lf` prints nothing to stdout due to an error
+    cd "$(command lf -print-last-dir $argv)"
 end

--- a/etc/lfcd.fish
+++ b/etc/lfcd.fish
@@ -13,6 +13,5 @@
 
 function lfcd --wraps="lf" --description="lf - Terminal file manager (changing directory on exit)"
     # `command` is needed in case `lfcd` is aliased to `lf`
-    command lf -print-last-dir $argv \
-        | read -l dir && test -n "$dir" && cd "$dir" || true
+    cd (command lf -print-last-dir $argv)
 end


### PR DESCRIPTION
A simple addition of `--wraps=lf` to the function definition will enable the standard lf completions to be used for `lfcd` function as well.

I also added a description to the function, so that when the used types `lf` and hits tab, a brief description of what the function does is show. I simplified the code to just bind a var to stdout instead of creating a temp file, then read this var and cd to the selected directory.