### PR TITLE
Apply preserve mode for directories

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -133,7 +133,11 @@ func copyAll(srcs []string, dstDir string, preserve []string) (nums chan int64, 
 				newPath := filepath.Join(dst, rel)
 				switch {
 				case info.IsDir():
-					if err := os.MkdirAll(newPath, info.Mode()); err != nil {
+					var dst_mode os.FileMode = os.ModePerm
+					if slices.Contains(preserve, "mode") {
+						dst_mode = info.Mode()
+					}
+					if err := os.MkdirAll(newPath, dst_mode); err != nil {
 						errs <- fmt.Errorf("mkdir: %s", err)
 					}
 					if slices.Contains(preserve, "timestamps") {


### PR DESCRIPTION
Since support for `set preserve timestamps` for directories was added in #1979, it makes sense to support `set preserve mode` as well. Actually by default the mode is always preserved, but this change allows the user to opt out of it.

For the purposes of release notes, this should be listed together along with #1979, something like:

> The `preserve` option is now applied to directories as well as files when copying.