### PR TITLE
update after copy/move

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -179,6 +179,7 @@ type dir struct {
 	ignoredia   bool       // ignoredia value from last sort
 	noPerm      bool       // whether lf has no permission to open the directory
 	lines       []string   // lines of text to display if directory previews are enabled
+	updated     bool       // directory has been updated after last dirCheck
 }
 
 func newDir(path string) *dir {
@@ -521,7 +522,7 @@ func (nav *nav) checkDir(dir *dir) {
 	}
 
 	switch {
-	case s.ModTime().After(dir.loadTime):
+	case s.ModTime().After(dir.loadTime) || dir.updated:
 		now := time.Now()
 
 		// XXX: Linux builtin exFAT drivers are able to predict modifications in the future
@@ -1372,6 +1373,8 @@ loop:
 	if errCount == 0 {
 		app.ui.exprChan <- &callExpr{"echo", []string{"\033[0;32mCopied successfully\033[0m"}, 1}
 	}
+	//mark the current directory as updated for refresh
+	nav.currDir().updated = true
 }
 
 func (nav *nav) moveAsync(app *app, srcs []string, dstDir string) {
@@ -1485,6 +1488,8 @@ func (nav *nav) moveAsync(app *app, srcs []string, dstDir string) {
 		app.ui.exprChan <- &callExpr{"clear", nil, 1}
 		app.ui.exprChan <- &callExpr{"echo", []string{"\033[0;32mMoved successfully\033[0m"}, 1}
 	}
+	//mark the current directory as updated for refresh
+	nav.currDir().updated = true
 }
 
 func (nav *nav) paste(app *app) error {


### PR DESCRIPTION
As suggested [here](https://github.com/gokcehan/lf/issues/1659#issuecomment-2028611735) this change would add the simple updated trigger after copy/move to cover most use cases.


 