### PR TITLE
Show git commit if version information is missing

### DIFF
--- a/main.go
+++ b/main.go
@@ -223,15 +223,15 @@ func printVersion() {
 			vcsTime = setting.Value
 		case "vcs.modified":
 			if setting.Value == "true" {
-				vcsModified = "modified"
+				vcsModified = " (dirty)"
 			}
 		}
 	}
 
-	fmt.Printf("Go version: %s\n", buildInfo.GoVersion)
 	if vcsRevision != "" {
-		fmt.Printf("Commit: %s %s %s\n", vcsRevision, vcsTime, vcsModified)
+		fmt.Printf("Built at commit: %s%s %s\n", vcsRevision, vcsModified, vcsTime)
 	}
+	fmt.Printf("Go version: %s\n", buildInfo.GoVersion)
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"runtime/debug"
 	"runtime/pprof"
 	"strconv"
 	"strings"
@@ -202,6 +203,37 @@ func checkServer() {
 	}
 }
 
+func printVersion() {
+	if gVersion != "" {
+		fmt.Println(gVersion)
+		return
+	}
+
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+
+	var vcsRevision, vcsTime, vcsModified string
+	for _, setting := range buildInfo.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			vcsRevision = setting.Value
+		case "vcs.time":
+			vcsTime = setting.Value
+		case "vcs.modified":
+			if setting.Value == "true" {
+				vcsModified = "modified"
+			}
+		}
+	}
+
+	fmt.Printf("Go version: %s\n", buildInfo.GoVersion)
+	if vcsRevision != "" {
+		fmt.Printf("Commit: %s %s %s\n", vcsRevision, vcsTime, vcsModified)
+	}
+}
+
 func main() {
 	flag.Usage = func() {
 		f := flag.CommandLine.Output()
@@ -304,7 +336,7 @@ func main() {
 	case *showDoc:
 		fmt.Print(genDocString)
 	case *showVersion:
-		fmt.Println(gVersion)
+		printVersion()
 	case *remoteCmd != "":
 		if err := remote(*remoteCmd); err != nil {
 			log.Fatalf("remote command: %s", err)


### PR DESCRIPTION
This uses `runtime/debug` to show the Go version and Git commit embedded in the binary if version information is missing. The previous behavior is to just print nothing if the version is missing which is not very helpful.

I also considered adding the Go version information to the regular version information, but decided against it in case someone parses the output from the current version command.

Example output of custom built binary:
```
Go version: go1.21.4
Commit: 4f8ba9726d0bb6af4904740b52ba7b18320709ee 2023-12-02T04:17:13Z modified
```
