### PR TITLE
fixed windows terminal icon colors cut off on overhanging icons

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -502,6 +502,7 @@ func (win *win) printDir(ui *ui, dir *dir, context *dirContext, dirStyle *dirSty
 
 		if icon.hasStyle && i != dir.pos {
 			win.print(ui.screen, lnwidth+2, i, icon.style, icon.icon)
+			win.print(ui.screen, lnwidth+3, i, icon.style, " ")
 		}
 
 		tag, ok := context.tags[path]

--- a/ui.go
+++ b/ui.go
@@ -502,7 +502,7 @@ func (win *win) printDir(ui *ui, dir *dir, context *dirContext, dirStyle *dirSty
 
 		if icon.hasStyle && i != dir.pos {
 			win.print(ui.screen, lnwidth+2, i, icon.style, icon.icon)
-			win.print(ui.screen, lnwidth+3, i, icon.style, " ")
+			win.print(ui.screen, lnwidth+3, i, icon.style, " ") // this fixes an issue in windows terminal with icon colors being cut off
 		}
 
 		tag, ok := context.tags[path]


### PR DESCRIPTION
on windows terminal for some reason icon colors are cut off if the icon overhangs this happens on other terminal programs too. the fix is to print a space after the icon with the same style

before:
![before](https://raw.githubusercontent.com/BPplays/images/main/issues/lf/fwt1/before.webp)

after:
![after](https://raw.githubusercontent.com/BPplays/images/main/issues/lf/fwt1/after.webp)