### PR TITLE
Fixed tags on windows

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -1926,10 +1926,15 @@ func (nav *nav) readTags() error {
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		path, tag, found := strings.Cut(scanner.Text(), ":")
-		if !found {
+		text := scanner.Text()
+
+		ind := strings.LastIndex(text, ":")
+		if ind == -1 {
 			return fmt.Errorf("invalid tags file entry: %s", scanner.Text())
 		}
+
+		path := text[0:ind]
+		tag := text[ind+1:]
 		if _, ok := nav.tags[path]; !ok {
 			nav.tags[path] = tag
 		}

--- a/nav.go
+++ b/nav.go
@@ -1930,7 +1930,7 @@ func (nav *nav) readTags() error {
 
 		ind := strings.LastIndex(text, ":")
 		if ind == -1 {
-			return fmt.Errorf("invalid tags file entry: %s", scanner.Text())
+			return fmt.Errorf("invalid tags file entry: %s", text)
 		}
 
 		path := text[0:ind]


### PR DESCRIPTION
fixes: https://github.com/gokcehan/lf/issues/1645

Split tags from the last `:` instead of first so the tags functionality will work on windows.