### PR TITLE
Refactor eval code

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -78,6 +78,13 @@ func (e *setExpr) eval(app *app, args []string) {
 			}
 			app.ui.loadFile(app, true)
 		}
+	case "globsearch", "noglobsearch", "globsearch!":
+		err = applyBoolOpt(&gOpts.globsearch, e)
+		if err == nil {
+			app.nav.sort()
+			app.ui.sort()
+			app.ui.loadFile(app, true)
+		}
 	case "borderfmt":
 		gOpts.borderfmt = e.val
 	case "cleaner":
@@ -130,36 +137,6 @@ func (e *setExpr) eval(app *app, args []string) {
 			return
 		}
 		gOpts.findlen = n
-	case "globsearch":
-		if e.val == "" || e.val == "true" {
-			gOpts.globsearch = true
-		} else if e.val == "false" {
-			gOpts.globsearch = false
-		} else {
-			app.ui.echoerr("globsearch: value should be empty, 'true', or 'false'")
-			return
-		}
-		app.nav.sort()
-		app.ui.sort()
-		app.ui.loadFile(app, true)
-	case "noglobsearch":
-		if e.val != "" {
-			app.ui.echoerrf("noglobsearch: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.globsearch = false
-		app.nav.sort()
-		app.ui.sort()
-		app.ui.loadFile(app, true)
-	case "globsearch!":
-		if e.val != "" {
-			app.ui.echoerrf("globsearch!: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.globsearch = !gOpts.globsearch
-		app.nav.sort()
-		app.ui.sort()
-		app.ui.loadFile(app, true)
 	case "hidden":
 		if e.val == "" || e.val == "true" {
 			gOpts.hidden = true

--- a/eval.go
+++ b/eval.go
@@ -85,6 +85,14 @@ func (e *setExpr) eval(app *app, args []string) {
 			app.ui.sort()
 			app.ui.loadFile(app, true)
 		}
+	case "hidden", "nohidden", "hidden!":
+		err = applyBoolOpt(&gOpts.hidden, e)
+		if err == nil {
+			app.nav.sort()
+			app.nav.position()
+			app.ui.sort()
+			app.ui.loadFile(app, true)
+		}
 	case "borderfmt":
 		gOpts.borderfmt = e.val
 	case "cleaner":
@@ -137,39 +145,6 @@ func (e *setExpr) eval(app *app, args []string) {
 			return
 		}
 		gOpts.findlen = n
-	case "hidden":
-		if e.val == "" || e.val == "true" {
-			gOpts.hidden = true
-		} else if e.val == "false" {
-			gOpts.hidden = false
-		} else {
-			app.ui.echoerr("hidden: value should be empty, 'true', or 'false'")
-			return
-		}
-		app.nav.sort()
-		app.nav.position()
-		app.ui.sort()
-		app.ui.loadFile(app, true)
-	case "nohidden":
-		if e.val != "" {
-			app.ui.echoerrf("nohidden: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.hidden = false
-		app.nav.sort()
-		app.nav.position()
-		app.ui.sort()
-		app.ui.loadFile(app, true)
-	case "hidden!":
-		if e.val != "" {
-			app.ui.echoerrf("hidden!: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.hidden = !gOpts.hidden
-		app.nav.sort()
-		app.nav.position()
-		app.ui.sort()
-		app.ui.loadFile(app, true)
 	case "hiddenfiles":
 		toks := strings.Split(e.val, ":")
 		for _, s := range toks {

--- a/eval.go
+++ b/eval.go
@@ -99,6 +99,19 @@ func (e *setExpr) eval(app *app, args []string) {
 		err = applyBoolOpt(&gOpts.history, e)
 	case "icons", "noicons", "icons!":
 		err = applyBoolOpt(&gOpts.icons, e)
+	case "ignorecase", "noignorecase", "ignorecase!":
+		err = applyBoolOpt(&gOpts.ignorecase, e)
+		if err == nil {
+			app.nav.sort()
+			app.ui.sort()
+			app.ui.loadFile(app, true)
+		}
+	case "ignoredia", "noignoredia", "ignoredia!":
+		err = applyBoolOpt(&gOpts.ignoredia, e)
+		if err == nil {
+			app.nav.sort()
+			app.ui.sort()
+		}
 	case "borderfmt":
 		gOpts.borderfmt = e.val
 	case "cleaner":
@@ -150,63 +163,6 @@ func (e *setExpr) eval(app *app, args []string) {
 		app.ui.loadFile(app, true)
 	case "ifs":
 		gOpts.ifs = e.val
-	case "ignorecase":
-		if e.val == "" || e.val == "true" {
-			gOpts.ignorecase = true
-		} else if e.val == "false" {
-			gOpts.ignorecase = false
-		} else {
-			app.ui.echoerr("ignorecase: value should be empty, 'true', or 'false'")
-			return
-		}
-		app.nav.sort()
-		app.ui.sort()
-		app.ui.loadFile(app, true)
-	case "noignorecase":
-		if e.val != "" {
-			app.ui.echoerrf("noignorecase: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.ignorecase = false
-		app.nav.sort()
-		app.ui.sort()
-		app.ui.loadFile(app, true)
-	case "ignorecase!":
-		if e.val != "" {
-			app.ui.echoerrf("ignorecase!: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.ignorecase = !gOpts.ignorecase
-		app.nav.sort()
-		app.ui.sort()
-		app.ui.loadFile(app, true)
-	case "ignoredia":
-		if e.val == "" || e.val == "true" {
-			gOpts.ignoredia = true
-		} else if e.val == "false" {
-			gOpts.ignoredia = false
-		} else {
-			app.ui.echoerr("ignoredia: value should be empty, 'true', or 'false'")
-			return
-		}
-		app.nav.sort()
-		app.ui.sort()
-	case "noignoredia":
-		if e.val != "" {
-			app.ui.echoerrf("noignoredia: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.ignoredia = false
-		app.nav.sort()
-		app.ui.sort()
-	case "ignoredia!":
-		if e.val != "" {
-			app.ui.echoerrf("ignoredia!: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.ignoredia = !gOpts.ignoredia
-		app.nav.sort()
-		app.ui.sort()
 	case "incfilter":
 		if e.val == "" || e.val == "true" {
 			gOpts.incfilter = true

--- a/eval.go
+++ b/eval.go
@@ -128,6 +128,18 @@ func (e *setExpr) eval(app *app, args []string) {
 				app.ui.screen.DisableMouse()
 			}
 		}
+	case "number", "nonumber", "number!":
+		err = applyBoolOpt(&gOpts.number, e)
+	case "relativenumber", "norelativenumber", "relativenumber!":
+		err = applyBoolOpt(&gOpts.relativenumber, e)
+	case "reverse", "noreverse", "reverse!":
+		err = applyBoolOpt(&gOpts.reverse, e)
+		if err == nil {
+			app.nav.sort()
+			app.ui.sort()
+		}
+	case "sixel", "nosixel", "sixel!":
+		err = applyBoolOpt(&gOpts.sixel, e)
 	case "borderfmt":
 		gOpts.borderfmt = e.val
 	case "cleaner":
@@ -234,27 +246,6 @@ func (e *setExpr) eval(app *app, args []string) {
 		gOpts.infotimefmtnew = e.val
 	case "infotimefmtold":
 		gOpts.infotimefmtold = e.val
-	case "number":
-		if e.val == "" || e.val == "true" {
-			gOpts.number = true
-		} else if e.val == "false" {
-			gOpts.number = false
-		} else {
-			app.ui.echoerr("number: value should be empty, 'true', or 'false'")
-			return
-		}
-	case "nonumber":
-		if e.val != "" {
-			app.ui.echoerrf("nonumber: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.number = false
-	case "number!":
-		if e.val != "" {
-			app.ui.echoerrf("number!: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.number = !gOpts.number
 	case "numberfmt":
 		gOpts.numberfmt = e.val
 	case "period":
@@ -332,54 +323,6 @@ func (e *setExpr) eval(app *app, args []string) {
 		gOpts.ratios = rats
 		app.ui.wins = getWins(app.ui.screen)
 		app.ui.loadFile(app, true)
-	case "relativenumber":
-		if e.val == "" || e.val == "true" {
-			gOpts.relativenumber = true
-		} else if e.val == "false" {
-			gOpts.relativenumber = false
-		} else {
-			app.ui.echoerr("relativenumber: value should be empty, 'true', or 'false'")
-			return
-		}
-	case "norelativenumber":
-		if e.val != "" {
-			app.ui.echoerrf("norelativenumber: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.relativenumber = false
-	case "relativenumber!":
-		if e.val != "" {
-			app.ui.echoerrf("relativenumber!: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.relativenumber = !gOpts.relativenumber
-	case "reverse":
-		if e.val == "" || e.val == "true" {
-			gOpts.reverse = true
-		} else if e.val == "false" {
-			gOpts.reverse = false
-		} else {
-			app.ui.echoerr("reverse: value should be empty, 'true', or 'false'")
-			return
-		}
-		app.nav.sort()
-		app.ui.sort()
-	case "noreverse":
-		if e.val != "" {
-			app.ui.echoerrf("noreverse: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.reverse = false
-		app.nav.sort()
-		app.ui.sort()
-	case "reverse!":
-		if e.val != "" {
-			app.ui.echoerrf("reverse!: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.reverse = !gOpts.reverse
-		app.nav.sort()
-		app.ui.sort()
 	case "scrolloff":
 		n, err := strconv.Atoi(e.val)
 		if err != nil {
@@ -552,27 +495,6 @@ func (e *setExpr) eval(app *app, args []string) {
 			return
 		}
 		gOpts.wrapscroll = !gOpts.wrapscroll
-	case "sixel":
-		if e.val == "" || e.val == "true" {
-			gOpts.sixel = true
-		} else if e.val == "false" {
-			gOpts.sixel = false
-		} else {
-			app.ui.echoerr("sixel: value should be empty, 'true', or 'false'")
-			return
-		}
-	case "nosixel":
-		if e.val != "" {
-			app.ui.echoerrf("nosixel: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.sixel = false
-	case "sixel!":
-		if e.val != "" {
-			app.ui.echoerrf("sixel!: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.sixel = !gOpts.sixel
 	default:
 		// any key with the prefix user_ is accepted as a user defined option
 		if strings.HasPrefix(e.opt, "user_") {

--- a/eval.go
+++ b/eval.go
@@ -42,6 +42,20 @@ func applyBoolOpt(opt *bool, e *setExpr) error {
 	return nil
 }
 
+func applyLocalBoolOpt(localOpt map[string]bool, globalOpt bool, e *setLocalExpr) error {
+	opt, ok := localOpt[e.path]
+	if !ok {
+		opt = globalOpt
+	}
+
+	if err := applyBoolOpt(&opt, &setExpr{e.opt, e.val}); err != nil {
+		return err
+	}
+
+	localOpt[e.path] = opt
+	return nil
+}
+
 func (e *setExpr) eval(app *app, args []string) {
 	var err error
 	switch e.opt {

--- a/eval.go
+++ b/eval.go
@@ -151,6 +151,19 @@ func (e *setExpr) eval(app *app, args []string) {
 		}
 	case "sixel", "nosixel", "sixel!":
 		err = applyBoolOpt(&gOpts.sixel, e)
+	case "smartcase", "nosmartcase", "smartcase!":
+		err = applyBoolOpt(&gOpts.smartcase, e)
+		if err == nil {
+			app.nav.sort()
+			app.ui.sort()
+			app.ui.loadFile(app, true)
+		}
+	case "smartdia", "nosmartdia", "smartdia!":
+		err = applyBoolOpt(&gOpts.smartdia, e)
+	case "wrapscan", "nowrapscan", "wrapscan!":
+		err = applyBoolOpt(&gOpts.wrapscan, e)
+	case "wrapscroll", "nowrapscroll", "wrapscroll!":
+		err = applyBoolOpt(&gOpts.wrapscroll, e)
 	case "borderfmt":
 		gOpts.borderfmt = e.val
 	case "cleaner":
@@ -333,57 +346,6 @@ func (e *setExpr) eval(app *app, args []string) {
 			return
 		}
 		gOpts.shellopts = strings.Split(e.val, ":")
-	case "smartcase":
-		if e.val == "" || e.val == "true" {
-			gOpts.smartcase = true
-		} else if e.val == "false" {
-			gOpts.smartcase = false
-		} else {
-			app.ui.echoerr("smartcase: value should be empty, 'true', or 'false'")
-			return
-		}
-		app.nav.sort()
-		app.ui.sort()
-		app.ui.loadFile(app, true)
-	case "nosmartcase":
-		if e.val != "" {
-			app.ui.echoerrf("nosmartcase: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.smartcase = false
-		app.nav.sort()
-		app.ui.sort()
-		app.ui.loadFile(app, true)
-	case "smartcase!":
-		if e.val != "" {
-			app.ui.echoerrf("smartcase!: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.smartcase = !gOpts.smartcase
-		app.nav.sort()
-		app.ui.sort()
-		app.ui.loadFile(app, true)
-	case "smartdia":
-		if e.val == "" || e.val == "true" {
-			gOpts.smartdia = true
-		} else if e.val == "false" {
-			gOpts.smartdia = false
-		} else {
-			app.ui.echoerr("smartdia: value should be empty, 'true', or 'false'")
-			return
-		}
-	case "nosmartdia":
-		if e.val != "" {
-			app.ui.echoerrf("nosmartdia: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.smartdia = false
-	case "smartdia!":
-		if e.val != "" {
-			app.ui.echoerrf("smartdia!: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.smartdia = !gOpts.smartdia
 	case "sortby":
 		method := sortMethod(e.val)
 		if !isValidSortMethod(method) {
@@ -432,48 +394,6 @@ func (e *setExpr) eval(app *app, args []string) {
 		gOpts.truncatepct = n
 	case "waitmsg":
 		gOpts.waitmsg = e.val
-	case "wrapscan":
-		if e.val == "" || e.val == "true" {
-			gOpts.wrapscan = true
-		} else if e.val == "false" {
-			gOpts.wrapscan = false
-		} else {
-			app.ui.echoerr("wrapscan: value should be empty, 'true', or 'false'")
-			return
-		}
-	case "nowrapscan":
-		if e.val != "" {
-			app.ui.echoerrf("nowrapscan: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.wrapscan = false
-	case "wrapscan!":
-		if e.val != "" {
-			app.ui.echoerrf("wrapscan!: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.wrapscan = !gOpts.wrapscan
-	case "wrapscroll":
-		if e.val == "" || e.val == "true" {
-			gOpts.wrapscroll = true
-		} else if e.val == "false" {
-			gOpts.wrapscroll = false
-		} else {
-			app.ui.echoerr("wrapscroll: value should be empty, 'true', or 'false'")
-			return
-		}
-	case "nowrapscroll":
-		if e.val != "" {
-			app.ui.echoerrf("nowrapscroll: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.wrapscroll = false
-	case "wrapscroll!":
-		if e.val != "" {
-			app.ui.echoerrf("wrapscroll!: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.wrapscroll = !gOpts.wrapscroll
 	default:
 		// any key with the prefix user_ is accepted as a user defined option
 		if strings.HasPrefix(e.opt, "user_") {

--- a/eval.go
+++ b/eval.go
@@ -456,13 +456,17 @@ func (e *setLocalExpr) eval(app *app, args []string) {
 		err = applyLocalBoolOpt(gLocalOpts.dironlys, gOpts.dironly, e)
 		if err == nil {
 			app.nav.sort()
+			app.nav.position()
 			app.ui.sort()
+			app.ui.loadFile(app, true)
 		}
 	case "hidden", "nohidden", "hidden!":
 		err = applyLocalBoolOpt(gLocalOpts.hiddens, gOpts.hidden, e)
 		if err == nil {
 			app.nav.sort()
+			app.nav.position()
 			app.ui.sort()
+			app.ui.loadFile(app, true)
 		}
 	case "reverse", "noreverse", "reverse!":
 		err = applyLocalBoolOpt(gLocalOpts.reverses, gOpts.reverse, e)

--- a/eval.go
+++ b/eval.go
@@ -119,6 +119,15 @@ func (e *setExpr) eval(app *app, args []string) {
 		err = applyBoolOpt(&gOpts.incfilter, e)
 	case "incsearch", "noincsearch", "incsearch!":
 		err = applyBoolOpt(&gOpts.incsearch, e)
+	case "mouse", "nomouse", "mouse!":
+		err = applyBoolOpt(&gOpts.mouse, e)
+		if err == nil {
+			if gOpts.mouse {
+				app.ui.screen.EnableMouse(tcell.MouseButtonEvents)
+			} else {
+				app.ui.screen.DisableMouse()
+			}
+		}
 	case "borderfmt":
 		gOpts.borderfmt = e.val
 	case "cleaner":
@@ -225,42 +234,6 @@ func (e *setExpr) eval(app *app, args []string) {
 		gOpts.infotimefmtnew = e.val
 	case "infotimefmtold":
 		gOpts.infotimefmtold = e.val
-	case "mouse":
-		if e.val == "" || e.val == "true" {
-			if !gOpts.mouse {
-				gOpts.mouse = true
-				app.ui.screen.EnableMouse(tcell.MouseButtonEvents)
-			}
-		} else if e.val == "false" {
-			if gOpts.mouse {
-				gOpts.mouse = false
-				app.ui.screen.DisableMouse()
-			}
-		} else {
-			app.ui.echoerr("mouse: value should be empty, 'true', or 'false'")
-			return
-		}
-	case "nomouse":
-		if e.val != "" {
-			app.ui.echoerrf("nomouse: unexpected value: %s", e.val)
-			return
-		}
-		if gOpts.mouse {
-			gOpts.mouse = false
-			app.ui.screen.DisableMouse()
-		}
-	case "mouse!":
-		if e.val != "" {
-			app.ui.echoerrf("mouse!: unexpected value: %s", e.val)
-			return
-		}
-		if gOpts.mouse {
-			gOpts.mouse = false
-			app.ui.screen.DisableMouse()
-		} else {
-			gOpts.mouse = true
-			app.ui.screen.EnableMouse(tcell.MouseButtonEvents)
-		}
 	case "number":
 		if e.val == "" || e.val == "true" {
 			gOpts.number = true

--- a/eval.go
+++ b/eval.go
@@ -83,6 +83,7 @@ func (e *setExpr) eval(app *app, args []string) {
 		err = applyBoolOpt(&gOpts.globsearch, e)
 		if err == nil {
 			app.nav.sort()
+			app.nav.position()
 			app.ui.sort()
 			app.ui.loadFile(app, true)
 		}
@@ -155,11 +156,18 @@ func (e *setExpr) eval(app *app, args []string) {
 		err = applyBoolOpt(&gOpts.smartcase, e)
 		if err == nil {
 			app.nav.sort()
+			app.nav.position()
 			app.ui.sort()
 			app.ui.loadFile(app, true)
 		}
 	case "smartdia", "nosmartdia", "smartdia!":
 		err = applyBoolOpt(&gOpts.smartdia, e)
+		if err == nil {
+			app.nav.sort()
+			app.nav.position()
+			app.ui.sort()
+			app.ui.loadFile(app, true)
+		}
 	case "wrapscan", "nowrapscan", "wrapscan!":
 		err = applyBoolOpt(&gOpts.wrapscan, e)
 	case "wrapscroll", "nowrapscroll", "wrapscroll!":

--- a/eval.go
+++ b/eval.go
@@ -103,6 +103,7 @@ func (e *setExpr) eval(app *app, args []string) {
 		err = applyBoolOpt(&gOpts.ignorecase, e)
 		if err == nil {
 			app.nav.sort()
+			app.nav.position()
 			app.ui.sort()
 			app.ui.loadFile(app, true)
 		}
@@ -110,7 +111,9 @@ func (e *setExpr) eval(app *app, args []string) {
 		err = applyBoolOpt(&gOpts.ignoredia, e)
 		if err == nil {
 			app.nav.sort()
+			app.nav.position()
 			app.ui.sort()
+			app.ui.loadFile(app, true)
 		}
 	case "borderfmt":
 		gOpts.borderfmt = e.val

--- a/eval.go
+++ b/eval.go
@@ -115,6 +115,10 @@ func (e *setExpr) eval(app *app, args []string) {
 			app.ui.sort()
 			app.ui.loadFile(app, true)
 		}
+	case "incfilter", "noincfilter", "incfilter!":
+		err = applyBoolOpt(&gOpts.incfilter, e)
+	case "incsearch", "noincsearch", "incsearch!":
+		err = applyBoolOpt(&gOpts.incsearch, e)
 	case "borderfmt":
 		gOpts.borderfmt = e.val
 	case "cleaner":
@@ -166,48 +170,6 @@ func (e *setExpr) eval(app *app, args []string) {
 		app.ui.loadFile(app, true)
 	case "ifs":
 		gOpts.ifs = e.val
-	case "incfilter":
-		if e.val == "" || e.val == "true" {
-			gOpts.incfilter = true
-		} else if e.val == "false" {
-			gOpts.incfilter = false
-		} else {
-			app.ui.echoerr("incfilter: value should be empty, 'true', or 'false'")
-			return
-		}
-	case "noincfilter":
-		if e.val != "" {
-			app.ui.echoerrf("noincfilter: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.incfilter = false
-	case "incfilter!":
-		if e.val != "" {
-			app.ui.echoerrf("incfilter!: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.incfilter = !gOpts.incfilter
-	case "incsearch":
-		if e.val == "" || e.val == "true" {
-			gOpts.incsearch = true
-		} else if e.val == "false" {
-			gOpts.incsearch = false
-		} else {
-			app.ui.echoerr("incsearch: value should be empty, 'true', or 'false'")
-			return
-		}
-	case "noincsearch":
-		if e.val != "" {
-			app.ui.echoerrf("noincsearch: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.incsearch = false
-	case "incsearch!":
-		if e.val != "" {
-			app.ui.echoerrf("incsearch!: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.incsearch = !gOpts.incsearch
 	case "info":
 		if e.val == "" {
 			gOpts.info = nil

--- a/eval.go
+++ b/eval.go
@@ -93,6 +93,12 @@ func (e *setExpr) eval(app *app, args []string) {
 			app.ui.sort()
 			app.ui.loadFile(app, true)
 		}
+	case "hidecursorinactive", "nohidecursorinactive", "hidecursorinactive!":
+		err = applyBoolOpt(&gOpts.hidecursorinactive, e)
+	case "history", "nohistory", "history!":
+		err = applyBoolOpt(&gOpts.history, e)
+	case "icons", "noicons", "icons!":
+		err = applyBoolOpt(&gOpts.icons, e)
 	case "borderfmt":
 		gOpts.borderfmt = e.val
 	case "cleaner":
@@ -107,27 +113,6 @@ func (e *setExpr) eval(app *app, args []string) {
 		gOpts.cursorpreviewfmt = e.val
 	case "cutfmt":
 		gOpts.cutfmt = e.val
-	case "hidecursorinactive":
-		if e.val == "" || e.val == "true" {
-			gOpts.hidecursorinactive = true
-		} else if e.val == "false" {
-			gOpts.hidecursorinactive = false
-		} else {
-			app.ui.echoerr("hidecursorinactive: value should be empty, 'true', or 'false'")
-			return
-		}
-	case "nohidecursorinactive":
-		if e.val != "" {
-			app.ui.echoerrf("nohidecursorinactive: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.hidecursorinactive = false
-	case "hidecursorinactive!":
-		if e.val != "" {
-			app.ui.echoerrf("hidecursorinactive!: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.hidecursorinactive = !gOpts.hidecursorinactive
 	case "dupfilefmt":
 		gOpts.dupfilefmt = e.val
 	case "errorfmt":
@@ -163,48 +148,6 @@ func (e *setExpr) eval(app *app, args []string) {
 		app.nav.position()
 		app.ui.sort()
 		app.ui.loadFile(app, true)
-	case "history":
-		if e.val == "" || e.val == "true" {
-			gOpts.history = true
-		} else if e.val == "false" {
-			gOpts.history = false
-		} else {
-			app.ui.echoerr("history: value should be empty, 'true', or 'false'")
-			return
-		}
-	case "nohistory":
-		if e.val != "" {
-			app.ui.echoerrf("nohistory: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.history = false
-	case "history!":
-		if e.val != "" {
-			app.ui.echoerrf("history!: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.history = !gOpts.history
-	case "icons":
-		if e.val == "" || e.val == "true" {
-			gOpts.icons = true
-		} else if e.val == "false" {
-			gOpts.icons = false
-		} else {
-			app.ui.echoerr("icons: value should be empty, 'true', or 'false'")
-			return
-		}
-	case "noicons":
-		if e.val != "" {
-			app.ui.echoerrf("noicons: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.icons = false
-	case "icons!":
-		if e.val != "" {
-			app.ui.echoerrf("icons!: unexpected value: %s", e.val)
-			return
-		}
-		gOpts.icons = !gOpts.icons
 	case "ifs":
 		gOpts.ifs = e.val
 	case "ignorecase":

--- a/eval_test.go
+++ b/eval_test.go
@@ -537,3 +537,32 @@ func TestSplitKeys(t *testing.T) {
 		}
 	}
 }
+
+func TestApplyBoolOpt(t *testing.T) {
+	tests := []struct {
+		opt bool
+		e   setExpr
+		exp bool
+	}{
+		{true, setExpr{"feature", ""}, true},
+		{true, setExpr{"feature", "true"}, true},
+		{true, setExpr{"feature", "false"}, false},
+		{false, setExpr{"feature", ""}, true},
+		{false, setExpr{"feature", "true"}, true},
+		{false, setExpr{"feature", "false"}, false},
+		{true, setExpr{"nofeature", ""}, false},
+		{false, setExpr{"nofeature", ""}, false},
+		{true, setExpr{"feature!", ""}, false},
+		{false, setExpr{"feature!", ""}, true},
+	}
+
+	for _, test := range tests {
+		if err := applyBoolOpt(&test.opt, &test.e); err != nil {
+			t.Errorf("at input '%#v' expected '%t' but got an error '%s'", test.e, test.exp, err)
+			continue
+		}
+		if test.opt != test.exp {
+			t.Errorf("at input '%#v' expected '%t' but got '%t'", test.e, test.exp, test.opt)
+		}
+	}
+}


### PR DESCRIPTION
Based on https://github.com/gokcehan/lf/pull/1569#issuecomment-1890449308, I have decided to submit this as an alternative to #1569.

In my opinion, converting the `switch` statement into a `map[string]func` adds significant overhead (as well as an extra layer of indirection), and the main focus should be to deduplicate the logic for evaluating the `setExpr` object. I have also applied the same change to `setLocalExpr` as well. Regarding `complete.go`, I think it is better to leave it for a separate PR.

@gokcehan, @Michael-Gallo Please let me know what you think.