### PR TITLE
Fallback to showing UID/GID if user/group lookup fails

### DIFF
--- a/os.go
+++ b/os.go
@@ -199,8 +199,11 @@ func isHidden(f os.FileInfo, path string, hiddenfiles []string) bool {
 
 func userName(f os.FileInfo) string {
 	if stat, ok := f.Sys().(*syscall.Stat_t); ok {
-		if u, err := user.LookupId(fmt.Sprint(stat.Uid)); err == nil {
+		uid := fmt.Sprint(stat.Uid)
+		if u, err := user.LookupId(uid); err == nil {
 			return u.Username
+		} else {
+			return uid
 		}
 	}
 	return ""
@@ -208,8 +211,11 @@ func userName(f os.FileInfo) string {
 
 func groupName(f os.FileInfo) string {
 	if stat, ok := f.Sys().(*syscall.Stat_t); ok {
-		if g, err := user.LookupGroupId(fmt.Sprint(stat.Gid)); err == nil {
+		gid := fmt.Sprint(stat.Gid)
+		if g, err := user.LookupGroupId(gid); err == nil {
 			return g.Name
+		} else {
+			return gid
 		}
 	}
 	return ""


### PR DESCRIPTION
If you mount a filesystem from another computer then UID/GID might not be mapped to any user. This changes it so that lf shows the UID and GID instead of nothing if user/group lookup fails.