### PR TITLE
Revert "Respect symlinks when tagging files (#1997)"

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -32,14 +32,6 @@ func replaceTilde(s string) string {
 	return s
 }
 
-func evalSymlinks(path string) string {
-	if target, err := filepath.EvalSymlinks(path); err == nil {
-		return target
-	}
-
-	return path
-}
-
 func runeSliceWidth(rs []rune) int {
 	w := 0
 	for _, r := range rs {

--- a/nav.go
+++ b/nav.go
@@ -1257,8 +1257,6 @@ func (nav *nav) toggle() {
 }
 
 func (nav *nav) tagToggleSelection(path string, tag string) {
-	path = evalSymlinks(path)
-
 	if _, ok := nav.tags[path]; ok {
 		delete(nav.tags, path)
 	} else {
@@ -1294,7 +1292,7 @@ func (nav *nav) tag(tag string) error {
 	}
 
 	for _, path := range list {
-		nav.tags[evalSymlinks(path)] = tag
+		nav.tags[path] = tag
 	}
 
 	return nil

--- a/ui.go
+++ b/ui.go
@@ -475,7 +475,7 @@ func (win *win) printDir(ui *ui, dir *dir, context *dirContext, dirStyle *dirSty
 		}
 
 		tag := " "
-		if val, ok := context.tags[evalSymlinks(path)]; ok && len(val) > 0 {
+		if val, ok := context.tags[path]; ok && len(val) > 0 {
 			tag = val
 		}
 


### PR DESCRIPTION
Revert #1997 due to the following reasons:

- Respecting symbolic links when tagging files removes the ability to tag the symbolic link and its target separately.
- Files are generally treated individually, for example if a symbolic link and its target can be selected separately, then the same should apply for tagging.
- It is causing the issue mentioned in #2048.
- I doubt most users will care about this feature anyway, so there is not enough justification to keep it.