### PR TITLE
Update lfrc.ps1.example

### DIFF
--- a/etc/lfrc.ps1.example
+++ b/etc/lfrc.ps1.example
@@ -1,17 +1,31 @@
 # interpreter for shell commands
-set shell powershell
+set shell pwsh
+
+# allow the usage of $args inside shell commands
+set shellflag "-cwa"
+
+# speed up Powershell by skipping the profile
+set shellopts "-nop"
 
 # Shell commands with multiline definitions and/or positional arguments and/or
-# quotes do not work in Windows. For anything but the simplest shell commands,
+# quotes only partly work in Windows. For anything but the simplest shell commands,
 # it is recommended to create separate script files and simply call them here
 # in commands or mappings.
 #
-# Also, the default keybindings are defined using cmd syntax (i.e. '%EDITOR%')
-# which does not work with powershell. Therefore, you need to override these
-# keybindings with explicit choices accordingly.
+# Also, the default commands and keybindings are defined using cmd syntax (i.e. '%EDITOR%')
+# which does not work with Powershell. Therefore, you need to override these
+# with explicit choices accordingly.
 
-# change the default open command to work in powerShell
-cmd open &start $Env:f
+# change the default commands and keybindings to work in Powershell
+cmd open &&$Env:OPENER.Trim('"', ' ') "$Env:f"
+map e $&$Env:EDITOR "$Env:f"
+map i !&$Env:PAGER "$Env:f"
+map w $&$Env:SHELL
+cmd doc !&$Env:lf.Trim('"', ' ') -doc | &$Env:PAGER
+map <f-1> doc
+cmd maps !&$Env:lf.Trim('"', ' ') -remote "query $Env:id maps" | &$Env:PAGER
+cmd cmaps !&$Env:lf.Trim('"', ' ') -remote "query $Env:id cmaps" | &$Env:PAGER
+cmd cmds !&$Env:lf.Trim('"', ' ') -remote "query $Env:id cmds" | &$Env:PAGER
 
 # change the editor used in default editor keybinding
 # There is no builtin terminal editor installed in Windows. The default editor


### PR DESCRIPTION
This pull request updates the provided example configuration for `Powershell`.
- replace the old `powershell` with the more modern `pwsh`
- add useful `shellflag` and `shellopts`
- make all default commands and keybindings compatible with Powershell

In order to make `lf` more accessible for Powershell users, I am trying to improve the overall documentation. 
I am already in the process of adding Powershell versions of scripts mentioned in [tips](https://github.com/gokcehan/lf/wiki/Tips) and I thought it would make sense to also update this configuration.