### PR TITLE
fix: support nushell on linux

### DIFF
--- a/os.go
+++ b/os.go
@@ -139,7 +139,7 @@ func shellCommand(s string, args []string) *exec.Cmd {
 		s = fmt.Sprintf("IFS='%s'; %s", gOpts.ifs, s)
 	}
 
-	args = append([]string{gOpts.shellflag, s, "--"}, args...)
+	args = append([]string{gOpts.shellflag, s}, args...)
 
 	args = append(gOpts.shellopts, args...)
 


### PR DESCRIPTION
# What it does

Fixes #1605

# Why it happend

`nushell` doesn't accept `--` at all, it would throw an exception when it was given

# How does the fix work

Remove the `--` argument

# Will it cause other problems?

I don't think so, the `--` for `sh` is to tell it that the rest of the arguments are meant for the command to be executed, which is not useful in this case because there is only one argument left.
I might be wrong though, 😊
