### PR TITLE
Add support for underline styles

### DIFF
--- a/colors_test.go
+++ b/colors_test.go
@@ -35,6 +35,14 @@ func TestApplyAnsiCodes(t *testing.T) {
 		{"4", none.Bold(true), none.Bold(true).Underline(true)},
 		{"4", none.Foreground(tcell.ColorMaroon).Bold(true), none.Foreground(tcell.ColorMaroon).Bold(true).Underline(true)},
 
+		{"4:0", none, none},
+		{"4:0", none.Underline(true), none},
+		{"4:1", none, none.Underline(true)},
+		{"4:2", none, none.Underline(tcell.UnderlineStyleDouble)},
+		{"4:3", none, none.Underline(tcell.UnderlineStyleCurly)},
+		{"4:4", none, none.Underline(tcell.UnderlineStyleDotted)},
+		{"4:5", none, none.Underline(tcell.UnderlineStyleDashed)},
+
 		{"31", none, none.Foreground(tcell.ColorMaroon)},
 		{"31", none.Foreground(tcell.ColorGreen), none.Foreground(tcell.ColorMaroon)},
 		{"31", none.Foreground(tcell.ColorGreen).Bold(true), none.Foreground(tcell.ColorMaroon).Bold(true)},


### PR DESCRIPTION
- Fixes #1232

---

Add support for the following terminal escape sequences which set underline styles:

|  Escape sequence | Description |
| --- | --- |
| `\033[4:0m` | No underline |
| `\033[4:1m` | Single underline (same as `\033[4m`) |
| `\033[4:2m` | Double underline |
| `\033[4:3m` | Curly underline |
| `\033[4:4m` | Dotted underline |
| `\033[4:5m` | Dashed underline |

Sample config for testing:

```sh
cmd test &{{
    lf -remote "send $id set cursorpreviewfmt \"\033[4:0m\""
    sleep 1
    lf -remote "send $id set cursorpreviewfmt \"\033[4:1m\""
    sleep 1
    lf -remote "send $id set cursorpreviewfmt \"\033[4:2m\""
    sleep 1
    lf -remote "send $id set cursorpreviewfmt \"\033[4:3m\""
    sleep 1
    lf -remote "send $id set cursorpreviewfmt \"\033[4:4m\""
    sleep 1
    lf -remote "send $id set cursorpreviewfmt \"\033[4:5m\""
    sleep 1
    lf -remote "send $id set cursorpreviewfmt \"\033[4m\""
}}
```