### PR TITLE
Run `on-quit` when terminal closes

### DIFF
--- a/app.go
+++ b/app.go
@@ -64,6 +64,8 @@ func newApp(ui *ui, nav *nav) *app {
 }
 
 func (app *app) quit() {
+	onQuit(app)
+
 	if gOpts.history {
 		if err := app.writeHistory(); err != nil {
 			log.Printf("writing history file: %s", err)
@@ -318,10 +320,6 @@ func (app *app) loop() {
 			if app.nav.deleteTotal > 0 {
 				app.ui.echoerr("quit: delete operation in progress")
 				continue
-			}
-
-			if cmd, ok := gOpts.cmds["on-quit"]; ok {
-				cmd.eval(app, nil)
 			}
 
 			app.quit()

--- a/eval.go
+++ b/eval.go
@@ -569,6 +569,12 @@ func onSelect(app *app) {
 	}
 }
 
+func onQuit(app *app) {
+	if cmd, ok := gOpts.cmds["on-quit"]; ok {
+		cmd.eval(app, nil)
+	}
+}
+
 func splitKeys(s string) (keys []string) {
 	for i := 0; i < len(s); {
 		r, w := utf8.DecodeRuneInString(s[i:])


### PR DESCRIPTION
- Fixes #847

Move `on-quit` hook command to inside `app.quit` so that it is executed even when terminated via a signel (e.g. terminal is closed). Based on https://github.com/gokcehan/lf/issues/847#issuecomment-1158119232.