### PR TITLE
sortMethod simplification.

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -789,25 +790,12 @@ func (e *setExpr) eval(app *app, args []string) {
 		}
 		gOpts.smartdia = !gOpts.smartdia
 	case "sortby":
-		switch e.val {
-		case "natural":
-			gOpts.sortType.method = naturalSort
-		case "name":
-			gOpts.sortType.method = nameSort
-		case "size":
-			gOpts.sortType.method = sizeSort
-		case "time":
-			gOpts.sortType.method = timeSort
-		case "ctime":
-			gOpts.sortType.method = ctimeSort
-		case "atime":
-			gOpts.sortType.method = atimeSort
-		case "ext":
-			gOpts.sortType.method = extSort
-		default:
-			app.ui.echoerr("sortby: value should either be 'natural', 'name', 'size', 'time', 'atime', 'ctime' or 'ext'")
+		method := sortMethod(e.val)
+		if !slices.Contains(validSortMethods, method) {
+			app.ui.echoerr(invalidSortErrorMessage)
 			return
 		}
+		gOpts.sortType.method = method
 		app.nav.sort()
 		app.ui.sort()
 	case "statfmt":
@@ -1083,25 +1071,12 @@ func (e *setLocalExpr) eval(app *app, args []string) {
 		app.nav.sort()
 		app.ui.sort()
 	case "sortby":
-		switch e.val {
-		case "natural":
-			gLocalOpts.sortMethods[path] = naturalSort
-		case "name":
-			gLocalOpts.sortMethods[path] = nameSort
-		case "size":
-			gLocalOpts.sortMethods[path] = sizeSort
-		case "time":
-			gLocalOpts.sortMethods[path] = timeSort
-		case "ctime":
-			gLocalOpts.sortMethods[path] = ctimeSort
-		case "atime":
-			gLocalOpts.sortMethods[path] = atimeSort
-		case "ext":
-			gLocalOpts.sortMethods[path] = extSort
-		default:
-			app.ui.echoerr("sortby: value should either be 'natural', 'name', 'size', 'time', 'atime', 'ctime' or 'ext'")
+		method := sortMethod(e.val)
+		if !slices.Contains(validSortMethods, method) {
+			app.ui.echoerr(invalidSortErrorMessage)
 			return
 		}
+		gLocalOpts.sortMethods[path] = method
 		app.nav.sort()
 		app.ui.sort()
 	default:

--- a/eval.go
+++ b/eval.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -791,7 +790,7 @@ func (e *setExpr) eval(app *app, args []string) {
 		gOpts.smartdia = !gOpts.smartdia
 	case "sortby":
 		method := sortMethod(e.val)
-		if !slices.Contains(validSortMethods, method) {
+		if !isValidSortMethod(method) {
 			app.ui.echoerr(invalidSortErrorMessage)
 			return
 		}
@@ -1072,7 +1071,7 @@ func (e *setLocalExpr) eval(app *app, args []string) {
 		app.ui.sort()
 	case "sortby":
 		method := sortMethod(e.val)
-		if !slices.Contains(validSortMethods, method) {
+		if !isValidSortMethod(method) {
 			app.ui.echoerr(invalidSortErrorMessage)
 			return
 		}

--- a/main.go
+++ b/main.go
@@ -12,9 +12,9 @@ import (
 	"runtime/pprof"
 	"strconv"
 	"strings"
-)
 
-import _ "embed"
+	_ "embed"
+)
 
 //go:embed doc.txt
 var genDocString string
@@ -136,28 +136,8 @@ func getOptsMap() map[string]string {
 			continue
 		}
 
-		// Get string representation of the value
 		if name == "lf_sortType" {
-			var sortby string
-
-			switch gOpts.sortType.method {
-			case naturalSort:
-				sortby = "natural"
-			case nameSort:
-				sortby = "name"
-			case sizeSort:
-				sortby = "size"
-			case timeSort:
-				sortby = "time"
-			case ctimeSort:
-				sortby = "ctime"
-			case atimeSort:
-				sortby = "atime"
-			case extSort:
-				sortby = "ext"
-			}
-
-			opts["lf_sortby"] = sortby
+			opts["lf_sortby"] = string(gOpts.sortType.method)
 			opts["lf_reverse"] = strconv.FormatBool(gOpts.sortType.option&reverseSort != 0)
 			opts["lf_hidden"] = strconv.FormatBool(gOpts.sortType.option&hiddenSort != 0)
 			opts["lf_dirfirst"] = strconv.FormatBool(gOpts.sortType.option&dirfirstSort != 0)

--- a/opts.go
+++ b/opts.go
@@ -5,17 +5,22 @@ import (
 	"time"
 )
 
-type sortMethod byte
+// String values match the sortby string sent by the user at startup
+type sortMethod string
 
 const (
-	naturalSort sortMethod = iota
-	nameSort
-	sizeSort
-	timeSort
-	atimeSort
-	ctimeSort
-	extSort
+	naturalSort sortMethod = "natural"
+	nameSort    sortMethod = "name"
+	sizeSort    sortMethod = "size"
+	timeSort    sortMethod = "time"
+	atimeSort   sortMethod = "atime"
+	ctimeSort   sortMethod = "ctime"
+	extSort     sortMethod = "ext"
 )
+
+var validSortMethods = []sortMethod{naturalSort, nameSort, sizeSort, atimeSort, ctimeSort, extSort}
+
+const invalidSortErrorMessage = `sortby: value should either be 'natural', 'name', 'size', 'time', 'atime', 'ctime' or 'ext'`
 
 type sortOption byte
 

--- a/opts.go
+++ b/opts.go
@@ -18,7 +18,14 @@ const (
 	extSort     sortMethod = "ext"
 )
 
-var validSortMethods = []sortMethod{naturalSort, nameSort, sizeSort, atimeSort, ctimeSort, extSort}
+func isValidSortMethod(method sortMethod) bool {
+	for _, validMethod := range []sortMethod{naturalSort, nameSort, sizeSort, atimeSort, ctimeSort, extSort} {
+		if method == validMethod {
+			return true
+		}
+	}
+	return false
+}
 
 const invalidSortErrorMessage = `sortby: value should either be 'natural', 'name', 'size', 'time', 'atime', 'ctime' or 'ext'`
 

--- a/opts.go
+++ b/opts.go
@@ -19,7 +19,7 @@ const (
 )
 
 func isValidSortMethod(method sortMethod) bool {
-	for _, validMethod := range []sortMethod{naturalSort, nameSort, sizeSort, atimeSort, ctimeSort, extSort} {
+	for _, validMethod := range []sortMethod{naturalSort, nameSort, sizeSort, timeSort, atimeSort, ctimeSort, extSort} {
 		if method == validMethod {
 			return true
 		}


### PR DESCRIPTION
The iota enum expression for sortMethod required the same lengthy switch statement in setExpression's `eval` and `setLocalExpression`'s eval, along with `getOptsMap` in main to be updated for every sort method.  Making sortMethod's underlying representation a string removes the need to have these long and repetitive switch statements and for new sortMethods to require changes outside of `dir.sort` in `nav.go` and the const definitions at the top of `opts.go`

Alternatively, `sortMethod` can stay as an iota and there can be a map of sortMethods to their string representations.

