### PR TITLE
Add more file extensions for docker icon

### DIFF
--- a/etc/icons.example
+++ b/etc/icons.example
@@ -188,6 +188,9 @@ fi             # FILE
 *procfile               
 *dockerfile             
 *docker-compose.yml     
+*docker-compose.yaml    
+*compose.yml            
+*compose.yaml           
 *rakefile               
 *config.ru              
 *gemfile                
@@ -209,6 +212,7 @@ fi             # FILE
 *Procfile               
 *Dockerfile             
 *Docker-compose.yml     
+*Docker-compose.yaml    
 *Rakefile               
 *Gemfile                
 *Makefile               


### PR DESCRIPTION
According to [official docker documentation](https://docs.docker.com/compose/compose-application-model/#the-compose-file), Docker Compose can be written in `compose.yaml` (preferred), `compose.yml` files. It also supports `docker-compose.yaml` and `docker-compose.yml` for backward compatibility 