### PR TITLE
Restrict mode prefixes for cmd-history

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -2009,7 +2009,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			log.Printf("entering unknown execution prefix: %q", app.ui.cmdPrefix)
 		}
 	case "cmd-history-next":
-		if app.ui.cmdPrefix == "" || app.ui.cmdPrefix == ">" {
+		if !slices.Contains([]string{":", "$", "!", "%", "&"}, app.ui.cmdPrefix) {
 			return
 		}
 		if app.cmdHistoryInd > 0 {
@@ -2027,7 +2027,7 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.ui.cmdPrefix = cmd.prefix
 		app.ui.cmdAccLeft = []rune(cmd.value)
 	case "cmd-history-prev":
-		if app.ui.cmdPrefix == ">" {
+		if !slices.Contains([]string{":", "$", "!", "%", "&", ""}, app.ui.cmdPrefix) {
 			return
 		}
 		if app.cmdHistoryInd == len(app.cmdHistory) {


### PR DESCRIPTION
To reproduce:

1. `rename` or `delete` a file (or trigger any other mode like `filter`)
2. In response to seeing the prompt, press `<c-p>` (`cmd-history-prev`), which suddenly exits the prompt and goes into command history mode.

This commit changes the behavior so that `cmd-history-prev`/`cmd-history-next` only works when the prefix represents command line mode (any of `:`, `$`, `!`, `%`, `&`). Additionally `cmd-history-prev` can be triggered when in normal mode - this is existing behavior.