### PR TITLE
fix "slice bounds out of range" in cmd-delete-word-back

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -2181,7 +2181,7 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 		ind := locs[len(locs)-1][3]
 		app.ui.cmdYankBuf = []rune(string(app.ui.cmdAccLeft)[ind:])
-		app.ui.cmdAccLeft = app.ui.cmdAccLeft[:ind]
+		app.ui.cmdAccLeft = []rune(string(app.ui.cmdAccLeft)[:ind])
 		update(app)
 	case "cmd-uppercase-word":
 		if len(app.ui.cmdAccRight) == 0 {


### PR DESCRIPTION
Hello, while trying to edit file names with Cyrillic characters in them, I encountered error when performing cmd-delete-word-back action to remove words: 
```
runtime error: slice bounds out of range [:18] with capacity 16 
```
To reproduce you can create two folders, one named `test test test` and `тест тест тест`, position your cursor at the end of file name (like this `тест тест тест|` as denoted by `|`), and try to delete one word back.

You may also need to bind this action to some key beforehand in `lfrc`, like this `cmap <c-w> cmd-delete-word-back`.

Prior to this commit, after deleting one word back in file names:
`test test test` will become `test test `
`тест тест тест` will crash lf, when it is expected to become `тест тест `