### PR TITLE
fix non-constant format string

### DIFF
--- a/diacritics_test.go
+++ b/diacritics_test.go
@@ -63,10 +63,10 @@ func runSearch(t *testing.T, ignorecase, smartcase, ignorediacritics, smartdiacr
 	gOpts.smartdia = smartdiacritics
 	matched, _ := searchMatch(base, pattern, false)
 	if matched != expected {
-		t.Errorf("False search for" +
-			" ignorecase = " + strconv.FormatBool(gOpts.ignorecase) + ", " +
-			" smartcase = " + strconv.FormatBool(gOpts.smartcase) + ", " +
-			" ignoredia = " + strconv.FormatBool(gOpts.ignoredia) + ", " +
-			" smartdia = " + strconv.FormatBool(gOpts.smartdia) + ", ")
+		t.Errorf("False search for ignorecase = %s, smartcase = %s, ignoredia = %s, smartdia = %s",
+			strconv.FormatBool(gOpts.ignorecase),
+			strconv.FormatBool(gOpts.smartcase),
+			strconv.FormatBool(gOpts.ignoredia),
+			strconv.FormatBool(gOpts.smartdia))
 	}
 }


### PR DESCRIPTION
Go version 1.24 throws an error with non-constant format string for `Errorf`. I don't see this error when building lf normally, but it appears consistently when doing builds for Fedora. [example](https://copr.fedorainfracloud.org/coprs/pennbauman/ports/build/8632944/)

This patch also cleans up the formatting of the affected error. It removes duplicate spaces and a trailing comma.