### PR TITLE
fix basename being `.` when it is empty

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -110,7 +110,10 @@ func copyAll(srcs []string, dstDir string, preserve []string) (nums chan int64, 
 			_, err := os.Lstat(dst)
 			if !os.IsNotExist(err) {
 				ext := filepath.Ext(file)
-				basename := filepath.Base(file[:len(file)-len(ext)])
+				basename := ""
+				if len(file) > len(ext) {
+					basename = filepath.Base(file[:len(file)-len(ext)])
+				}
 				var newPath string
 				for i := 1; !os.IsNotExist(err); i++ {
 					file = strings.ReplaceAll(gOpts.dupfilefmt, "%f", basename+ext)

--- a/copy.go
+++ b/copy.go
@@ -110,10 +110,7 @@ func copyAll(srcs []string, dstDir string, preserve []string) (nums chan int64, 
 			_, err := os.Lstat(dst)
 			if !os.IsNotExist(err) {
 				ext := filepath.Ext(file)
-				basename := ""
-				if len(file) > len(ext) {
-					basename = filepath.Base(file[:len(file)-len(ext)])
-				}
+				basename := file[:len(file)-len(ext)]
 				var newPath string
 				for i := 1; !os.IsNotExist(err); i++ {
 					file = strings.ReplaceAll(gOpts.dupfilefmt, "%f", basename+ext)

--- a/nav.go
+++ b/nav.go
@@ -1391,10 +1391,7 @@ func (nav *nav) moveAsync(app *app, srcs []string, dstDir string) {
 			continue
 		} else if !os.IsNotExist(err) {
 			ext := filepath.Ext(file)
-			basename := ""
-			if len(file) > len(ext) {
-				basename = filepath.Base(file[:len(file)-len(ext)])
-			}
+			basename := file[:len(file)-len(ext)]
 			var newPath string
 			for i := 1; !os.IsNotExist(err); i++ {
 				file = strings.ReplaceAll(gOpts.dupfilefmt, "%f", basename+ext)

--- a/nav.go
+++ b/nav.go
@@ -1391,7 +1391,10 @@ func (nav *nav) moveAsync(app *app, srcs []string, dstDir string) {
 			continue
 		} else if !os.IsNotExist(err) {
 			ext := filepath.Ext(file)
-			basename := filepath.Base(file[:len(file)-len(ext)])
+			basename := ""
+			if len(file) > len(ext) {
+				basename = filepath.Base(file[:len(file)-len(ext)])
+			}
 			var newPath string
 			for i := 1; !os.IsNotExist(err); i++ {
 				file = strings.ReplaceAll(gOpts.dupfilefmt, "%f", basename+ext)


### PR DESCRIPTION
`filepath.Base("")` is `.`. so when copying a hidden file like `.gitignore` to the same place, it becomes `..gitignore.~1~`

this PR fixes the case when basename should be empty