### PR TITLE
Invalidate cache for recreated files

### DIFF
--- a/app.go
+++ b/app.go
@@ -45,7 +45,7 @@ func newApp(ui *ui, nav *nav) *app {
 		nav:      nav,
 		ticker:   new(time.Ticker),
 		quitChan: quitChan,
-		watch:    newWatch(nav.dirChan, nav.fileChan),
+		watch:    newWatch(nav.dirChan, nav.fileChan, nav.delChan),
 	}
 
 	sigChan := make(chan os.Signal, 1)
@@ -457,6 +457,9 @@ func (app *app) loop() {
 
 			app.ui.loadFile(app, false)
 			app.ui.draw(app.nav)
+		case path := <-app.nav.delChan:
+			delete(app.nav.dirCache, path)
+			delete(app.nav.regCache, path)
 		case ev := <-app.ui.evChan:
 			e := app.ui.readEvent(ev, app.nav)
 			if e == nil {

--- a/eval.go
+++ b/eval.go
@@ -1396,7 +1396,7 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.ui.loadFile(app, true)
 		onRedraw(app)
 	case "load":
-		if !app.nav.init {
+		if !app.nav.init || gOpts.watch {
 			return
 		}
 		app.nav.renew()

--- a/nav.go
+++ b/nav.go
@@ -1530,7 +1530,7 @@ func (nav *nav) del(app *app) error {
 		if gSingleMode {
 			nav.renew()
 			app.ui.loadFile(app, true)
-		} else {
+		} else if !gOpts.watch {
 			if err := remote("send load"); err != nil {
 				errCount++
 				echo.args[0] = fmt.Sprintf("[%d] %s", errCount, err)

--- a/nav.go
+++ b/nav.go
@@ -1530,7 +1530,7 @@ func (nav *nav) del(app *app) error {
 		if gSingleMode {
 			nav.renew()
 			app.ui.loadFile(app, true)
-		} else if !gOpts.watch {
+		} else {
 			if err := remote("send load"); err != nil {
 				errCount++
 				echo.args[0] = fmt.Sprintf("[%d] %s", errCount, err)

--- a/nav.go
+++ b/nav.go
@@ -439,6 +439,7 @@ type nav struct {
 	dirChan         chan *dir
 	regChan         chan *reg
 	fileChan        chan *file
+	delChan         chan string
 	dirCache        map[string]*dir
 	regCache        map[string]*reg
 	saves           map[string]bool
@@ -585,6 +586,7 @@ func newNav(height int) *nav {
 		dirChan:         make(chan *dir),
 		regChan:         make(chan *reg),
 		fileChan:        make(chan *file),
+		delChan:         make(chan string),
 		dirCache:        make(map[string]*dir),
 		regCache:        make(map[string]*reg),
 		saves:           make(map[string]bool),

--- a/watch.go
+++ b/watch.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -101,6 +102,9 @@ func (watch *watch) loop() {
 			}
 		case <-watch.loadTimer.C:
 			for path := range watch.loads {
+				if _, err := os.Lstat(path); err != nil {
+					continue
+				}
 				dir := newDir(path)
 				dir.sort()
 				watch.dirChan <- dir
@@ -108,6 +112,9 @@ func (watch *watch) loop() {
 			watch.loads = make(map[string]bool)
 		case <-watch.updateTimer.C:
 			for path := range watch.updates {
+				if _, err := os.Lstat(path); err != nil {
+					continue
+				}
 				watch.fileChan <- newFile(path)
 			}
 			watch.updates = make(map[string]bool)


### PR DESCRIPTION
Invalidate `nav.dirCache` and `nav.regCache` when receiving a remove/rename update from `fsnotify`, plus a couple of useful other nice to have fixes.