### PR TITLE
Enable focus reporting only for hidecursorinactive

### DIFF
--- a/client.go
+++ b/client.go
@@ -36,7 +36,6 @@ func run() {
 	if gOpts.mouse {
 		screen.EnableMouse()
 	}
-	screen.EnableFocus()
 
 	if gLogPath != "" {
 		f, err := os.OpenFile(gLogPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)

--- a/eval.go
+++ b/eval.go
@@ -114,6 +114,13 @@ func (e *setExpr) eval(app *app, args []string) {
 		}
 	case "hidecursorinactive", "nohidecursorinactive", "hidecursorinactive!":
 		err = applyBoolOpt(&gOpts.hidecursorinactive, e)
+		if err == nil {
+			if gOpts.hidecursorinactive {
+				app.ui.screen.EnableFocus()
+			} else {
+				app.ui.screen.DisableFocus()
+			}
+		}
 	case "history", "nohistory", "history!":
 		err = applyBoolOpt(&gOpts.history, e)
 	case "icons", "noicons", "icons!":


### PR DESCRIPTION
- Fixes #1673 

`screen.EnableFocus` appears to be causing some issues on libvte-based terminals, so as a quick workaround I have changed it to be invoked only when the `hidecursorinactive` is enabled instead of by default.