### PR TITLE
Use 32KB buffer for `copyFile()` (reduces copy time by 30%)

### DIFF
--- a/app.go
+++ b/app.go
@@ -332,7 +332,7 @@ func (app *app) loop() {
 			return
 		case n := <-app.nav.copyBytesChan:
 			app.nav.copyBytes += n
-			// n is usually 4096B so update roughly per 4096B x 1024 = 4MB copied
+			// n is usually 32*1024B (default io.Copy() buffer) so update roughly per 32KB x 1024 = 32MB copied
 			if app.nav.copyUpdate++; app.nav.copyUpdate >= 1024 {
 				app.nav.copyUpdate = 0
 				app.ui.draw(app.nav)

--- a/app.go
+++ b/app.go
@@ -332,8 +332,8 @@ func (app *app) loop() {
 			return
 		case n := <-app.nav.copyBytesChan:
 			app.nav.copyBytes += n
-			// n is usually 32*1024B (default io.Copy() buffer) so update roughly per 32KB x 1024 = 32MB copied
-			if app.nav.copyUpdate++; app.nav.copyUpdate >= 1024 {
+			// n is usually 32*1024B (default io.Copy() buffer) so update roughly per 32KB x 128 = 4MB copied
+			if app.nav.copyUpdate++; app.nav.copyUpdate >= 128 {
 				app.nav.copyUpdate = 0
 				app.ui.draw(app.nav)
 			}

--- a/copy.go
+++ b/copy.go
@@ -11,6 +11,24 @@ import (
 	"github.com/djherbis/times"
 )
 
+type ProgressWriter struct {
+	writer io.Writer
+	nums   chan<- int64
+}
+
+func NewProgressWriter(writer io.Writer, nums chan<- int64) *ProgressWriter {
+	return &ProgressWriter{
+		writer: writer,
+		nums:   nums,
+	}
+}
+
+func (progressWriter *ProgressWriter) Write(b []byte) (int, error) {
+	n, err := progressWriter.writer.Write(b)
+	progressWriter.nums <- int64(n)
+	return n, err
+}
+
 func copySize(srcs []string) (int64, error) {
 	var total int64
 
@@ -47,8 +65,6 @@ func copyFile(src, dst string, preserve []string, info os.FileInfo, nums chan in
 		}
 	}
 
-	buf := make([]byte, 32*1024)
-
 	r, err := os.Open(src)
 	if err != nil {
 		return err
@@ -60,23 +76,13 @@ func copyFile(src, dst string, preserve []string, info os.FileInfo, nums chan in
 		return err
 	}
 
-	for {
-		n, err := r.Read(buf)
-		if err != nil && err != io.EOF {
-			w.Close()
-			os.Remove(dst)
-			return err
-		}
-
-		if n == 0 {
-			break
-		}
-
-		if _, err := w.Write(buf[:n]); err != nil {
-			return err
-		}
-
-		nums <- int64(n)
+	_, err = io.Copy(NewProgressWriter(w, nums), r)
+	if err == io.ErrShortWrite {
+		return err
+	} else if err != nil {
+		w.Close()
+		os.Remove(dst)
+		return err
 	}
 
 	if err := w.Close(); err != nil {

--- a/copy.go
+++ b/copy.go
@@ -47,7 +47,7 @@ func copyFile(src, dst string, preserve []string, info os.FileInfo, nums chan in
 		}
 	}
 
-	buf := make([]byte, 4096)
+	buf := make([]byte, 32*1024)
 
 	r, err := os.Open(src)
 	if err != nil {

--- a/copy.go
+++ b/copy.go
@@ -77,9 +77,7 @@ func copyFile(src, dst string, preserve []string, info os.FileInfo, nums chan in
 	}
 
 	_, err = io.Copy(NewProgressWriter(w, nums), r)
-	if err == io.ErrShortWrite {
-		return err
-	} else if err != nil {
+	if err != nil {
 		w.Close()
 		os.Remove(dst)
 		return err


### PR DESCRIPTION
Fixes #1685

This makes `:paste` comparable in performance to `cp --reflink=never` for large files.

For large number of small files improvements are less substantial (compared to `cp -r --reflink=never`), though still noticeable.

In both cases the copy takes about 30% less time than with `buf` size at 4096.

32KB is the same number `io.Copy()` uses internally (when it can), and is about where improvements stop.

Testing of other possible values for `buf` size, relevant channels, and `app.ui.draw(app.nav)` interval during progress output, and their influence on copy performance:
https://github.com/gokcehan/lf/issues/1685#issuecomment-2163934296