### PR TITLE
Taking hidden files parameter into account in windows

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -765,7 +765,7 @@ Otherwise, these characters are interpreted as they are.
 
 Show hidden files.
 On Unix systems, hidden files are determined by the value of `hiddenfiles`.
-On Windows, only files with hidden attributes are considered hidden files.
+On Windows, the files with the hidden attributes are also considered hidden files.
 
 ## hiddenfiles ([]string) (default `.*`)
 

--- a/doc.md
+++ b/doc.md
@@ -765,7 +765,7 @@ Otherwise, these characters are interpreted as they are.
 
 Show hidden files.
 On Unix systems, hidden files are determined by the value of `hiddenfiles`.
-On Windows, the files with hidden attributes are also considered hidden files.
+On Windows, files with hidden attributes are also considered hidden files.
 
 ## hiddenfiles ([]string) (default `.*`)
 

--- a/doc.md
+++ b/doc.md
@@ -158,7 +158,7 @@ The following options can be used to customize the behavior of lf:
 	globfilter          bool      (default false)
 	globsearch          bool      (default false)
 	hidden              bool      (default false)
-	hiddenfiles         []string  (default '.*')
+	hiddenfiles         []string  (default '.*' for Unix and '' for Windows)
 	hidecursorinactive  bool      (default false)
 	history             bool      (default true)
 	icons               bool      (default false)
@@ -767,7 +767,7 @@ Show hidden files.
 On Unix systems, hidden files are determined by the value of `hiddenfiles`.
 On Windows, files with hidden attributes are also considered hidden files.
 
-## hiddenfiles ([]string) (default `.*`)
+## hiddenfiles ([]string) (default `.*` for Unix and `` for Windows)
 
 List of hidden file glob patterns.
 Patterns can be given as relative or absolute paths.

--- a/doc.md
+++ b/doc.md
@@ -765,7 +765,7 @@ Otherwise, these characters are interpreted as they are.
 
 Show hidden files.
 On Unix systems, hidden files are determined by the value of `hiddenfiles`.
-On Windows, the files with the hidden attributes are also considered hidden files.
+On Windows, the files with hidden attributes are also considered hidden files.
 
 ## hiddenfiles ([]string) (default `.*`)
 

--- a/nav.go
+++ b/nav.go
@@ -751,7 +751,6 @@ func (nav *nav) previewLoop(ui *ui) {
 	}
 }
 
-//lint:ignore U1000 This function is not used on Windows
 func matchPattern(pattern, name, path string) bool {
 	s := name
 

--- a/opts.go
+++ b/opts.go
@@ -235,7 +235,7 @@ func init() {
 	gOpts.truncatechar = "~"
 	gOpts.truncatepct = 100
 	gOpts.ratios = []int{1, 2, 3}
-	gOpts.hiddenfiles = []string{".*"}
+	gOpts.hiddenfiles = gDefaultHiddenFiles
 	gOpts.history = true
 	gOpts.info = nil
 	gOpts.ruler = nil

--- a/os.go
+++ b/os.go
@@ -24,10 +24,11 @@ var (
 )
 
 var (
-	gDefaultShell      = "sh"
-	gDefaultShellFlag  = "-c"
-	gDefaultSocketProt = "unix"
-	gDefaultSocketPath string
+	gDefaultShell       = "sh"
+	gDefaultShellFlag   = "-c"
+	gDefaultSocketProt  = "unix"
+	gDefaultSocketPath  string
+	gDefaultHiddenFiles = []string{".*"}
 )
 
 var (

--- a/os_windows.go
+++ b/os_windows.go
@@ -181,7 +181,22 @@ func isHidden(f os.FileInfo, path string, hiddenfiles []string) bool {
 	if err != nil {
 		return false
 	}
-	return attrs&windows.FILE_ATTRIBUTE_HIDDEN != 0
+
+	if attrs&windows.FILE_ATTRIBUTE_HIDDEN != 0 {
+		return true
+	}
+
+	hidden := false
+	for _, pattern := range hiddenfiles {
+		matched := matchPattern(strings.TrimPrefix(pattern, "!"), f.Name(), path)
+		if strings.HasPrefix(pattern, "!") && matched {
+			hidden = false
+		} else if matched {
+			hidden = true
+		}
+	}
+
+	return hidden
 }
 
 func userName(f os.FileInfo) string {

--- a/os_windows.go
+++ b/os_windows.go
@@ -23,10 +23,11 @@ var (
 var envPathExt = os.Getenv("PATHEXT")
 
 var (
-	gDefaultShell      = "cmd"
-	gDefaultShellFlag  = "/c"
-	gDefaultSocketProt = "unix"
-	gDefaultSocketPath string
+	gDefaultShell       = "cmd"
+	gDefaultShellFlag   = "/c"
+	gDefaultSocketProt  = "unix"
+	gDefaultSocketPath  string
+	gDefaultHiddenFiles []string
 )
 
 var (


### PR DESCRIPTION
fixes: https://github.com/gokcehan/lf/issues/1683

On windows a file is considered hidden only if it has `FILE_ATTRIBUTE_HIDDEN` set. While this is the correct way to check if a file is hidden on windows, we should also take into account the `hiddenfiles` option so we can allow custom file patterns (ex. `__pycache__`, `obj`) as we can do on Linux.