### PR TITLE
Reload file info after `mark-save`/`mark-remove`

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -1456,16 +1456,20 @@ func insert(app *app, arg string) {
 		app.nav.marks[arg] = app.nav.currDir().path
 		if err := app.nav.writeMarks(); err != nil {
 			app.ui.echoerrf("mark-save: %s", err)
+			return
 		}
 		if gSingleMode {
 			if err := app.nav.sync(); err != nil {
 				app.ui.echoerrf("mark-save: %s", err)
+				return
 			}
 		} else {
 			if err := remote("send sync"); err != nil {
 				app.ui.echoerrf("mark-save: %s", err)
+				return
 			}
 		}
+		app.ui.loadFileInfo(app.nav)
 	case app.ui.cmdPrefix == "mark-load: ":
 		normal(app)
 
@@ -1510,12 +1514,15 @@ func insert(app *app, arg string) {
 		if gSingleMode {
 			if err := app.nav.sync(); err != nil {
 				app.ui.echoerrf("mark-remove: %s", err)
+				return
 			}
 		} else {
 			if err := remote("send sync"); err != nil {
 				app.ui.echoerrf("mark-remove: %s", err)
+				return
 			}
 		}
+		app.ui.loadFileInfo(app.nav)
 	case app.ui.cmdPrefix == ":" && len(app.ui.cmdAccLeft) == 0:
 		switch arg {
 		case "!", "$", "%", "&":


### PR DESCRIPTION
- Fixes #1541

Steps to reproduce for `mark-save`:

1. Create an error message (e.g. `:echoerr foo`)
2. Press `m` to perform `mark-save`, and create a mark

Steps to reproduce for `mark-reload`:

1. Create an error message (e.g. `:echoerr foo`)
2. Press `"` to perform `mark-reload`, and remove an existing mark

Both scenarios continue to display the old error message, which I think is a mistake. Note that for both scenarios, using `:mark-save`/`:mark-reload` directly won't reproduce the issue, since the `read` command loads loads the file info, clearing the error message.