### PR TITLE
add auto-autocompletion of commands

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -2750,7 +2750,13 @@ func (e *callExpr) eval(app *app, args []string) {
 	default:
 		cmd, ok := gOpts.cmds[e.name]
 		if !ok {
-			app.ui.echoerrf("command not found: %s", e.name)
+			completions, _ := completeCmd([]rune(e.name))
+			if len(completions) == 0 {
+				app.ui.echoerrf("command not found: %s", e.name)
+			} else {
+				e.name = completions[0]
+				e.eval(app, args)
+			}
 			return
 		}
 		cmd.eval(app, e.args)


### PR DESCRIPTION
**what it is:** i've made it so that when entering half a command, say, `:dele`, lf will just assume you meant the alphabetically first completion of the command, `:delete`.

**why it is:** vim does it this way.

maybe it should be an option instead, i wouldn't mind to add that, but if it is, i don't know what it should be called.