### PR TITLE
Fix image previews containing long lines

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -890,25 +890,29 @@ func (nav *nav) preview(path string, win *win) {
 
 	// bufio.Scanner can't handle files containing long lines if they exceed the
 	// size of its internal buffer
-	addLine := true
+	line := []byte{}
 	for len(reg.lines) < win.h {
-		line, isPrefix, err := reader.ReadLine()
+		bytes, isPrefix, err := reader.ReadLine()
 		if err != nil {
+			if len(line) > 0 {
+				reg.lines = append(reg.lines, string(line))
+			}
 			break
 		}
 
-		for _, r := range line {
-			if r == 0 {
+		for _, byte := range bytes {
+			if byte == 0 {
 				reg.lines = []string{"\033[7mbinary\033[0m"}
 				return
 			}
 		}
 
-		if addLine {
-			reg.lines = append(reg.lines, string(line))
-		}
+		line = append(line, bytes...)
 
-		addLine = !isPrefix
+		if !isPrefix {
+			reg.lines = append(reg.lines, string(line))
+			line = []byte{}
+		}
 	}
 }
 


### PR DESCRIPTION
- Fixes #1736

To reproduce, use `chafa --polite on -f symbols -s "${2}x{3}" "$1"` for an image preview.