### PR TITLE
Add watch option

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -196,6 +196,8 @@ var (
 		"wrapscroll!",
 		"findlen",
 		"period",
+		"watch",
+		"nowatch",
 		"scrolloff",
 		"tabstop",
 		"errorfmt",

--- a/doc.md
+++ b/doc.md
@@ -823,6 +823,10 @@ Note that directories are already updated automatically in many cases.
 This option can be useful when there is an external process changing the displayed directory and you are not doing anything in lf.
 Periodic checks are disabled when the value of this option is set to zero.
 
+## watch (bool) (default false)
+
+If enabled, watch visible directories for changes.
+
 ## preserve ([]string) (default `mode`)
 
 List of attributes that are preserved when copying files.

--- a/eval.go
+++ b/eval.go
@@ -629,12 +629,14 @@ func (e *setExpr) eval(app *app, args []string) {
 				return
 			}
 		}
-		curr, err := app.nav.currFile()
-		if err == nil {
-			if curr.IsDir() {
-				if err := watcher.Add(curr.path); err != nil {
-					app.ui.echoerrf("watch: watcher add: %s", err)
-					return
+		if len(app.nav.dirs) > 0 {
+			curr, err := app.nav.currFile()
+			if err == nil {
+				if curr.IsDir() {
+					if err := watcher.Add(curr.path); err != nil {
+						app.ui.echoerrf("watch: watcher add: %s", err)
+						return
+					}
 				}
 			}
 		}
@@ -1214,10 +1216,12 @@ func onSelect(app *app) {
 		for _, d := range app.nav.dirs {
 			dirsSet[d.path] = struct{}{}
 		}
-		curr, err := app.nav.currFile()
-		if err == nil {
-			if curr.IsDir() {
-				dirsSet[curr.path] = struct{}{}
+		if len(app.nav.dirs) > 0 {
+			curr, err := app.nav.currFile()
+			if err == nil {
+				if curr.IsDir() {
+					dirsSet[curr.path] = struct{}{}
+				}
 			}
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/djherbis/times v1.6.0
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/gdamore/tcell/v2 v2.7.0
 	github.com/mattn/go-runewidth v0.0.15
 	golang.org/x/sys v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/djherbis/times v1.6.0 h1:w2ctJ92J8fBvWPxugmXIv7Nz7Q3iDMKNx9v5ocVH20c=
 github.com/djherbis/times v1.6.0/go.mod h1:gOHeRAz2h+VJNZ5Gmc/o7iD9k4wW7NMVqieYCY99oc0=
+github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
+github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/gdamore/tcell/v2 v2.7.0 h1:I5LiGTQuwrysAt1KS9wg1yFfOI3arI3ucFrxtd/xqaA=

--- a/opts.go
+++ b/opts.go
@@ -61,6 +61,7 @@ var gOpts struct {
 	wrapscroll       bool
 	findlen          int
 	period           int
+	watch            bool
 	scrolloff        int
 	tabstop          int
 	errorfmt         string
@@ -212,6 +213,7 @@ func init() {
 	gOpts.wrapscroll = false
 	gOpts.findlen = 1
 	gOpts.period = 0
+	gOpts.watch = false
 	gOpts.scrolloff = 0
 	gOpts.tabstop = 8
 	gOpts.errorfmt = "\033[7;31;47m"


### PR DESCRIPTION
This merge request adds a `watch` option which leverages https://github.com/fsnotify/fsnotify to automatically update the UI when visible files change. It only tracks `nav.dirs` and `nav.currFile` if it's a directory so it should be pretty lightweight. fsnotify supports a wide variety of platforms, so we shouldn't have any compatibility issues, though I haven't tested this on all of them. The option is disabled by default.

This PR doesn't handle chmod or write notifications. Adding support for those could be a future improvement. Doing so would require more than just removing the separate case for those events in `app.loop` though, cause `nav.renew` doesn't catch those changes, so we'd have to add extra logic to update file modes/sizes.

As mentioned in the commit message, I haven't regenerated the other doc files aside from `doc.md` cause there seems to be something different about my local pandoc version that causes a bunch of extra changes. Not sure what's going on there...

Maybe closes #1449? We might want to wait for chmod and write too before we close that though.