### PR TITLE
Prevent infinite loop when using `on-quit`

### DIFF
--- a/app.go
+++ b/app.go
@@ -35,6 +35,7 @@ type app struct {
 	menuCompInd    int
 	selectionOut   []string
 	watch          *watch
+	quitting       bool
 }
 
 func newApp(ui *ui, nav *nav) *app {
@@ -66,6 +67,14 @@ func newApp(ui *ui, nav *nav) *app {
 }
 
 func (app *app) quit() {
+	// Using synchronous shell commands for `on-quit` can cause this to be
+	// called again, so a guard variable is introduced here to prevent an
+	// infinite loop.
+	if app.quitting {
+		return
+	}
+	app.quitting = true
+
 	onQuit(app)
 
 	if gOpts.history {


### PR DESCRIPTION
- Fixes #1819
- Fixes #1854

To reproduce, use the following config, start `lf` and then close the terminal window:

```
cmd on-quit ${{
    notify-send foo
    sleep 1
}}
```

Because the terminal is already closed, running `on-quit` as a synchronous shell command will cause `app.quit` to be called again, forming an infinite loop.