### PR TITLE
lfrc.example: double quotes for filename with spaces

### DIFF
--- a/etc/lfrc.example
+++ b/etc/lfrc.example
@@ -44,7 +44,7 @@ map O $mimeopen --ask $f
 cmd open &{{
     case $(file --mime-type -Lb $f) in
         text/*) lf -remote "send $id \$$EDITOR \$fx";;
-        *) for f in $fx; do $OPENER $f > /dev/null 2> /dev/null & done;;
+        *) for f in "$fx"; do $OPENER "$f" > /dev/null 2> /dev/null & done;;
     esac
 }}
 


### PR DESCRIPTION
this will fix a minor bug in the lfrc.example so that people can have it working,
" double quotes around $fx and $f "