### PR TITLE
Display line numbers on the main window only

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -392,7 +392,7 @@ func (win *win) printDir(ui *ui, dir *dir, context *dirContext, dirStyle *dirSty
 
 	var lnwidth int
 
-	if gOpts.number || gOpts.relativenumber {
+	if dirStyle.role == Active && (gOpts.number || gOpts.relativenumber) {
 		lnwidth = 1
 		if gOpts.number && gOpts.relativenumber {
 			lnwidth++


### PR DESCRIPTION
**Related issues:**

- Fixes #1751
- Supersedes #1752 

---

Currently the `number` and `relativenumber` options display line numbers on all windows. This is in contrast to other file managers like `ranger` and `joshuto`, which display line numbers on the main window only.

> [!WARNING]
> This is a **breaking change** as it modifies the existing behavior of the UI. If anyone is against this, we can instead consider adding an option to toggle this behavior.