### PR TITLE
Prevent preview flicker when directories are reloaded

### DIFF
--- a/app.go
+++ b/app.go
@@ -388,6 +388,11 @@ func (app *app) loop() {
 				app.nav.dirCache[d.path] = d
 			}
 
+			var oldCurrPath string
+			if curr, err := app.nav.currFile(); err == nil {
+				oldCurrPath = curr.path
+			}
+
 			for i := range app.nav.dirs {
 				if app.nav.dirs[i].path == d.path {
 					app.nav.dirs[i] = d
@@ -398,7 +403,7 @@ func (app *app) loop() {
 
 			curr, err := app.nav.currFile()
 			if err == nil {
-				if d.path == app.nav.currDir().path {
+				if curr.path != oldCurrPath {
 					app.ui.loadFile(app, true)
 					if app.ui.msgIsStat {
 						app.ui.loadFileInfo(app.nav)


### PR DESCRIPTION
It's still necessary to call `app.ui.loadFile` when a directory is modified and subsequently reloaded, for example if the file currently under the cursor is being deleted (results in selecting the next file). But I think it's not necessary if the current file doesn't change, otherwise this will cause image previews to flicker.