### PR TITLE
verify the Trash directory exists before moving files there

### DIFF
--- a/etc/lfrc.example
+++ b/etc/lfrc.example
@@ -60,7 +60,7 @@ map a :push %mkdir<space>
 
 # move current file or selected files to trash folder
 # (also see 'man mv' for backup/overwrite options)
-cmd trash %set -f; mv $fx -t ~/.trash
+cmd trash %set -f; mv -t ~/.trash $fx
 
 # define a custom 'delete' command
 # cmd delete ${{

--- a/etc/lfrc.example
+++ b/etc/lfrc.example
@@ -60,7 +60,7 @@ map a :push %mkdir<space>
 
 # move current file or selected files to trash folder
 # (also see 'man mv' for backup/overwrite options)
-cmd trash %set -f; mv $fx ~/.trash
+cmd trash %set -f; mv $fx -t ~/.trash
 
 # define a custom 'delete' command
 # cmd delete ${{


### PR DESCRIPTION
The current lfrc.example file already contains the hint to create the `~./trash` directory, but the default delete command will always try to move any files to this path, making it a regular file instead if the directory is missing.
This change will instead return an error about the missing Trash directory.