### PR TITLE
update after return from shell

### DIFF
--- a/app.go
+++ b/app.go
@@ -514,6 +514,9 @@ func (app *app) runShell(s string, args []string, prefix string) {
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stderr
 		cmd.Stderr = os.Stderr
+		
+		//mark the current directory as updated for refresh
+		app.nav.currDir().updated = true
 
 		app.runCmdSync(cmd, prefix == "!")
 		return


### PR DESCRIPTION
This marks the current directory as updated before runCmdSync is executed and only for interactive shells.
Avoids [#1659](https://github.com/gokcehan/lf/issues/1659) 