### PR TITLE
Clear cut buffer only when paste succeeds

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -1482,6 +1482,7 @@ func (nav *nav) moveAsync(app *app, srcs []string, dstDir string) {
 	}
 
 	if errCount == 0 {
+		app.ui.exprChan <- &callExpr{"clear", nil, 1}
 		app.ui.exprChan <- &callExpr{"echo", []string{"\033[0;32mMoved successfully\033[0m"}, 1}
 	}
 }
@@ -1502,19 +1503,6 @@ func (nav *nav) paste(app *app) error {
 		go nav.copyAsync(app, srcs, dstDir)
 	} else {
 		go nav.moveAsync(app, srcs, dstDir)
-		if err := saveFiles(nil, false); err != nil {
-			return fmt.Errorf("clearing copy/cut buffer: %s", err)
-		}
-
-		if gSingleMode {
-			if err := nav.sync(); err != nil {
-				return fmt.Errorf("paste: %s", err)
-			}
-		} else {
-			if err := remote("send sync"); err != nil {
-				return fmt.Errorf("paste: %s", err)
-			}
-		}
 	}
 
 	return nil


### PR DESCRIPTION
- Fixes #1651 

It can be annoying to to have to reselect the files if you accidentally try and paste into a directory without permissions. This only applies for `cut`, for `copy` the buffer isn't cleared anyway so it doesn't matter.