### PR TITLE
Support wrapping while in Visual mode

### DIFF
--- a/app.go
+++ b/app.go
@@ -392,6 +392,7 @@ func (app *app) loop() {
 					d.ind = prev.ind
 					d.pos = prev.pos
 					d.visualAnchor = min(prev.visualAnchor, len(d.files)-1)
+					d.visualWrap = prev.visualWrap
 					d.filter = prev.filter
 					d.sort()
 					d.sel(prev.name(), app.nav.height)

--- a/eval.go
+++ b/eval.go
@@ -837,6 +837,7 @@ func normal(app *app) {
 func visual(app *app) {
 	dir := app.nav.currDir()
 	dir.visualAnchor = dir.ind
+	dir.visualWrap = 0
 
 	app.ui.loadFileInfo(app.nav)
 }
@@ -2378,6 +2379,7 @@ func (e *callExpr) eval(app *app, args []string) {
 		beg := max(dir.ind-dir.pos, 0)
 		dir.ind, dir.visualAnchor = dir.visualAnchor, dir.ind
 		dir.pos = dir.ind - beg
+		dir.visualWrap = -dir.visualWrap
 		dir.boundPos(app.nav.height)
 	default:
 		cmd, ok := gOpts.cmds[e.name]


### PR DESCRIPTION
- Fixes #2047 

This change allows the visual selection to be wrapped (following the cursor) when `wrapscroll`/`wrapscan` is enabled.