### PR TITLE
Respect symlinks when tagging files

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -31,6 +31,14 @@ func replaceTilde(s string) string {
 	return s
 }
 
+func evalSymlinks(path string) string {
+	if target, err := filepath.EvalSymlinks(path); err == nil {
+		return target
+	}
+
+	return path
+}
+
 func runeSliceWidth(rs []rune) int {
 	w := 0
 	for _, r := range rs {

--- a/nav.go
+++ b/nav.go
@@ -1161,6 +1161,8 @@ func (nav *nav) toggle() {
 }
 
 func (nav *nav) tagToggleSelection(path string, tag string) {
+	path = evalSymlinks(path)
+
 	if _, ok := nav.tags[path]; ok {
 		delete(nav.tags, path)
 	} else {
@@ -1196,7 +1198,7 @@ func (nav *nav) tag(tag string) error {
 	}
 
 	for _, path := range list {
-		nav.tags[path] = tag
+		nav.tags[evalSymlinks(path)] = tag
 	}
 
 	return nil

--- a/ui.go
+++ b/ui.go
@@ -458,7 +458,7 @@ func (win *win) printDir(ui *ui, dir *dir, context *dirContext, dirStyle *dirSty
 		}
 
 		tag := " "
-		if val, ok := context.tags[path]; ok && len(val) > 0 {
+		if val, ok := context.tags[evalSymlinks(path)]; ok && len(val) > 0 {
 			tag = val
 		}
 


### PR DESCRIPTION
**Related issues:**
- Fixes #830 

---

To reproduce:

- Create a file:
   ```sh
   touch foo
   ```
- Create a symlink pointing to that file:
   ```sh
   ln -s foo bar
   ```
- Tag either the original file or the symlink in `lf` by pressing `t`

In the original implementation, both the original file and symlink are treated separately when tagging files. This PR changes the behavior so that they are treated as the same file - i.e. tagging `foo` will also mark `bar` as tagged, and vice-versa. This follows the behavior of `ranger`.