### PR TITLE
Fix `nkeys` and `vkeys` getting exported as environment variables

### DIFF
--- a/main.go
+++ b/main.go
@@ -126,7 +126,7 @@ func getOptsMap() map[string]string {
 		name := "lf_" + t.Field(i).Name
 
 		// Skip maps
-		if name == "lf_keys" || name == "lf_cmdkeys" || name == "lf_cmds" {
+		if name == "lf_nkeys" || name == "lf_vkeys" || name == "lf_cmdkeys" || name == "lf_cmds" {
 			continue
 		}
 


### PR DESCRIPTION
- Follow up to https://github.com/gokcehan/lf/pull/2021

This pull request prevents the maps `nkeys` and `vkeys` from getting exported as env vars in user defined commands (showing as *lf_nkeys=<map[string]main.expr Value>* and *lf_vkeys=<map[string]main.expr Value>*).

This is a purely cosmetic issue.