### PR TITLE
Continue responding to signals after initial sigint

### DIFF
--- a/app.go
+++ b/app.go
@@ -49,13 +49,14 @@ func newApp(ui *ui, nav *nav) *app {
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM)
 	go func() {
-		switch <-sigChan {
-		case os.Interrupt:
-			return
-		case syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM:
-			app.quit()
-			os.Exit(3)
-			return
+		for {
+			switch <-sigChan {
+			case os.Interrupt:
+			case syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM:
+				app.quit()
+				os.Exit(3)
+				return
+			}
 		}
 	}()
 


### PR DESCRIPTION
This merge request fixes a bug where lf stops responding to signals after the first SIGINT.

The existing bug can be reproduced on Linux by:
1. Launching lf
2. Sending SIGINT to the lf process
3. Sending SIGHUP to the lf process

Currently, the second SIGHUP signal is ignored, but lf should exit, as it does it you send it a single SIGHUP before anything else.

After these changes, the subsequent signals after any initial SIGINTs are now respected.