### PR TITLE
Clear fileinfo if the directory is empty

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -773,6 +773,9 @@ func (ui *ui) loadFileInfo(nav *nav) {
 		return
 	}
 
+	ui.msg = ""
+	ui.msgIsStat = true
+
 	curr, err := nav.currFile()
 	if err != nil {
 		return
@@ -807,7 +810,6 @@ func (ui *ui) loadFileInfo(nav *nav) {
 	}
 
 	ui.msg = fileInfo
-	ui.msgIsStat = true
 }
 
 func (ui *ui) drawPromptLine(nav *nav) {


### PR DESCRIPTION
**Related issues:**

- Fixes #1807 

When changing into an empty directory, the fileinfo still shows the stat of the previous file.