### PR TITLE
[WIP] Add `filtermethod` and `searchmethod` options

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -106,8 +106,10 @@ func (e *setExpr) eval(app *app, args []string) {
 			app.ui.sort()
 			app.ui.loadFile(app, true)
 		}
+		app.ui.echoerr("option 'globfilter' is deprecated, use 'filtermethod' instead")
 	case "globsearch", "noglobsearch", "globsearch!":
 		err = applyBoolOpt(&gOpts.globsearch, e)
+		app.ui.echoerr("option 'globsearch' is deprecated, use 'searchmethod' instead")
 	case "hidden", "nohidden", "hidden!":
 		err = applyBoolOpt(&gOpts.hidden, e)
 		if err == nil {
@@ -379,6 +381,26 @@ func (e *setExpr) eval(app *app, args []string) {
 		default:
 			app.ui.echoerr("selmode: value should either be 'all' or 'dir'")
 			return
+		}
+	case "filtermethod":
+		switch e.val {
+		case "text", "glob", "re":
+			gOpts.filtermethod = searchMethod(e.val)
+		default:
+			app.ui.echoerr("filtermethod: value should either be 'text', 'glob' or 're")
+		}
+		if err == nil {
+			app.nav.sort()
+			app.nav.position()
+			app.ui.sort()
+			app.ui.loadFile(app, true)
+		}
+	case "searchmethod":
+		switch e.val {
+		case "text", "glob", "re":
+			gOpts.searchmethod = searchMethod(e.val)
+		default:
+			app.ui.echoerr("searchmethod: value should either be 'text', 'glob' or 're'")
 		}
 	case "shell":
 		gOpts.shell = e.val

--- a/opts.go
+++ b/opts.go
@@ -35,6 +35,14 @@ func isValidSortMethod(method sortMethod) bool {
 
 const invalidSortErrorMessage = `sortby: value should either be 'natural', 'name', 'size', 'time', 'atime', 'btime', 'ctime', 'ext' or 'custom'`
 
+type searchMethod string
+
+const (
+	textSearch searchMethod = "text"
+	globSearch searchMethod = "glob"
+	regSearch  searchMethod = "re"
+)
+
 var gOpts struct {
 	anchorfind       bool
 	autoquit         bool
@@ -53,6 +61,8 @@ var gOpts struct {
 	dupfilefmt       string
 	globfilter       bool
 	globsearch       bool
+	searchmethod     searchMethod
+	filtermethod     searchMethod
 	hidden           bool
 	icons            bool
 	ignorecase       bool
@@ -222,6 +232,8 @@ func init() {
 	gOpts.cutfmt = "\033[7;31m"
 	gOpts.globfilter = false
 	gOpts.globsearch = false
+	gOpts.filtermethod = textSearch
+	gOpts.searchmethod = textSearch
 	gOpts.hidden = false
 	gOpts.icons = false
 	gOpts.ignorecase = true


### PR DESCRIPTION
- Fix https://github.com/gokcehan/lf/issues/762

This pull request is based on the suggestion in https://github.com/gokcehan/lf/pull/763#issuecomment-1052542460.

- Add `filtermethod` option ("text", "glob" or "re")
- Add `searchmethod` option ("text", "glob" or "re") 
- Deprecate `globfilter` option
- Deprecate 'globsearch' option