### PR TITLE
Update documentation contributing guidelines

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Cross-compile on all supported platforms
       run: gen/xbuild.sh
 
-  generate:
+  formatting:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -59,8 +59,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: "1.19"
+        go-version: "1.18"
 
-    - name: Test `go fmt && go generate` on Go 1.19 creates no diffs
-      run: go fmt && go generate && git diff --exit-code
+    - name: Test `go fmt` creates no diffs
+      run: go fmt && git diff --exit-code
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Global variable names are prefixed with `g` as in `gFooBar`.
 Exceptions are variables holding values of environmental variables which are prefixed with `env` as in `envFooBar` and regular expressions which are prefixed with `re` as in `reFooBar` when they are global.
 - Type and function names are small case as in `fooBar` since we don't use exporting.
 - For file name variables, `name`, `fname`, or `filename` should refer to the base name of the file as in `baz.txt`, and `path`, `fpath`, or `filepath` should refer to the full path of the file as in `/foo/bar/baz.txt`.
-- Run `go fmt && go generate` using Go 1.19+. On earlier versions of Go, `go generate` creates needless whitespace differences.
+- Run `go fmt` to ensure that files are formatted correctly.
 
 Use the surrounding code as reference when in doubt as usual.
 
@@ -28,8 +28,8 @@ Adding a new option usually requires the following steps:
 - Add option evaluation logic to `setExpr.eval` in `eval.go`
 - Implement the option somewhere in the code
 - Add option name to `gOptWords` in `complete.go` for tab completion
-- Add option name and its default value to `Quick Reference` and `Options` sections in `doc.go`
-- Run `go generate` to update the documentation
+- Add option name and its default value to `Quick Reference` and `Options` sections in `doc.md`
+- Run `gen/doc-with-docker.sh` to update the documentation
 - Commit your changes and send a pull request
 
 ## Adding a new builtin command
@@ -40,8 +40,8 @@ Adding a new command usually requires the following steps:
 - Add command evaluation logic to `callExpr.eval` in `eval.go`
 - Implement the command somewhere in the code
 - Add command name to `gCmdWords` in `complete.go` for tab completion
-- Add command name to `Quick Reference` and `Commands` sections in `doc.go`
-- Run `go generate` to update the documentation
+- Add command name to `Quick Reference` and `Commands` sections in `doc.md`
+- Run `gen/doc-with-docker.sh` to update the documentation
 - Commit your changes and send a pull request
 
 ## Platform specific code

--- a/app.go
+++ b/app.go
@@ -16,7 +16,7 @@ import (
 
 type cmdItem struct {
 	prefix string
-	value string
+	value  string
 }
 
 type app struct {

--- a/app.go
+++ b/app.go
@@ -16,7 +16,7 @@ import (
 
 type cmdItem struct {
 	prefix string
-	value  string
+	value string
 }
 
 type app struct {


### PR DESCRIPTION
As of #1474, [`pandoc`](https://pandoc.org/) is now being used to generate the documentation instead of `go generate`. This PR updates the contributing guidelines, and also removes the `go generate` verification part of the CI pipeline.