### PR TITLE
avoid using the user.Current on windows to avoid slow startup

### DIFF
--- a/os_windows.go
+++ b/os_windows.go
@@ -59,14 +59,20 @@ func init() {
 		envShell = "cmd"
 	}
 
-	u, err := user.Current()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		log.Printf("user: %s", err)
+		panic(err)
 	}
-	gUser = u
 
-	// remove domain prefix
-	gUser.Username = strings.Split(gUser.Username, `\`)[1]
+	username := os.Getenv("USERNAME")
+	if username == "" {
+		panic("$USERNAME variable is empty or not set")
+	}
+
+	gUser = &user.User{
+		HomeDir: homeDir,
+		Username: username,
+	}
 
 	data := os.Getenv("LF_CONFIG_HOME")
 	if data == "" {

--- a/os_windows.go
+++ b/os_windows.go
@@ -70,7 +70,7 @@ func init() {
 	}
 
 	gUser = &user.User{
-		HomeDir: homeDir,
+		HomeDir:  homeDir,
 		Username: username,
 	}
 


### PR DESCRIPTION
- fixes: https://github.com/gokcehan/lf/issues/1097

If the user is domain joined, it can experience slow startups (aprox. 4-5 seconds, sometimes longer). After some investigation it seems that `user.Current()` makes a request to get the user info from active directory which will time out, and then it will fallback on the local info.

this articles gives a very good example with docker commands.
https://www.fearofoblivion.com/slow-docker-commands-on-domain-joined-pc

I also used `process explorer` and find the same event on the `lf.exe` process taking long time and failing with `BAD NETWORK PATH`.

This fix uses the `user.UserHomeDir()` and `os.Getenv("USERNAME")` to get the user details which will get them directly from the environment and solves the issue.