### PR TITLE
`lf.zsh`: make completions complete both `lf` and `lfcd`

### DIFF
--- a/etc/lf.zsh
+++ b/etc/lf.zsh
@@ -1,4 +1,4 @@
-#compdef lf
+#compdef lf lfcd
 
 # Autocompletion for zsh shell.
 #

--- a/etc/lfcd.sh
+++ b/etc/lfcd.sh
@@ -13,12 +13,6 @@
 #     bind '"\C-o":"lfcd\C-m"'  # bash
 #     bindkey -s '^o' 'lfcd\n'  # zsh
 #
-# If you are a ZSH user, and have installed ZSH completions for LF,
-# you may also like to enable them for `lfcd` as well.
-# To do so, after sourcing/defining `lfcd` function, put the following line:
-#
-#   compdef _lf lfcd
-#
 
 lfcd () {
     # `command` is needed in case `lfcd` is aliased to `lf`

--- a/etc/lfcd.sh
+++ b/etc/lfcd.sh
@@ -13,6 +13,12 @@
 #     bind '"\C-o":"lfcd\C-m"'  # bash
 #     bindkey -s '^o' 'lfcd\n'  # zsh
 #
+# If you are a ZSH user, and have installed ZSH completions for LF,
+# you may also like to enable them for `lfcd` as well.
+# To do so, after sourcing/defining `lfcd` function, put the following line:
+#
+#   compdef _lf lfcd
+#
 
 lfcd () {
     # `command` is needed in case `lfcd` is aliased to `lf`


### PR DESCRIPTION
Added a short comment on how to make `lfcd` complete CLI options and filepaths just as `lf` itself in ZSH.

Initially I had in mind splitting `lfcd.sh` into a new ZSH-specific file which would define shell completions for `lfcd` but then I realized it might be more simple to just leave a note on how a user could do it themselves. Let me know if the initial idea is preferred.
