### PR TITLE
Skip drawing UI for period timer

### DIFF
--- a/app.go
+++ b/app.go
@@ -452,7 +452,6 @@ func (app *app) loop() {
 		case <-app.ticker.C:
 			app.nav.renew()
 			app.ui.loadFile(app, false)
-			app.ui.draw(app.nav)
 		case <-app.nav.previewTimer.C:
 			app.nav.previewLoading = true
 			app.ui.draw(app.nav)


### PR DESCRIPTION
- Fixes #1665

I don't think there's a need to draw the UI for the `period` timer, since it's supposed to just check for file modifications in the background. This is similar to #546, but for sixel images which are drawn directly in `ui.draw`.