### PR TITLE
fix: optimize speed of retrieving user/group widths

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -412,16 +412,12 @@ func (win *win) printDir(ui *ui, dir *dir, context *dirContext, dirStyle *dirSty
 	var groupWidth int
 
 	// Only fetch user/group widths if configured to display them
+iterInfo:
 	for _, s := range getInfo(dir.path) {
 		switch s {
-		case "user":
-			userWidth = getUserWidth(dir, beg, end)
-		case "group":
-			groupWidth = getGroupWidth(dir, beg, end)
-		}
-
-		if userWidth > 0 && groupWidth > 0 {
-			break
+		case "user", "group":
+			userWidth, groupWidth = getUserGroupWidth(dir, beg, end)
+			break iterInfo
 		}
 	}
 
@@ -542,24 +538,16 @@ func (win *win) printDir(ui *ui, dir *dir, context *dirContext, dirStyle *dirSty
 	}
 }
 
-func getUserWidth(dir *dir, beg int, end int) int {
-	maxw := 0
+func getUserGroupWidth(dir *dir, beg int, end int) (int, int) {
+	userMaxw := 0
+	groupMaxw := 0
 
 	for _, f := range dir.files[beg:end] {
-		maxw = max(len(userName(f.FileInfo)), maxw)
+		userMaxw = max(len(userName(f.FileInfo)), userMaxw)
+		groupMaxw = max(len(groupName(f.FileInfo)), groupMaxw)
 	}
 
-	return maxw
-}
-
-func getGroupWidth(dir *dir, beg int, end int) int {
-	maxw := 0
-
-	for _, f := range dir.files[beg:end] {
-		maxw = max(len(groupName(f.FileInfo)), maxw)
-	}
-
-	return maxw
+	return userMaxw, groupMaxw
 }
 
 func getWidths(wtot int) []int {


### PR DESCRIPTION
After using the new user and group info parameters for a while I have started to notice an occasional slow-down, when quickly navigating down/up in the same directory.

I investigated the time it would take retrieve user and group max widths, where total is the whole getInfo loop:

Unoptimized, average over N=58, time in ms:
| getUserWidth | getGroupWidth | Total |
|--------|--------|--------|
| 0.01 | 15.59 | 15.62 |

Optimized, average over N=80, time in ms:
| getUserGroup | Total |
|--------|--------|
| 0.01 | 0.03 |

I'm not really sure why getGroupWidth was so slow.

15 ms is not slow enough that I would notice it, what I experienced was that the UI would freeze for about 1 second. But it's probably related to the cause of it.