### PR TITLE
Fix missing tempmarks after `sync` command

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -1516,15 +1516,20 @@ func (nav *nav) sync() error {
 		nav.saves[f] = cp
 	}
 
-	oldmarks := nav.marks
-	errMarks := nav.readMarks()
+	tempmarks := make(map[string]string)
 	for _, ch := range gOpts.tempmarks {
-		tmp := string(ch)
-		if v, e := oldmarks[tmp]; e {
-			nav.marks[tmp] = v
+		k := string(ch)
+		if v, ok := nav.marks[k]; ok {
+			tempmarks[k] = v
 		}
 	}
+	errMarks := nav.readMarks()
+	for k, v := range tempmarks {
+		nav.marks[k] = v
+	}
+
 	err = nav.readTags()
+
 	if errMarks != nil {
 		return errMarks
 	}


### PR DESCRIPTION
To reproduce:

1. Use the `cd` command to change to some directory
2. Press `'` (`mark-load`) to show the available marks
3. Run the `sync` command (or alternative `cut`/`copy` a file)
4. Repeat step 2

After the `sync` command is run, temporary marks like `'` disappear because `nav.marks` is cleared, and it is only saved as a shallow copy when it should be a deep copy.