### PR TITLE
Fix `low`/`high` crash for big `scrolloff` values

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -1144,7 +1144,7 @@ func (nav *nav) high() bool {
 
 	old := dir.ind
 	beg := max(dir.ind-dir.pos, 0)
-	offs := gOpts.scrolloff
+	offs := min(nav.height/2, gOpts.scrolloff)
 	if beg == 0 {
 		offs = 0
 	}
@@ -1175,7 +1175,14 @@ func (nav *nav) low() bool {
 	old := dir.ind
 	beg := max(dir.ind-dir.pos, 0)
 	end := min(beg+nav.height, len(dir.files))
-	offs := gOpts.scrolloff
+
+	offs := min(nav.height/2, gOpts.scrolloff)
+	// use a smaller value for half when the height is even and scrolloff is
+	// maxed in order to stay at the same row when using both high and low
+	if nav.height%2 == 0 {
+		offs = min(nav.height/2-1, gOpts.scrolloff)
+	}
+
 	if end == len(dir.files) {
 		offs = 0
 	}


### PR DESCRIPTION
- Fixes #1500

Steps to reproduce crashing for `low`:

1. Set `scrolloff` to a large value, for example `set scrolloff 1000`
2. Ensure the current directory has more files than the terminal height
3. Run the `low` command

Steps to reproduce crashing for `high`:

1. Set `scrolloff` to a large value, for example `set scrolloff 1000`
2. Scroll down (e.g. using `scroll-down`) so that the first file in the directory is not shown
3. Run the `high` command

This happens because the [code](https://github.com/gokcehan/lf/blob/9698ecddf17c5fdff78494314bd2a718b4100f3e/nav.go#L1142-L1187) does not cap the value of `scrolloff` at half the window height like the `up`/`down` commands.