### PR TITLE
Fix crash if log file can't be opened

### DIFF
--- a/client.go
+++ b/client.go
@@ -26,6 +26,19 @@ func init() {
 }
 
 func run() {
+	if gLogPath != "" {
+		f, err := os.OpenFile(gLogPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
+		if err != nil {
+			log.Fatalf("failed to open log file: %s", err)
+		}
+		defer f.Close()
+		log.SetOutput(f)
+	} else {
+		log.SetOutput(io.Discard)
+	}
+
+	log.Print("hi!")
+
 	var screen tcell.Screen
 	var err error
 	if screen, err = tcell.NewScreen(); err != nil {
@@ -36,19 +49,6 @@ func run() {
 	if gOpts.mouse {
 		screen.EnableMouse()
 	}
-
-	if gLogPath != "" {
-		f, err := os.OpenFile(gLogPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
-		if err != nil {
-			panic(err)
-		}
-		defer f.Close()
-		log.SetOutput(f)
-	} else {
-		log.SetOutput(io.Discard)
-	}
-
-	log.Print("hi!")
 
 	ui := newUI(screen)
 	nav := newNav(ui.wins[0].h)

--- a/server.go
+++ b/server.go
@@ -19,7 +19,7 @@ func serve() {
 	if gLogPath != "" {
 		f, err := os.OpenFile(gLogPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 		if err != nil {
-			panic(err)
+			log.Fatalf("failed to open log file: %s", err)
 		}
 		defer f.Close()
 		log.SetOutput(f)


### PR DESCRIPTION
- Fixes #1935 

If a log file is specified and can't be opened (e.g. `lf -log /foo`), then the application will `panic`. This happens after the TUI has been initialized so the terminal is left in a messed up state, instead of being restored after a normal exit.

This commit moves the code for opening the log file to before the TUI initialization, so that a failure will cause `lf` to abort with an error message without affecting the terminal.