### PR TITLE
Ignore extension when renaming directory

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -2196,8 +2196,8 @@ func (e *callExpr) eval(app *app, args []string) {
 			normal(app)
 			app.ui.cmdPrefix = "rename: "
 			extension := filepath.Ext(curr.Name())
-			if len(extension) == 0 || extension == curr.Name() {
-				// no extension or .hidden
+			if len(extension) == 0 || extension == curr.Name() || curr.IsDir() {
+				// no extension or .hidden or is directory
 				app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(curr.Name())...)
 			} else {
 				app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(curr.Name()[:len(curr.Name())-len(extension)])...)


### PR DESCRIPTION
I noticed when renaming a directory that had a `.` in the name that it would put the cursor before the dot. It doesn't make sense to treat that as a file extension, so this PR ignores this logic when renaming a directory.