### PR TITLE
Ignore updates for log file when `watch` is enabled

### DIFF
--- a/app.go
+++ b/app.go
@@ -443,6 +443,13 @@ func (app *app) loop() {
 
 			app.ui.draw(app.nav)
 		case f := <-app.nav.fileChan:
+			// skip updates for the log path, otherwise it is possible to have
+			// an infinite loop where writing to a log file causes it to be
+			// reloaded, which in turn triggers more events that are logged
+			if f.path == gLogPath {
+				continue
+			}
+
 			for _, dir := range app.nav.dirCache {
 				if dir.path != filepath.Dir(f.path) {
 					continue

--- a/app.go
+++ b/app.go
@@ -443,13 +443,6 @@ func (app *app) loop() {
 
 			app.ui.draw(app.nav)
 		case f := <-app.nav.fileChan:
-			// skip updates for the log path, otherwise it is possible to have
-			// an infinite loop where writing to a log file causes it to be
-			// reloaded, which in turn triggers more events that are logged
-			if f.path == gLogPath {
-				continue
-			}
-
 			for _, dir := range app.nav.dirCache {
 				if dir.path != filepath.Dir(f.path) {
 					continue

--- a/main.go
+++ b/main.go
@@ -298,6 +298,14 @@ func main() {
 	gSocketProt = gDefaultSocketProt
 	gSocketPath = gDefaultSocketPath
 
+	if gLogPath != "" {
+		path, err := filepath.Abs(gLogPath)
+		if err != nil {
+			log.Fatalf("getting log path: %s", err)
+		}
+		gLogPath = path
+	}
+
 	if *cpuprofile != "" {
 		f, err := os.Create(*cpuprofile)
 		if err != nil {
@@ -319,14 +327,6 @@ func main() {
 			log.Fatalf("remote command: %s", err)
 		}
 	case *serverMode:
-		if gLogPath != "" && !filepath.IsAbs(gLogPath) {
-			wd, err := os.Getwd()
-			if err != nil {
-				log.Fatalf("getting current directory: %s", err)
-			} else {
-				gLogPath = filepath.Join(wd, gLogPath)
-			}
-		}
 		os.Chdir(gUser.HomeDir)
 		serve()
 	default:

--- a/watch.go
+++ b/watch.go
@@ -100,7 +100,7 @@ func (watch *watch) loop() {
 				// have an infinite loop where writing to the log file causes it
 				// to be reloaded, which in turn triggers more events that are
 				// then logged
-				if ev.Name == gLogPath {
+				if ev.Name == gLogPath && ev.Has(fsnotify.Write) {
 					continue
 				}
 

--- a/watch.go
+++ b/watch.go
@@ -96,6 +96,14 @@ func (watch *watch) loop() {
 			}
 
 			if ev.Has(fsnotify.Write) || ev.Has(fsnotify.Chmod) {
+				// skip updates for the log file, otherwise it is possible to
+				// have an infinite loop where writing to the log file causes it
+				// to be reloaded, which in turn triggers more events that are
+				// then logged
+				if ev.Name == gLogPath {
+					continue
+				}
+
 				dir, file := filepath.Split(ev.Name)
 				for _, path := range watch.getSameDirs(dir) {
 					watch.addUpdate(filepath.Join(path, file))

--- a/watch.go
+++ b/watch.go
@@ -96,10 +96,10 @@ func (watch *watch) loop() {
 			}
 
 			if ev.Has(fsnotify.Write) || ev.Has(fsnotify.Chmod) {
-				// skip updates for the log file, otherwise it is possible to
-				// have an infinite loop where writing to the log file causes it
-				// to be reloaded, which in turn triggers more events that are
-				// then logged
+				// skip write updates for the log file, otherwise it is possible
+				// to have an infinite loop where writing to the log file causes
+				// it to be reloaded, which in turn triggers more events that
+				// are then logged
 				if ev.Name == gLogPath && ev.Has(fsnotify.Write) {
 					continue
 				}


### PR DESCRIPTION
Currently it is possible to have an infinite loop with updates to the log file when `watch` is enabled:

1. A message is written to the log file
2. The `watch` feature detects that the log file has been modified
3. Something is triggered in response (e.g. `on-load` hook command, introduced in #2010, is called)
4. The above step writes a message to the log file as part of its execution

This can be reproduced using the following minimal config file:

```sh
set watch true

# do nothing, just cause an entry to be written to the log file
cmd on-load &true
```