### PR TITLE
Ignore pasted input while in Normal mode

### DIFF
--- a/client.go
+++ b/client.go
@@ -49,6 +49,7 @@ func run() {
 	if gOpts.mouse {
 		screen.EnableMouse()
 	}
+	screen.EnablePaste()
 
 	ui := newUI(screen)
 	nav := newNav(ui.wins[0].h)

--- a/ui.go
+++ b/ui.go
@@ -664,6 +664,7 @@ type ui struct {
 	styles      styleMap
 	icons       iconMap
 	currentFile string
+	pasteEvent  bool
 }
 
 func newUI(screen tcell.Screen) *ui {
@@ -1398,6 +1399,10 @@ func (ui *ui) readNormalEvent(ev tcell.Event, nav *nav) expr {
 
 	switch tev := ev.(type) {
 	case *tcell.EventKey:
+		if ui.pasteEvent {
+			return nil
+		}
+
 		// KeyRune is a regular character
 		if tev.Key() == tcell.KeyRune {
 			switch {
@@ -1576,6 +1581,12 @@ func (ui *ui) readNormalEvent(ev tcell.Event, nav *nav) expr {
 			return &callExpr{"on-focus-gained", nil, 1}
 		} else {
 			return &callExpr{"on-focus-lost", nil, 1}
+		}
+	case *tcell.EventPaste:
+		if tev.Start() {
+			ui.pasteEvent = true
+		} else if tev.End() {
+			ui.pasteEvent = false
 		}
 	}
 	return nil


### PR DESCRIPTION
- Fixes #2052 

This change prevents text pasted from the terminal from being treated as keyboard input, which could lead to potentially dangerous side-effects.

Does not work on Windows at the time of writing, because `tcell` (and presumably upstream) [lacks support](https://github.com/gdamore/tcell/blob/c2f1f74e2d279e24b5761174ca72405914a53e6a/console_win.go#L313-L317) for detecting bracketed-paste mode on Windows.