### PR TITLE
Add support for underline colors

### DIFF
--- a/colors.go
+++ b/colors.go
@@ -201,6 +201,14 @@ loop:
 			}
 			st = st.Background(color)
 			i += offset
+		case "58":
+			color, offset, err := parseColor(toks[i+1:])
+			if err != nil {
+				log.Printf("error processing ansi code 58: %s", err)
+				break loop
+			}
+			st = st.Underline(color)
+			i += offset
 		default:
 			log.Printf("unknown ansi code: %s", toks[i])
 		}


### PR DESCRIPTION
Add support for underline colors via SGR code `58`.

---

Examples (red foreground with green underline):

256 color palette:

```sh
set promptfmt "\033[31;4;58;5;2m%d%f"
```

RGB:

```sh
set promptfmt "\033[31;4;58;2;0;255;0m%d%f"
```