### PR TITLE
Update lfcd.nu to remove the nushell error

### DIFF
--- a/etc/lfcd.nu
+++ b/etc/lfcd.nu
@@ -21,5 +21,5 @@
 
 # For nushell version >= 0.87.0
 def --env --wrapped lfcd [...args: string] { 
-  cd (lf -print-last-dir $args)
+  cd (lf -print-last-dir ...$args)
 }


### PR DESCRIPTION
The previous code caused a "Lists are not automatically spread when calling external commands" error telling to use a spread operator