### PR TITLE
Simpler implementation of `dirpreviews`

### DIFF
--- a/app.go
+++ b/app.go
@@ -258,7 +258,6 @@ func (app *app) writeHistory() error {
 // separate goroutines and sent here for update.
 func (app *app) loop() {
 	go app.nav.previewLoop(app.ui)
-	go app.nav.dirPreviewLoop(app.ui)
 
 	var serverChan <-chan expr
 	if !gSingleMode {
@@ -336,7 +335,6 @@ func (app *app) loop() {
 			app.quit()
 
 			app.nav.previewChan <- ""
-			app.nav.dirPreviewChan <- nil
 
 			log.Print("bye!")
 
@@ -510,7 +508,6 @@ func (app *app) loop() {
 
 func (app *app) runCmdSync(cmd *exec.Cmd, pause_after bool) {
 	app.nav.previewChan <- ""
-	app.nav.dirPreviewChan <- nil
 
 	if err := app.ui.suspend(); err != nil {
 		log.Printf("suspend: %s", err)


### PR DESCRIPTION
From discussion in https://github.com/gokcehan/lf/pull/1949#issuecomment-2785207399

This is a rewrite of the `dirpreviews` feature, which was originally implemented in #842. This has a number of improvements:

- The original channel/goroutine for handling file previews is now used for directory previews as well, instead of creating a new dedicated channel and goroutine just to handle directory previews.
- The code for handling previews is now no longer duplicated as a result of the above, which makes maintenance easier
- The `loading` property of a `dir` struct now properly indicates whether it has been read from the filesystem, and is not confused with whether its preview has loaded or not.

---

For the purposes of release notes, technically there is a bug fix in this change:

- The `previewer` script is now only invoked for the current directory (not all directories), when starting `lf` with `dirpreviews` enabled.