### PR TITLE
fix(lfcd.cmd) : cd to other drive / fix non-english encoding

### DIFF
--- a/etc/lfcd.cmd
+++ b/etc/lfcd.cmd
@@ -3,4 +3,5 @@ rem Change working dir in cmd.exe to last dir in lf on exit.
 rem
 rem You need to put this file to a folder in %PATH% variable.
 
-for /f "usebackq tokens=*" %%d in (`lf -print-last-dir %*`) do cd %%d
+chcp 65001 > nul 2>&1
+for /f "usebackq tokens=*" %%d in (`lf -print-last-dir %*`) do cd /d %%d


### PR DESCRIPTION
To fix #1769 
1) add `/d` to cd command for moving other drive
2) change code page number to read non-english output of `lf -print-last-dir` although current code page is 949