### PR TITLE
Automatically unselect files after watch remove

### DIFF
--- a/app.go
+++ b/app.go
@@ -467,6 +467,11 @@ func (app *app) loop() {
 		case path := <-app.nav.delChan:
 			delete(app.nav.dirCache, path)
 			delete(app.nav.regCache, path)
+
+			delete(app.nav.selections, path)
+			if len(app.nav.selections) == 0 {
+				app.nav.selectionInd = 0
+			}
 		case ev := <-app.ui.evChan:
 			e := app.ui.readEvent(ev, app.nav)
 			if e == nil {


### PR DESCRIPTION
Related issues:

- Fixes #1900

To reproduce:

1. Enable the `watch` option
2. `select` some files
3. Use some external process (e.g. start a new terminal) and rename/move/delete the files

The expected behavior is that the file paths should be automatically unselected when they no longer exist (i.e. removed from `$fs`/`$fx`).