### PR TITLE
Trigger update after copy/move

### DIFF
--- a/app.go
+++ b/app.go
@@ -487,6 +487,10 @@ func (app *app) runCmdSync(cmd *exec.Cmd, pause_after bool) {
 	}
 
 	app.ui.loadFile(app, true)
+
+	//mark the current directory as updated for refresh
+	app.nav.currDir().updated = true
+
 	app.nav.renew()
 }
 
@@ -522,12 +526,6 @@ func (app *app) runShell(s string, args []string, prefix string) {
 		cmd.Stderr = os.Stderr
 
 		app.runCmdSync(cmd, prefix == "!")
-
-		//mark the current directory as updated for refresh
-		app.nav.currDir().updated = true
-		
-		//trigger update after returning from shell
-		app.nav.renew()
 
 		return
 	}

--- a/app.go
+++ b/app.go
@@ -525,6 +525,9 @@ func (app *app) runShell(s string, args []string, prefix string) {
 
 		//mark the current directory as updated for refresh
 		app.nav.currDir().updated = true
+		
+		//trigger update after returning from shell
+		app.nav.renew()
 
 		return
 	}

--- a/app.go
+++ b/app.go
@@ -522,6 +522,10 @@ func (app *app) runShell(s string, args []string, prefix string) {
 		cmd.Stderr = os.Stderr
 
 		app.runCmdSync(cmd, prefix == "!")
+
+		//mark the current directory as updated for refresh
+		app.nav.currDir().updated = true
+
 		return
 	}
 

--- a/nav.go
+++ b/nav.go
@@ -179,6 +179,7 @@ type dir struct {
 	ignoredia   bool       // ignoredia value from last sort
 	noPerm      bool       // whether lf has no permission to open the directory
 	lines       []string   // lines of text to display if directory previews are enabled
+	updated     bool       // directory has been updated after last dirCheck
 }
 
 func newDir(path string) *dir {
@@ -521,7 +522,7 @@ func (nav *nav) checkDir(dir *dir) {
 	}
 
 	switch {
-	case s.ModTime().After(dir.loadTime):
+	case s.ModTime().After(dir.loadTime) || dir.updated:
 		now := time.Now()
 
 		// XXX: Linux builtin exFAT drivers are able to predict modifications in the future
@@ -1372,6 +1373,8 @@ loop:
 	if errCount == 0 {
 		app.ui.exprChan <- &callExpr{"echo", []string{"\033[0;32mCopied successfully\033[0m"}, 1}
 	}
+	//mark the current directory as updated for refresh
+	nav.currDir().updated = true
 }
 
 func (nav *nav) moveAsync(app *app, srcs []string, dstDir string) {
@@ -1484,6 +1487,8 @@ func (nav *nav) moveAsync(app *app, srcs []string, dstDir string) {
 	if errCount == 0 {
 		app.ui.exprChan <- &callExpr{"echo", []string{"\033[0;32mMoved successfully\033[0m"}, 1}
 	}
+	//mark the current directory as updated for refresh
+	nav.currDir().updated = true
 }
 
 func (nav *nav) paste(app *app) error {


### PR DESCRIPTION
This adds the 'updated' member to the dir struct to trigger a manual update of the current directory after copy/move operations (when the period option is used).

Previously the directory information were only updated when the directory mtime was changed, which happens only during file creation but not after the file has finished copying.

Fixes #1417 , Fixes #1226 , Fixes #776

There are probably a few other bugs that can be fixed like this, but I would like some feedback on this approach first.