### PR TITLE
Fix printing tags if it contains color

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -445,9 +445,9 @@ func (win *win) printDir(ui *ui, dir *dir, context *dirContext, dirStyle *dirSty
 			maxWidth -= 1
 		}
 
-		tag := ' '
+		tag := " "
 		if val, ok := context.tags[path]; ok && len(val) > 0 {
-			tag = rune(val[0])
+			tag = val
 		}
 
 		var icon []rune
@@ -493,14 +493,16 @@ func (win *win) printDir(ui *ui, dir *dir, context *dirContext, dirStyle *dirSty
 			case Preview:
 				cursorFmt = optionToFmtstr(gOpts.cursorpreviewfmt)
 			}
-			line := append([]rune{tag}, icon...)
-			line = append(line, filename...)
-			line = append(line, ' ')
-			win.print(ui.screen, lnwidth+1, i, st, fmt.Sprintf(cursorFmt, string(line)))
 
+			// print tag separately as it can contain color escape sequences
+			win.print(ui.screen, lnwidth+1, i, st, fmt.Sprintf(cursorFmt, tag))
+
+			line := append(icon, filename...)
+			line = append(line, ' ')
+			win.print(ui.screen, lnwidth+2, i, st, fmt.Sprintf(cursorFmt, string(line)))
 		} else {
-			if tag != ' ' {
-				tagStr := fmt.Sprintf(optionToFmtstr(gOpts.tagfmt), string(tag))
+			if tag != " " {
+				tagStr := fmt.Sprintf(optionToFmtstr(gOpts.tagfmt), tag)
 				win.print(ui.screen, lnwidth+1, i, tcell.StyleDefault, tagStr)
 			}
 


### PR DESCRIPTION
Apparently it's possible for tags to contain color, for example:

```sh
:tag "\033[31m-"
```
```sh
:tag "\033[32m+"
```

This no longer displays properly after b819d90be20eab1ba2f62f8f4e4976288d872f8f, so this PR fixes it.