### PR TITLE
Fix crash when file is nil

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -88,7 +88,7 @@ func readdir(path string) ([]*file, error) {
 				dirSize:    -1,
 				accessTime: time.Unix(0, 0),
 				changeTime: time.Unix(0, 0),
-				ext:        getFileExtension(lstat),
+				ext:        "",
 				err:        err,
 			})
 			continue


### PR DESCRIPTION
Lf crashes when the cursor is on `openpgp-revocs.d` with

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x59663c]

goroutine 6 [running]:
main.getFileExtension({0x0, 0x0})
	github.com/gokcehan/lf/misc.go:306 +0x1c
main.readdir({0xc0002f0810, 0x2f})
	github.com/gokcehan/lf/nav.go:91 +0x325
main.newDir({0xc0002f0810, 0x2f})
	github.com/gokcehan/lf/nav.go:183 +0x53
main.(*nav).loadDirInternal.func1()
	github.com/gokcehan/lf/nav.go:484 +0x25
created by main.(*nav).loadDirInternal in goroutine 1
	github.com/gokcehan/lf/nav.go:483 +0x1fa
```

`file` gets dereferenced in `getFileExtension` even though it's `nil`.