### PR TITLE
Silence `gopls` hints

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -132,7 +132,7 @@ func copyAll(srcs []string, dstDir string, preserve []string) (nums chan int64, 
 				newPath := filepath.Join(dst, rel)
 				switch {
 				case info.IsDir():
-					var dst_mode os.FileMode = os.ModePerm
+					var dst_mode = os.ModePerm
 					if slices.Contains(preserve, "mode") {
 						dst_mode = info.Mode()
 					}

--- a/nav.go
+++ b/nav.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1613,9 +1614,7 @@ func (nav *nav) sync() error {
 		}
 	}
 	errMarks := nav.readMarks()
-	for k, v := range tempmarks {
-		nav.marks[k] = v
-	}
+	maps.Copy(nav.marks, tempmarks)
 
 	err = nav.readTags()
 


### PR DESCRIPTION
This pull requests adds suggestions by `gopls` (the only ones I got in the entire code base):
- Replace m[k]=v loop with maps.Copy [mapsloop]
- could omit type os.FileMode from declaration; it will be inferred from the right-hand side [default]