### PR TITLE
Add workaround for equivalent paths for watch option

### DIFF
--- a/app.go
+++ b/app.go
@@ -427,7 +427,7 @@ func (app *app) loop() {
 				}
 			}
 
-			app.addWatchPaths()
+			app.watchDir(d)
 
 			app.ui.draw(app.nav)
 		case r := <-app.nav.regChan:
@@ -633,21 +633,17 @@ func (app *app) runShell(s string, args []string, prefix string) {
 	}
 }
 
-func (app *app) addWatchPaths() {
-	if !gOpts.watch || len(app.nav.dirs) == 0 {
+func (app *app) watchDir(dir *dir) {
+	if !gOpts.watch {
 		return
 	}
 
-	paths := make(map[string]bool)
-	for _, dir := range app.nav.dirs {
-		paths[dir.path] = true
-	}
+	app.watch.add(dir.path)
 
-	for _, file := range app.nav.currDir().allFiles {
+	// ensure dircounts are updated for child directories
+	for _, file := range dir.allFiles {
 		if file.IsDir() {
-			paths[file.path] = true
+			app.watch.add(file.path)
 		}
 	}
-
-	app.watch.add(paths)
 }

--- a/eval.go
+++ b/eval.go
@@ -195,7 +195,9 @@ func (e *setExpr) eval(app *app, args []string) {
 		if err == nil {
 			if gOpts.watch {
 				app.watch.start()
-				app.addWatchPaths()
+				for _, dir := range app.nav.dirCache {
+					app.watchDir(dir)
+				}
 			} else {
 				app.watch.stop()
 			}
@@ -582,7 +584,6 @@ func preChdir(app *app) {
 
 func onChdir(app *app) {
 	app.nav.addJumpList()
-	app.addWatchPaths()
 	if cmd, ok := gOpts.cmds["on-cd"]; ok {
 		cmd.eval(app, nil)
 	}

--- a/watch.go
+++ b/watch.go
@@ -143,6 +143,8 @@ func (watch *watch) addUpdate(path string) {
 	watch.updates[path] = true
 }
 
+// Hacky workaround since fsnotify reports changes for only one path if a
+// directory is located at more than one path.
 func (watch *watch) getSameDirs(dir string) []string {
 	var paths []string
 

--- a/watch.go
+++ b/watch.go
@@ -64,16 +64,14 @@ func (watch *watch) stop() {
 	watch.events = nil
 }
 
-func (watch *watch) add(paths map[string]bool) {
+func (watch *watch) add(path string) {
 	if watch.watcher == nil {
 		return
 	}
 
-	for path := range paths {
-		// ignore /dev since write updates to /dev/tty causes high cpu usage
-		if path != "/dev" {
-			watch.watcher.Add(path)
-		}
+	// ignore /dev since write updates to /dev/tty causes high cpu usage
+	if path != "/dev" {
+		watch.watcher.Add(path)
 	}
 }
 
@@ -144,7 +142,7 @@ func (watch *watch) addUpdate(path string) {
 }
 
 // Hacky workaround since fsnotify reports changes for only one path if a
-// directory is located at more than one path.
+// directory is located at more than one path (e.g. bind mounts).
 func (watch *watch) getSameDirs(dir string) []string {
 	var paths []string
 


### PR DESCRIPTION
- Fixes #1894 

Changes:

- Whenever a watched directory receives an event from `fsnotify`, updates are now additionally sent to other watched directories that are equivalent (i.e. point to the same inode, for example bind mounts).
- The logic for watching directories is simplified. Now instead of calculating which paths to watch whenever the changing directories (e.g. using the `updir`/`open`/`cd` commands), directories will now be watched whenever it is loaded (i.e. added to the directory cache). 