### PR TITLE
Add function for parsing SGR colors

### DIFF
--- a/colors.go
+++ b/colors.go
@@ -196,7 +196,7 @@ loop:
 		case "48":
 			color, offset, err := parseColor(toks[i+1:])
 			if err != nil {
-				log.Printf("error processing ansi code 38: %s", err)
+				log.Printf("error processing ansi code 48: %s", err)
 				break loop
 			}
 			st = st.Background(color)

--- a/colors.go
+++ b/colors.go
@@ -98,13 +98,13 @@ func parseEscapeSequence(s string) tcell.Style {
 
 func parseColor(toks []string) (tcell.Color, int, error) {
 	if len(toks) == 0 {
-		return tcell.ColorDefault, 0, fmt.Errorf("incorrect form: %v", toks)
+		return tcell.ColorDefault, 0, fmt.Errorf("invalid args: %v", toks)
 	}
 
 	if toks[0] == "5" && len(toks) >= 2 {
 		n, err := strconv.Atoi(toks[1])
 		if err != nil {
-			return tcell.ColorDefault, 0, fmt.Errorf("incorrect form: %v", toks)
+			return tcell.ColorDefault, 0, fmt.Errorf("invalid args: %v", toks)
 		}
 
 		return tcell.PaletteColor(n), 2, nil
@@ -113,23 +113,23 @@ func parseColor(toks []string) (tcell.Color, int, error) {
 	if toks[0] == "2" && len(toks) >= 4 {
 		r, err := strconv.Atoi(toks[1])
 		if err != nil {
-			return tcell.ColorDefault, 0, fmt.Errorf("incorrect form: %v", toks)
+			return tcell.ColorDefault, 0, fmt.Errorf("invalid args: %v", toks)
 		}
 
 		g, err := strconv.Atoi(toks[2])
 		if err != nil {
-			return tcell.ColorDefault, 0, fmt.Errorf("incorrect form: %v", toks)
+			return tcell.ColorDefault, 0, fmt.Errorf("invalid args: %v", toks)
 		}
 
 		b, err := strconv.Atoi(toks[3])
 		if err != nil {
-			return tcell.ColorDefault, 0, fmt.Errorf("incorrect form: %v", toks)
+			return tcell.ColorDefault, 0, fmt.Errorf("invalid args: %v", toks)
 		}
 
 		return tcell.NewRGBColor(int32(r), int32(g), int32(b)), 4, nil
 	}
 
-	return tcell.ColorDefault, 0, fmt.Errorf("incorrect form: %v", toks)
+	return tcell.ColorDefault, 0, fmt.Errorf("invalid args: %v", toks)
 }
 
 func applyAnsiCodes(s string, st tcell.Style) tcell.Style {

--- a/colors.go
+++ b/colors.go
@@ -139,6 +139,8 @@ func applyAnsiCodes(s string, st tcell.Style) tcell.Style {
 	// TODO: should we support turning off attributes?
 	//    Probably because this is used for previewers too
 	tokslen := len(toks)
+
+loop:
 	for i := 0; i < tokslen; i++ {
 		switch strings.TrimLeft(toks[i], "0") {
 		case "":
@@ -181,7 +183,7 @@ func applyAnsiCodes(s string, st tcell.Style) tcell.Style {
 			color, offset, err := parseColor(toks[i+1:])
 			if err != nil {
 				log.Printf("error processing ansi code 38: %s", err)
-				break
+				break loop
 			}
 			st = st.Foreground(color)
 			i += offset
@@ -195,7 +197,7 @@ func applyAnsiCodes(s string, st tcell.Style) tcell.Style {
 			color, offset, err := parseColor(toks[i+1:])
 			if err != nil {
 				log.Printf("error processing ansi code 38: %s", err)
-				break
+				break loop
 			}
 			st = st.Background(color)
 			i += offset

--- a/colors_test.go
+++ b/colors_test.go
@@ -6,6 +6,35 @@ import (
 	"github.com/gdamore/tcell/v2"
 )
 
+func TestParseColor(t *testing.T) {
+	tests := []struct {
+		toks    []string
+		color   tcell.Color
+		offset  int
+		success bool
+	}{
+		{[]string{}, tcell.ColorDefault, 0, false},
+		{[]string{"foo"}, tcell.ColorDefault, 0, false},
+		{[]string{"5"}, tcell.ColorDefault, 0, false},
+		{[]string{"5", "foo"}, tcell.ColorDefault, 0, false},
+		{[]string{"5", "42"}, tcell.PaletteColor(42), 2, true},
+		{[]string{"2"}, tcell.ColorDefault, 0, false},
+		{[]string{"2", "foo"}, tcell.ColorDefault, 0, false},
+		{[]string{"2", "42", "foo"}, tcell.ColorDefault, 0, false},
+		{[]string{"2", "42", "43", "foo"}, tcell.ColorDefault, 0, false},
+		{[]string{"2", "42", "43", "44"}, tcell.NewRGBColor(42, 43, 44), 4, true},
+	}
+
+	for _, test := range tests {
+		color, offset, err := parseColor(test.toks)
+		success := err == nil
+		if color != test.color || offset != test.offset || success != test.success {
+			t.Errorf("at input %v expected (%v, %v, %v) but got (%v, %v, %v)",
+				test.toks, test.color, test.offset, test.success, color, offset, success)
+		}
+	}
+}
+
 func TestApplyAnsiCodes(t *testing.T) {
 	none := tcell.StyleDefault
 


### PR DESCRIPTION
- Fixes #1931

Can be reproduced using the following config file:

```
set promptfmt "\033[38m%d%f" 
```

The crash occurs because the arguments to `38`/`48` are stored in an array, and are accessed without checking if the array is empty or not.

Also refactored out the code for parsing colors into a separate function.