### PR TITLE
Directories added to dirChan no longer trigger checkDir

### DIFF
--- a/app.go
+++ b/app.go
@@ -379,9 +379,6 @@ func (app *app) loop() {
 			}
 			app.ui.draw(app.nav)
 		case d := <-app.nav.dirChan:
-
-			app.nav.checkDir(d)
-
 			if gOpts.dircache {
 				prev, ok := app.nav.dirCache[d.path]
 				if ok {

--- a/app.go
+++ b/app.go
@@ -413,8 +413,6 @@ func (app *app) loop() {
 
 			app.ui.draw(app.nav)
 		case r := <-app.nav.regChan:
-			app.nav.checkReg(r)
-
 			app.nav.regCache[r.path] = r
 
 			curr, err := app.nav.currFile()


### PR DESCRIPTION
In certain conditions, `checkDir` would cause a directory to be sent to `app.nav.dirChan` which would in turn call `checkDir`, creating an infinite loop.  The call to `checkDir` when a value is sent to `app.nav.dirChan` is likely unnecessary and removing it should fix the loop
See Issue #1543 

