### PR TITLE
Rewrite sixel code to reduce flickering

### DIFF
--- a/sixel.go
+++ b/sixel.go
@@ -27,19 +27,38 @@ type sixelScreen struct {
 }
 
 func (sxs *sixelScreen) clearSixels(screen tcell.Screen) {
+	if sxs.sixel == nil {
+		return
+	}
+
 	win := sxs.win
 	for y := 0; y < win.h; y++ {
 		win.print(screen, 0, y, tcell.StyleDefault, strings.Repeat(string(gSixelFiller), win.w))
 	}
+
+	sxs.sixel = nil
 }
 
-func (sxs *sixelScreen) showSixels() {
+func (sxs *sixelScreen) setSixels(win *win, sixel *string) {
+	sxs.win = win
+	sxs.sixel = sixel
+}
+
+func (sxs *sixelScreen) showSixels(screen tcell.Screen, path string) {
 	if sxs.sixel == nil {
 		return
+	}
+
+	if path != sxs.lastFile {
+		tmp := sxs.sixel
+		sxs.clearSixels(screen)
+		sxs.sixel = tmp
 	}
 
 	fmt.Fprint(os.Stderr, "\0337")                                  // Save cursor position
 	fmt.Fprintf(os.Stderr, "\033[%d;%dH", sxs.win.y+1, sxs.win.x+1) // Move cursor to position
 	fmt.Fprint(os.Stderr, *sxs.sixel)                               //
 	fmt.Fprint(os.Stderr, "\0338")                                  // Restore cursor position
+
+	sxs.lastFile = path
 }

--- a/sixel.go
+++ b/sixel.go
@@ -30,9 +30,9 @@ func (sxs *sixelScreen) clearSixels(screen tcell.Screen) {
 		return
 	}
 
-	win := sxs.win
-	for y := 0; y < win.h; y++ {
-		win.print(screen, 0, y, tcell.StyleDefault, strings.Repeat(string(gSixelFiller), win.w))
+	filler := strings.Repeat(string(gSixelFiller), sxs.win.w)
+	for y := 0; y < sxs.win.h; y++ {
+		sxs.win.print(screen, 0, y, tcell.StyleDefault, filler)
 	}
 
 	sxs.sixel = nil

--- a/sixel.go
+++ b/sixel.go
@@ -15,8 +15,7 @@ const (
 	// - rarely used: the filler is used to trick tcell into redrawing, if the
 	//   filler character appears in the user's preview, that cell might not
 	//   be cleaned up properly
-	// - ideally renders as empty space: the filler alternates between bold
-	//   and regular, using a non-space would look weird to the user.
+	// - ideally renders as empty space
 	gSixelFiller = '\u2000'
 )
 

--- a/ui.go
+++ b/ui.go
@@ -268,8 +268,7 @@ func (win *win) printReg(screen tcell.Screen, reg *reg, previewLoading bool, sxs
 	}
 
 	if reg.sixel != nil {
-		sxs.sixel = reg.sixel
-		sxs.win = win
+		sxs.setSixels(win, reg.sixel)
 	} else {
 		sxs.clearSixels(screen)
 	}
@@ -1032,7 +1031,6 @@ func (ui *ui) draw(nav *nav) {
 	context := dirContext{selections: nav.selections, saves: nav.saves, tags: nav.tags}
 
 	ui.screen.Clear()
-	ui.sxScreen.sixel = nil
 
 	ui.drawPromptLine(nav)
 
@@ -1076,7 +1074,7 @@ func (ui *ui) draw(nav *nav) {
 		if err == nil {
 			preview := ui.wins[len(ui.wins)-1]
 
-			if ui.menuBuf != nil || ui.cmdPrefix != "" {
+			if ui.menuBuf != nil {
 				ui.sxScreen.clearSixels(ui.screen)
 			}
 
@@ -1116,12 +1114,8 @@ func (ui *ui) draw(nav *nav) {
 	}
 
 	ui.screen.Show()
-	if ui.menuBuf == nil && ui.cmdPrefix == "" && ui.sxScreen.sixel != nil {
-		if ui.regPrev.path != ui.sxScreen.lastFile {
-			ui.sxScreen.clearSixels(ui.screen)
-		}
-		ui.sxScreen.showSixels()
-		ui.sxScreen.lastFile = ui.regPrev.path
+	if ui.menuBuf == nil && ui.sxScreen.sixel != nil {
+		ui.sxScreen.showSixels(ui.screen, ui.regPrev.path)
 	}
 }
 


### PR DESCRIPTION
After upgrading `tcell`, it looks like there's increased flickering because the original Sixel implementation relies on some hacky behavior in `tcell` which has since been fixed.

This PR is an attempt to reduce the flickering, it works on my setup but I'm keeping it as a draft for the time being since it is a risky change. Hopefully it works for others too, if not I will just close it.

---

Feedback is welcome, particular suggestions above improvements to the actual code.