### PR TITLE
unix sockets on windows

### DIFF
--- a/os_windows.go
+++ b/os_windows.go
@@ -95,6 +95,11 @@ func init() {
 		filepath.Join(data, "lf", "icons"),
 	}
 
+	gFilesPath = filepath.Join(data, "lf", "files")
+	gMarksPath = filepath.Join(data, "lf", "marks")
+	gTagsPath = filepath.Join(data, "lf", "tags")
+	gHistoryPath = filepath.Join(data, "lf", "history")
+
 	socket, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
 	if err != nil {
 		gDefaultSocketProt = "tcp"
@@ -103,11 +108,6 @@ func init() {
 		gDefaultSocketPath = filepath.Join(data, "lf", fmt.Sprintf("lf.%s.sock", gUser.Username))
 		syscall.Close(socket)
 	}
-
-	gFilesPath = filepath.Join(data, "lf", "files")
-	gMarksPath = filepath.Join(data, "lf", "marks")
-	gTagsPath = filepath.Join(data, "lf", "tags")
-	gHistoryPath = filepath.Join(data, "lf", "history")
 }
 
 func detachedCommand(name string, arg ...string) *exec.Cmd {

--- a/os_windows.go
+++ b/os_windows.go
@@ -105,7 +105,8 @@ func init() {
 		gDefaultSocketProt = "tcp"
 		gDefaultSocketPath = "127.0.0.1:12345"
 	} else {
-		gDefaultSocketPath = filepath.Join(data, "lf", fmt.Sprintf("lf.%s.sock", gUser.Username))
+		runtime := os.TempDir()
+		gDefaultSocketPath = filepath.Join(runtime, fmt.Sprintf("lf.%s.sock", gUser.Username))
 		syscall.Close(socket)
 	}
 }

--- a/os_windows.go
+++ b/os_windows.go
@@ -98,7 +98,7 @@ func init() {
 	socket, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
 	if err != nil {
 		gDefaultSocketProt = "tcp"
-		gDefaultSocketPath = "127.0.0.1:1234"
+		gDefaultSocketPath = "127.0.0.1:12345"
 	} else {
 		gDefaultSocketPath = filepath.Join(data, "lf", fmt.Sprintf("lf.%s.sock", gUser.Username))
 		syscall.Close(socket)

--- a/os_windows.go
+++ b/os_windows.go
@@ -8,6 +8,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"golang.org/x/sys/windows"
 )
@@ -24,8 +25,8 @@ var envPathExt = os.Getenv("PATHEXT")
 var (
 	gDefaultShell      = "cmd"
 	gDefaultShellFlag  = "/c"
-	gDefaultSocketProt = "tcp"
-	gDefaultSocketPath = "127.0.0.1:12345"
+	gDefaultSocketProt = "unix"
+	gDefaultSocketPath string
 )
 
 var (
@@ -92,6 +93,15 @@ func init() {
 	gIconsPaths = []string{
 		filepath.Join(os.Getenv("ProgramData"), "lf", "icons"),
 		filepath.Join(data, "lf", "icons"),
+	}
+
+	socket, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		gDefaultSocketProt = "tcp"
+		gDefaultSocketPath = "127.0.0.1:1234"
+	} else {
+		gDefaultSocketPath = filepath.Join(data, "lf", fmt.Sprintf("lf.%s.sock", gUser.Username))
+		syscall.Close(socket)
 	}
 
 	gFilesPath = filepath.Join(data, "lf", "files")


### PR DESCRIPTION
Windows supports unix domain sockets for some years now but they are not used in lf. Changed the default socket to `unix` on windows to bring the benefits of it on the windows platform also. If the unix sockets are not supported ( very old version of windows ) fallback on tcp localhost sockets.

https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/

