### PR TITLE
Update lfcd.nu to support nushell >= 0.87.0

### DIFF
--- a/etc/lfcd.nu
+++ b/etc/lfcd.nu
@@ -19,17 +19,7 @@
 #   }
 # ]
 
-# def-env lfcd [] {    # for nushell verison <  0.87.0 
-def --env lfcd [] {    # For nushell version >= 0.87.0
-  let tmp = (mktemp)
-  lf -last-dir-path $tmp
-  try {
-    let target_dir = (open --raw $tmp)
-    rm -f $tmp
-    try {
-        if ($target_dir != $env.PWD) { cd $target_dir }
-    } catch { |e| print -e $'lfcd: Can not change to ($target_dir): ($e | get debug)' }
-  } catch {
-    |e| print -e $'lfcd: Reading ($tmp) returned an error: ($e | get debug)'
-  }
+# For nushell version >= 0.87.0
+def --env --wrapped lfcd [...args: string] { 
+  cd (lf -print-last-dir $args)
 }

--- a/etc/lfcd.nu
+++ b/etc/lfcd.nu
@@ -19,7 +19,8 @@
 #   }
 # ]
 
-def-env lfcd [] {
+# def-env lfcd [] {    # for nushell verison <  0.87.0 
+def --env lfcd [] {    # For nushell version >= 0.87.0
   let tmp = (mktemp)
   lf -last-dir-path $tmp
   try {


### PR DESCRIPTION
Deprecated def-env in favor of def --env
https://www.nushell.sh/blog/2023-11-14-nushell_0_87_0.html#deprecated-commands-toc