### PR TITLE
Improve refreshing of file statinfo

### DIFF
--- a/app.go
+++ b/app.go
@@ -404,7 +404,7 @@ func (app *app) loop() {
 			if err == nil {
 				if d.path == app.nav.currDir().path {
 					app.ui.loadFile(app, true)
-					if app.ui.msg == "" {
+					if app.ui.msgIsStat {
 						app.ui.loadFileInfo(app.nav)
 					}
 				}

--- a/eval.go
+++ b/eval.go
@@ -1965,8 +1965,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			app.ui.echoerrf("reload: %s", err)
 		}
 		app.ui.loadFile(app, true)
-		// clear file information, will be loaded asynchronously
-		app.ui.msg = ""
+		app.ui.loadFileInfo(app.nav)
 	case "read":
 		if app.ui.cmdPrefix == ">" {
 			return

--- a/ui.go
+++ b/ui.go
@@ -567,6 +567,7 @@ type ui struct {
 	msgWin      *win
 	menuWin     *win
 	msg         string
+	msgIsStat   bool
 	regPrev     *reg
 	dirPrev     *dir
 	exprChan    chan expr
@@ -596,6 +597,7 @@ func newUI(screen tcell.Screen) *ui {
 		promptWin:   newWin(wtot, 1, 0, 0),
 		msgWin:      newWin(wtot, 1, 0, htot-1),
 		menuWin:     newWin(wtot, 1, 0, htot-2),
+		msgIsStat:   true,
 		exprChan:    make(chan expr, 1000),
 		keyChan:     make(chan string, 1000),
 		tevChan:     make(chan tcell.Event, 1000),
@@ -653,10 +655,11 @@ func (ui *ui) sort() {
 
 func (ui *ui) echo(msg string) {
 	ui.msg = msg
+	ui.msgIsStat = false
 }
 
 func (ui *ui) echomsg(msg string) {
-	ui.msg = msg
+	ui.echo(msg)
 	log.Print(msg)
 }
 
@@ -669,7 +672,7 @@ func optionToFmtstr(optstr string) string {
 }
 
 func (ui *ui) echoerr(msg string) {
-	ui.msg = fmt.Sprintf(optionToFmtstr(gOpts.errorfmt), msg)
+	ui.echo(fmt.Sprintf(optionToFmtstr(gOpts.errorfmt), msg))
 	log.Printf("error: %s", msg)
 }
 
@@ -754,7 +757,8 @@ func (ui *ui) loadFileInfo(nav *nav) {
 		}
 	}
 
-	ui.echo(fileInfo)
+	ui.msg = fileInfo
+	ui.msgIsStat = true
 }
 
 func (ui *ui) drawPromptLine(nav *nav) {


### PR DESCRIPTION
I have found a bug where the file statinfo doesn't update when using `:cd` to change to a new directory that has not already been loaded by `lf`. The issue happens because of the following check `if app.ui.msg == ""` which occurs when loading directories asynchronously: https://github.com/gokcehan/lf/blob/d8b7df87cbc0592fcb9ed2cb1f41e24279303ae2/app.go#L407-L409

This check comes from #994, where the intention was that asynchronous reloads should update the file statinfo, but also not overwrite error messages.

I have added a new variable `ui.msgIsStat` to track whether the statline is showing file statinfo or an `echo`/`echoerr` message, and changed the check to use this variable instead, which should fix the above issue. This also means the workaround in #1149 is not needed anymore.