### PR TITLE
Handle arrow keys when waiting for key press

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -1605,7 +1605,7 @@ func anyKey() {
 	}
 	defer term.Restore(int(os.Stdin.Fd()), oldState)
 
-	b := make([]byte, 1)
+	b := make([]byte, 8)
 	os.Stdin.Read(b)
 }
 


### PR DESCRIPTION
- Fixes #1955

To reproduce, run a `shell-wait` command (e.g. `!true`) and then press an arrow key at the `Press any key to continue` prompt.