### PR TITLE
Fix crash when pasting into directory without permissions

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -104,8 +104,7 @@ func copyAll(srcs []string, dstDir string, preserve []string) (nums chan int64, 
 			file := filepath.Base(src)
 			dst := filepath.Join(dstDir, file)
 
-			lstat, err := os.Lstat(dst)
-			if !os.IsNotExist(err) {
+			if lstat, err := os.Lstat(dst); err == nil {
 				ext := getFileExtension(lstat)
 				basename := file[:len(file)-len(ext)]
 				var newPath string

--- a/nav.go
+++ b/nav.go
@@ -1357,13 +1357,13 @@ func (nav *nav) moveAsync(app *app, srcs []string, dstDir string) {
 		file := filepath.Base(src)
 		dst := filepath.Join(dstDir, file)
 
-		dstStat, err := os.Stat(dst)
-		if os.SameFile(srcStat, dstStat) {
-			errCount++
-			echo.args[0] = fmt.Sprintf("[%d] rename %s %s: source and destination are the same file", errCount, src, dst)
-			app.ui.exprChan <- echo
-			continue
-		} else if !os.IsNotExist(err) {
+		if dstStat, err := os.Stat(dst); err == nil {
+			if os.SameFile(srcStat, dstStat) {
+				errCount++
+				echo.args[0] = fmt.Sprintf("[%d] rename %s %s: source and destination are the same file", errCount, src, dst)
+				app.ui.exprChan <- echo
+				continue
+			}
 			ext := getFileExtension(dstStat)
 			basename := file[:len(file)-len(ext)]
 			var newPath string


### PR DESCRIPTION
- Fixes #2023 

To reproduce, cut/copy some files and then paste them into a directory with permissions of `600` (read, write but no execute).