### PR TITLE
Better fix for reload if current path is renamed

### DIFF
--- a/app.go
+++ b/app.go
@@ -466,12 +466,19 @@ func (app *app) loop() {
 			}
 			app.ui.draw(app.nav)
 		case path := <-app.nav.delChan:
-			delete(app.nav.dirCache, path)
-			delete(app.nav.regCache, path)
-
-			delete(app.nav.selections, path)
+			deletePathRecusrive(app.nav.selections, path)
 			if len(app.nav.selections) == 0 {
 				app.nav.selectionInd = 0
+			}
+
+			deletePathRecusrive(app.nav.regCache, path)
+
+			deletePathRecusrive(app.nav.dirCache, path)
+			currPath := app.nav.currDir().path
+			if currPath == path || strings.HasPrefix(currPath, path+string(filepath.Separator)) {
+				if wd, err := os.Getwd(); err == nil {
+					app.nav.getDirs(wd)
+				}
 			}
 		case ev := <-app.ui.evChan:
 			e := app.ui.readEvent(ev, app.nav)

--- a/misc.go
+++ b/misc.go
@@ -378,6 +378,19 @@ func makeCollator(localeStr string, opts ...collate.Option) (*collate.Collator, 
 	return collate.New(localeTag, opts...), nil
 }
 
+// This function deletes entries from a map if the key is either the given path
+// or a subpath of it.
+// This is useful for clearing cached data when a directory is moved or deleted.
+func deletePathRecusrive[T any](m map[string]T, path string) {
+	delete(m, path)
+	prefix := path + string(filepath.Separator)
+	for k := range m {
+		if strings.HasPrefix(k, prefix) {
+			delete(m, k)
+		}
+	}
+}
+
 // We don't need no generic code
 // We don't need no type control
 // No dark templates in compiler

--- a/nav.go
+++ b/nav.go
@@ -1488,8 +1488,8 @@ func (nav *nav) rename() error {
 	// existed and was deleted. In this case the cache entries should be deleted
 	// before loading newPath to prevent displaying a stale preview. However,
 	// this clears only the current instance of lf, and not any other instances.
-	delete(nav.regCache, newPath)
-	delete(nav.dirCache, newPath)
+	deletePathRecusrive(nav.regCache, newPath)
+	deletePathRecusrive(nav.dirCache, newPath)
 	dir := nav.loadDir(filepath.Dir(newPath))
 
 	if dir.loading {


### PR DESCRIPTION
Better implementation of #1982. This approach checks if a reload is required when receiving a rename event from `fsnotify`, instead of blindly comparing the CWD to what `lf` thinks is the current directory whenever a directory is loaded.

---

If any path component in the CWD is renamed, then the set of directory objects will contain outdated information and have to be reloaded.

For example, if the CWD is `/home/user/foo/bar` then the set of directories are:

- `/`
- `/home`
- `/home/user`
- `/home/user/foo`
- `/home/user/foo/bar`

Then is `foo` is renamed to `foo2`, the above will no longer be correct. Currently `/home/user` will be reloaded as it is the parent directory that contains the rename, but the directory objects for `/home/user/foo` and `/home/user/foo/bar` also need to be reloaded as their value of `path` is stale.

---

To reproduce:

1. Create a directory `~/test`

   ```shell
   mkdir ~/test
   ```

2. Start `lf` there with `watch` enabled:

   ```shell
   lf -config /dev/null -command 'set watch true' ~/test
   ```
3. Rename `~/test` to `~/test2`:

   ```shell
   mv ~/test ~/test2
   ```
   Note that the prompt at the top doesn't update

4. Create a file inside the newly renamed `~/test2`:

   ```shell
   touch ~/test2/file
   ```