### PR TITLE
Reload if any component in current path is renamed

### DIFF
--- a/app.go
+++ b/app.go
@@ -404,13 +404,18 @@ func (app *app) loop() {
 				oldCurrPath = curr.path
 			}
 
-			for i := range app.nav.dirs {
-				if app.nav.dirs[i].path == d.path {
-					app.nav.dirs[i] = d
+			if wd, err := os.Getwd(); err == nil && wd != app.nav.currDir().path {
+				// if any path component in the current path is renamed, then
+				// the entire set of directories has to be reloaded
+				app.nav.cd(wd)
+			} else {
+				for i := range app.nav.dirs {
+					if app.nav.dirs[i].path == d.path {
+						app.nav.dirs[i] = d
+					}
 				}
+				app.nav.position()
 			}
-
-			app.nav.position()
 
 			curr, err := app.nav.currFile()
 			if err == nil {


### PR DESCRIPTION
If any path component in the CWD is renamed, then the set of directory objects will contain outdated information and have to be reloaded.

For example, if the CWD is `/home/user/foo/bar` then the set of directories are:

- `/`
- `/home`
- `/home/user`
- `/home/user/foo`
- `/home/user/foo/bar`

Then is `foo` is renamed to `foo2`, the above will no longer be correct. Currently `/home/user` will be reloaded as it is the parent directory that contains the rename, but the directory objeccs for `/home/user/foo` and `/home/user/foo/bar` also need to be reloaded as their value of `path` is stale.

---

To reproduce:

1. Create a directory `~/test`

   ```shell
   mkdir ~/test
   ```

2. Start `lf` there with `watch` enabled:

   ```shell
   lf -config /dev/null -command 'set watch true' ~/test
   ```
3. Rename `~/test` to `~/test2`:

   ```shell
   mv ~/test ~/test2
   ```
   Note that the prompt at the top doesn't update

4. Create a file inside the newly renamed `~/test2`:

   ```shell
   touch ~/test2/file
   ```