### PR TITLE
Automatically load `dircounts` after enabling it

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -68,6 +68,10 @@ func (e *setExpr) eval(app *app, args []string) {
 		err = applyBoolOpt(&gOpts.dircache, e)
 	case "dircounts", "nodircounts", "dircounts!":
 		err = applyBoolOpt(&gOpts.dircounts, e)
+		if err == nil {
+			app.nav.renew()
+			app.ui.loadFile(app, false)
+		}
 	case "dirfirst", "nodirfirst", "dirfirst!":
 		err = applyBoolOpt(&gOpts.dirfirst, e)
 		if err == nil {

--- a/nav.go
+++ b/nav.go
@@ -625,8 +625,16 @@ func (nav *nav) checkDir(dir *dir) {
 			nd := newDir(dir.path)
 			nav.dirChan <- nd
 		}()
+	case dir.dircounts != getDirCounts(dir.path):
+		dir.loading = true
+		go func() {
+			nd := newDir(dir.path)
+			nav.dirChan <- nd
+		}()
+	// Although toggling dircounts can affect sorting, it is already handled by
+	// reloading the directory which should sort the files anyway, so it is not
+	// checked below.
 	case dir.sortby != getSortBy(dir.path) ||
-		dir.dircounts != getDirCounts(dir.path) ||
 		dir.dirfirst != getDirFirst(dir.path) ||
 		dir.dironly != getDirOnly(dir.path) ||
 		dir.hidden != getHidden(dir.path) ||


### PR DESCRIPTION
From the discussion https://github.com/gokcehan/lf/pull/2025#discussion_r2214785746

This change automatically loads the directory counts when starting `lf` with `dircounts` disabled and then enabling it afterwards.