### PR TITLE
Fix statline overwrite during `shell-pipe` command

### DIFF
--- a/app.go
+++ b/app.go
@@ -603,8 +603,8 @@ func (app *app) runShell(s string, args []string, prefix string) {
 		normal(app)
 		app.cmd = cmd
 		app.cmdOutBuf = nil
-		app.ui.msg = ""
 		app.ui.cmdPrefix = ">"
+		app.ui.echo("")
 
 		go func() {
 			eol := false


### PR DESCRIPTION
To reproduce, run `:test` with the following config file:

```sh
set watch true

cmd test %{{
    sleep 1
    date > foo.txt
    sleep 1
}}
```

When running a `shell-pipe` command, the file `stat` information should not be displayed even if there are updates.