### PR TITLE
Fix crash if tags/marks contains invalid entry

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -1868,9 +1868,12 @@ func (nav *nav) readMarks() error {
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		toks := strings.SplitN(scanner.Text(), ":", 2)
-		if _, ok := nav.marks[toks[0]]; !ok {
-			nav.marks[toks[0]] = toks[1]
+		mark, path, found := strings.Cut(scanner.Text(), ":")
+		if !found {
+			return fmt.Errorf("invalid marks file entry: %s", scanner.Text())
+		}
+		if _, ok := nav.marks[mark]; !ok {
+			nav.marks[mark] = path
 		}
 	}
 

--- a/nav.go
+++ b/nav.go
@@ -1923,12 +1923,12 @@ func (nav *nav) readTags() error {
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		text := scanner.Text()
-		ind := strings.LastIndex(text, ":")
-		path := text[0:ind]
-		mark := text[ind+1:]
+		path, tag, found := strings.Cut(scanner.Text(), ":")
+		if !found {
+			return fmt.Errorf("invalid tags file entry: %s", scanner.Text())
+		}
 		if _, ok := nav.tags[path]; !ok {
-			nav.tags[path] = mark
+			nav.tags[path] = tag
 		}
 	}
 


### PR DESCRIPTION
- Fixes #1613

`lf` crashes if either the tags file or marks file contains an invalid entry. I have changed this to show an error message instead. I also don't mind just ignoring invalid entries silently, if that is preferable.