### PR TITLE
Improvements for command line completion

### DIFF
--- a/app.go
+++ b/app.go
@@ -682,7 +682,7 @@ func (app *app) doComplete() (matches []compMatch) {
 	return
 }
 
-func (app *app) menuComplete(dir int) {
+func (app *app) menuComplete(direction int) {
 	if !app.menuCompActive {
 		app.menuCompTmp = tokenize(string(app.ui.cmdAccLeft))
 		app.menuComps = app.doComplete()
@@ -691,7 +691,7 @@ func (app *app) menuComplete(dir int) {
 			app.menuCompActive = true
 		}
 	} else {
-		app.menuCompInd += dir
+		app.menuCompInd += direction
 		if app.menuCompInd == len(app.menuComps) {
 			app.menuCompInd = 0
 		} else if app.menuCompInd < 0 {

--- a/complete.go
+++ b/complete.go
@@ -414,10 +414,6 @@ func completeCmd(acc []rune) (matches []compMatch, result string) {
 			}
 		}
 	case "setlocal":
-		if len(f) == 2 {
-			matches, result = matchCmdFile(f[1], true)
-			break
-		}
 		if len(f) == 3 {
 			matches, result = matchWord(f[2], gLocalOptWords)
 			break

--- a/complete.go
+++ b/complete.go
@@ -296,7 +296,7 @@ func matchFile(s string, dironly bool, escape func(string) string, unescape func
 		result = s
 	case 1:
 		result = escape(dir + longest)
-		if !strings.HasSuffix(result, string(filepath.Separator)) {
+		if !strings.HasSuffix(longest, string(filepath.Separator)) {
 			result += " "
 		}
 	default:

--- a/complete.go
+++ b/complete.go
@@ -377,6 +377,8 @@ func completeCmd(acc []rune) (matches []compMatch, result string) {
 		return
 	}
 
+	result = f[len(f)-1]
+
 	switch f[0] {
 	case "set":
 		if len(f) == 2 {

--- a/complete.go
+++ b/complete.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -159,50 +160,161 @@ func getLocalOptWords(localOpts any) (localOptWords []string) {
 	return
 }
 
-func matchLongest(s1, s2 []rune) []rune {
+func commonPrefix(s1, s2 string) string {
+	r1 := []rune(s1)
+	r2 := []rune(s2)
+
 	i := 0
-	for ; i < len(s1) && i < len(s2); i++ {
-		if s1[i] != s2[i] {
+	for ; i < len(r1) && i < len(r2); i++ {
+		if r1[i] != r2[i] {
 			break
 		}
 	}
-	return s1[:i]
+
+	return string(r1[:i])
 }
 
-func matchWord(s string, words []string) (matches []string, longest []rune) {
+type compMatch struct {
+	name   string // display name in completion menu
+	result string // result when cycling through completion menu
+}
+
+func matchWord(s string, words []string) (matches []compMatch, result string) {
 	for _, w := range words {
 		if !strings.HasPrefix(w, s) {
 			continue
 		}
 
-		matches = append(matches, w)
-		if len(longest) != 0 {
-			longest = matchLongest(longest, []rune(w))
-		} else if s != "" {
-			longest = []rune(w + " ")
+		matches = append(matches, compMatch{w, w})
+		if len(matches) == 1 {
+			result = w
+		} else {
+			result = commonPrefix(result, w)
 		}
 	}
 
-	if len(longest) == 0 {
-		longest = []rune(s)
+	switch len(matches) {
+	case 0:
+		result = s
+	case 1:
+		result = result + " "
 	}
-
 	return
 }
 
-func matchExec(s string) (matches []string, longest []rune) {
-	var words []string
+func matchList(s string, words []string) (matches []compMatch, result string) {
+	toks := strings.Split(s, ":")
 
-	paths := strings.Split(envPath, string(filepath.ListSeparator))
+	var longest string
 
-	for _, p := range paths {
-		if _, err := os.Stat(p); os.IsNotExist(err) {
+	for _, w := range words {
+		if slices.Contains(toks[:len(toks)-1], w) || !strings.HasPrefix(w, toks[len(toks)-1]) {
 			continue
 		}
 
+		result := strings.Join(append(slices.Clone(toks[:len(toks)-1]), w), ":")
+		matches = append(matches, compMatch{w, result})
+
+		if len(matches) == 1 {
+			longest = result
+		} else {
+			longest = commonPrefix(longest, result)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		result = s
+	case 1:
+		result = longest
+		if result == s {
+			result += " "
+		}
+	default:
+		result = longest
+	}
+	return
+}
+
+func matchCmd(s string) (matches []compMatch, result string) {
+	words := append(gCmdWords, slices.Collect(maps.Keys(gOpts.cmds))...)
+	slices.Sort(words)
+	matches, result = matchWord(s, slices.Compact(words))
+	return
+}
+
+func matchFile(s string, escape func(string) string, unescape func(string) string) (matches []compMatch, result string) {
+	dir, file := filepath.Split(unescape(replaceTilde(s)))
+
+	d := dir
+	if dir == "" {
+		d = "."
+	}
+	files, err := os.ReadDir(d)
+	if err != nil {
+		log.Printf("reading directory: %s", err)
+		result = s
+		return
+	}
+
+	var longest string
+
+	for _, f := range files {
+		if !strings.HasPrefix(strings.ToLower(f.Name()), strings.ToLower(file)) {
+			continue
+		}
+
+		name := f.Name()
+		if f.IsDir() {
+			name += string(filepath.Separator)
+		} else if f.Type()&os.ModeSymlink != 0 {
+			if stat, err := os.Stat(filepath.Join(d, f.Name())); err == nil && stat.IsDir() {
+				name += string(filepath.Separator)
+			}
+		}
+		result := escape(dir + name)
+		matches = append(matches, compMatch{name, result})
+
+		if len(matches) == 1 {
+			longest = name
+		} else {
+			longest = commonPrefix(strings.ToLower(longest), strings.ToLower(name))
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		result = s
+	case 1:
+		result = escape(dir + longest)
+		if !strings.HasSuffix(result, string(filepath.Separator)) {
+			result += " "
+		}
+	default:
+		result = escape(dir + longest)
+	}
+	return
+}
+
+func matchCmdFile(s string) (matches []compMatch, result string) {
+	matches, result = matchFile(s, cmdEscape, cmdUnescape)
+	return
+}
+
+func matchShellFile(s string) (matches []compMatch, result string) {
+	matches, result = matchFile(s, shellEscape, shellUnescape)
+	return
+}
+
+func matchExec(s string) (matches []compMatch, result string) {
+	var words []string
+	for _, p := range strings.Split(envPath, string(filepath.ListSeparator)) {
 		files, err := os.ReadDir(p)
 		if err != nil {
-			log.Printf("reading path: %s", err)
+			if !os.IsNotExist(err) {
+				log.Printf("reading path: %s", err)
+			}
+			continue
 		}
 
 		for _, f := range files {
@@ -220,192 +332,21 @@ func matchExec(s string) (matches []string, longest []rune) {
 				continue
 			}
 
-			words = append(words, finfo.Name())
+			words = append(words, f.Name())
 		}
 	}
 
-	if len(words) > 0 {
-		sort.Strings(words)
-
-		uniq := words[:1]
-		for i := 1; i < len(words); i++ {
-			if words[i] != words[i-1] {
-				uniq = append(uniq, words[i])
-			}
-		}
-		words = uniq
-	}
-
-	return matchWord(s, words)
+	slices.Sort(words)
+	matches, result = matchWord(s, slices.Compact(words))
+	return
 }
 
-func matchFile(s string) (matches []string, longest []rune) {
-	dir := replaceTilde(s)
-
-	if !filepath.IsAbs(dir) {
-		wd, err := os.Getwd()
-		if err != nil {
-			log.Printf("getting current directory: %s", err)
-		} else {
-			dir = wd + string(filepath.Separator) + dir
-		}
-	}
-
-	dir = filepath.Dir(unescape(dir))
-
-	files, err := os.ReadDir(dir)
+func matchSearch(s string) (matches []compMatch, result string) {
+	files, err := os.ReadDir(".")
 	if err != nil {
 		log.Printf("reading directory: %s", err)
-	}
-
-	for _, f := range files {
-		name := filepath.Join(dir, f.Name())
-		f, err := os.Lstat(name)
-		if err != nil {
-			log.Printf("getting file information: %s", err)
-			continue
-		}
-
-		name = strings.ToLower(escape(f.Name()))
-		_, last := filepath.Split(s)
-		if !strings.HasPrefix(name, strings.ToLower(last)) {
-			continue
-		}
-
-		name = f.Name()
-		if isRoot(s) || filepath.Base(s) != s {
-			name = filepath.Join(filepath.Dir(unescape(s)), f.Name())
-		}
-		name = escape(replaceTilde(name))
-
-		item := f.Name()
-		if f.Mode().IsDir() {
-			item += escape(string(filepath.Separator))
-		}
-		matches = append(matches, item)
-
-		if longest == nil {
-			if f.Mode().IsRegular() {
-				longest = []rune(name + " ")
-			} else {
-				longest = []rune(name + escape(string(filepath.Separator)))
-			}
-		} else {
-			longest = matchLongest(longest, []rune(name))
-		}
-	}
-
-	if len(longest) < len([]rune(s)) {
-		longest = []rune(s)
-	}
-
-	return
-}
-
-func matchCmd(s string) (matches []string, longest []rune) {
-	words := make([]string, 0, len(gCmdWords)+len(gOpts.cmds))
-	words = append(words, gCmdWords...)
-	for c := range gOpts.cmds {
-		words = append(words, c)
-	}
-	sort.Strings(words)
-	j := 0
-	for i := 1; i < len(words); i++ {
-		if words[j] == words[i] {
-			continue
-		}
-		j++
-		words[i], words[j] = words[j], words[i]
-	}
-	words = words[:j+1]
-	matches, longest = matchWord(s, words)
-	return
-}
-
-func completeCmd(acc []rune) (matches []string, longestAcc []rune) {
-	s := string(acc)
-	f := tokenize(s)
-
-	if len(f) == 1 {
-		matches, longestAcc = matchCmd(s)
+		result = s
 		return
-	}
-
-	longest := []rune(f[len(f)-1])
-
-	switch f[0] {
-	case "set":
-		if len(f) == 2 {
-			matches, longest = matchWord(f[1], gOptWords)
-			break
-		}
-		if len(f) != 3 {
-			break
-		}
-		switch f[1] {
-		case "filtermethod", "searchmethod":
-			matches, longest = matchWord(f[2], []string{"glob", "regex", "text"})
-		case "selmode":
-			matches, longest = matchWord(f[2], []string{"all", "dir"})
-		case "sortby":
-			matches, longest = matchWord(f[2], []string{"atime", "btime", "ctime", "custom", "ext", "name", "natural", "size", "time"})
-		default:
-			if slices.Contains(gOptWords, f[1]+"!") {
-				matches, longest = matchWord(f[2], []string{"false", "true"})
-			}
-		}
-	case "setlocal":
-		if len(f) == 2 {
-			matches, longest = matchFile(f[1])
-			break
-		}
-		if len(f) == 3 {
-			matches, longest = matchWord(f[2], gLocalOptWords)
-			break
-		}
-		if len(f) != 4 {
-			break
-		}
-		switch f[2] {
-		case "sortby":
-			matches, longest = matchWord(f[3], []string{"atime", "btime", "ctime", "custom", "ext", "name", "natural", "size", "time"})
-		default:
-			if slices.Contains(gLocalOptWords, f[2]+"!") {
-				matches, longest = matchWord(f[3], []string{"false", "true"})
-			}
-		}
-	case "map", "nmap", "vmap", "cmap":
-		if len(f) == 3 {
-			matches, longest = matchCmd(f[2])
-		}
-	case "cmd":
-	case "toggle":
-		matches, longest = matchFile(f[len(f)-1])
-	case "cd", "select", "source":
-		if len(f) == 2 {
-			matches, longest = matchFile(f[1])
-		}
-	default:
-		if !slices.Contains(gCmdWords, f[0]) {
-			matches, longest = matchFile(f[len(f)-1])
-		}
-	}
-
-	longestAcc = append(acc[:len(acc)-len([]rune(f[len(f)-1]))], longest...)
-	return
-}
-
-func completeFile(acc []rune) (matches []string, longestAcc []rune) {
-	s := string(acc)
-
-	wd, err := os.Getwd()
-	if err != nil {
-		log.Printf("getting current directory: %s", err)
-	}
-
-	files, err := os.ReadDir(wd)
-	if err != nil {
-		log.Printf("reading directory: %s", err)
 	}
 
 	for _, f := range files {
@@ -413,35 +354,114 @@ func completeFile(acc []rune) (matches []string, longestAcc []rune) {
 			continue
 		}
 
-		matches = append(matches, f.Name())
-
-		if longestAcc == nil {
-			longestAcc = []rune(f.Name())
+		matches = append(matches, compMatch{f.Name(), f.Name()})
+		if len(matches) == 1 {
+			result = f.Name()
 		} else {
-			longestAcc = matchLongest(longestAcc, []rune(f.Name()))
+			result = commonPrefix(strings.ToLower(result), strings.ToLower(f.Name()))
 		}
 	}
 
-	if len(longestAcc) < len(acc) {
-		longestAcc = acc
+	if len(matches) == 0 {
+		result = s
 	}
-
 	return
 }
 
-func completeShell(acc []rune) (matches []string, longestAcc []rune) {
+func completeCmd(acc []rune) (matches []compMatch, result string) {
 	s := string(acc)
 	f := tokenize(s)
 
-	var longest []rune
+	if len(f) == 1 {
+		matches, result = matchCmd(s)
+		return
+	}
+
+	switch f[0] {
+	case "set":
+		if len(f) == 2 {
+			matches, result = matchWord(f[1], gOptWords)
+			break
+		}
+		if len(f) != 3 {
+			break
+		}
+		switch f[1] {
+		case "filtermethod", "searchmethod":
+			matches, result = matchWord(f[2], []string{"glob", "regex", "text"})
+		case "info":
+			matches, result = matchList(f[2], []string{"atime", "btime", "ctime", "custom", "group", "perm", "size", "time", "user"})
+		case "preserve":
+			matches, result = matchList(f[2], []string{"mode", "timestamps"})
+		case "selmode":
+			matches, result = matchWord(f[2], []string{"all", "dir"})
+		case "sortby":
+			matches, result = matchWord(f[2], []string{"atime", "btime", "ctime", "custom", "ext", "name", "natural", "size", "time"})
+		default:
+			if slices.Contains(gOptWords, f[1]+"!") {
+				matches, result = matchWord(f[2], []string{"false", "true"})
+			}
+		}
+	case "setlocal":
+		if len(f) == 2 {
+			matches, result = matchCmdFile(f[1])
+			break
+		}
+		if len(f) == 3 {
+			matches, result = matchWord(f[2], gLocalOptWords)
+			break
+		}
+		if len(f) != 4 {
+			break
+		}
+		switch f[2] {
+		case "info":
+			matches, result = matchList(f[3], []string{"atime", "btime", "ctime", "custom", "group", "perm", "size", "time", "user"})
+		case "sortby":
+			matches, result = matchWord(f[3], []string{"atime", "btime", "ctime", "custom", "ext", "name", "natural", "size", "time"})
+		default:
+			if slices.Contains(gLocalOptWords, f[2]+"!") {
+				matches, result = matchWord(f[3], []string{"false", "true"})
+			}
+		}
+	case "map", "nmap", "vmap", "cmap":
+		if len(f) == 3 {
+			matches, result = matchCmd(f[2])
+		}
+	case "cmd":
+	case "toggle":
+		matches, result = matchCmdFile(f[len(f)-1])
+	case "cd", "select", "source":
+		if len(f) == 2 {
+			matches, result = matchCmdFile(f[1])
+		}
+	default:
+		if !slices.Contains(gCmdWords, f[0]) {
+			matches, result = matchCmdFile(f[len(f)-1])
+		}
+	}
+
+	f[len(f)-1] = result
+	result = strings.Join(f, " ")
+	return
+}
+
+func completeShell(acc []rune) (matches []compMatch, result string) {
+	f := tokenize(string(acc))
 
 	switch len(f) {
 	case 1:
-		matches, longestAcc = matchExec(s)
+		matches, result = matchExec(f[0])
 	default:
-		matches, longest = matchFile(f[len(f)-1])
-		longestAcc = append(acc[:len(acc)-len([]rune(f[len(f)-1]))], longest...)
+		matches, result = matchShellFile(f[len(f)-1])
 	}
 
+	f[len(f)-1] = result
+	result = strings.Join(f, " ")
+	return
+}
+
+func completeSearch(acc []rune) (matches []compMatch, result string) {
+	matches, result = matchSearch(string(acc))
 	return
 }

--- a/lfrc
+++ b/lfrc
@@ -1,0 +1,2 @@
+cmap <a-j> cmd-menu-complete
+cmap <a-k> cmd-menu-complete-back

--- a/misc.go
+++ b/misc.go
@@ -78,7 +78,7 @@ func runeSliceWidthLastRange(rs []rune, maxWidth int) []rune {
 
 // This function is used to escape whitespaces and special characters with
 // backslashes in a given string.
-func escape(s string) string {
+func cmdEscape(s string) string {
 	buf := make([]rune, 0, len(s))
 	for _, r := range s {
 		if unicode.IsSpace(r) || r == '\\' || r == ';' || r == '#' {
@@ -91,7 +91,7 @@ func escape(s string) string {
 
 // This function is used to remove backslashes that are used to escape
 // whitespaces and special characters in a given string.
-func unescape(s string) string {
+func cmdUnescape(s string) string {
 	esc := false
 	buf := make([]rune, 0, len(s))
 	for _, r := range s {

--- a/misc.go
+++ b/misc.go
@@ -117,27 +117,28 @@ func cmdUnescape(s string) string {
 }
 
 // This function splits the given string by whitespaces. It is aware of escaped
-// whitespaces so that they are not split unintentionally.
+// and quoted whitespaces so that they are not split unintentionally.
 func tokenize(s string) []string {
 	esc := false
+	quote := false
 	var buf []rune
 	var toks []string
 	for _, r := range s {
-		if r == '\\' {
-			esc = true
-			buf = append(buf, r)
-			continue
-		}
-		if esc {
+		switch {
+		case esc:
 			esc = false
 			buf = append(buf, r)
-			continue
-		}
-		if !unicode.IsSpace(r) {
+		case r == '\\':
+			esc = true
 			buf = append(buf, r)
-		} else {
+		case r == '"':
+			quote = !quote
+			buf = append(buf, r)
+		case unicode.IsSpace(r) && !quote:
 			toks = append(toks, string(buf))
 			buf = nil
+		default:
+			buf = append(buf, r)
 		}
 	}
 	return append(toks, string(buf))

--- a/misc_test.go
+++ b/misc_test.go
@@ -195,7 +195,7 @@ func TestTokenize(t *testing.T) {
 		{`"foo\" bar"`, []string{`"foo\" bar"`}},
 		{`\"foo bar\"`, []string{`\"foo`, `bar\"`}},
 		{`:rename foo\ bar`, []string{":rename", `foo\ bar`}},
-		{`:cd "C:\Program Files"`, []string{":cd", `"C:\Program Files"`}},
+		{`!dir "C:\Program Files"`, []string{"!dir", `"C:\Program Files"`}},
 	}
 
 	for _, test := range tests {

--- a/misc_test.go
+++ b/misc_test.go
@@ -128,7 +128,7 @@ func TestRuneSliceWidthLastRange(t *testing.T) {
 	}
 }
 
-func TestEscape(t *testing.T) {
+func TestCmdEscape(t *testing.T) {
 	tests := []struct {
 		s   string
 		exp string
@@ -147,13 +147,13 @@ func TestEscape(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if got := escape(test.s); !reflect.DeepEqual(got, test.exp) {
+		if got := cmdEscape(test.s); !reflect.DeepEqual(got, test.exp) {
 			t.Errorf("at input '%v' expected '%v' but got '%v'", test.s, test.exp, got)
 		}
 	}
 }
 
-func TestUnescape(t *testing.T) {
+func TestCmdUnescape(t *testing.T) {
 	tests := []struct {
 		s   string
 		exp string
@@ -172,7 +172,7 @@ func TestUnescape(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if got := unescape(test.s); !reflect.DeepEqual(got, test.exp) {
+		if got := cmdUnescape(test.s); !reflect.DeepEqual(got, test.exp) {
 			t.Errorf("at input '%v' expected '%v' but got '%v'", test.s, test.exp, got)
 		}
 	}

--- a/misc_test.go
+++ b/misc_test.go
@@ -185,8 +185,14 @@ func TestTokenize(t *testing.T) {
 	}{
 		{"", []string{""}},
 		{"foo", []string{"foo"}},
+		{`foo\`, []string{`foo\`}},
+		{`foo"`, []string{`foo"`}},
 		{"foo bar", []string{"foo", "bar"}},
+		{`foo\ bar`, []string{`foo\ bar`}},
+		{`"foo bar"`, []string{`"foo bar"`}},
+		{`"foo\" bar"`, []string{`"foo\" bar"`}},
 		{`:rename foo\ bar`, []string{":rename", `foo\ bar`}},
+		{`:cd "C:\Program Files"`, []string{":cd", `"C:\Program Files"`}},
 	}
 
 	for _, test := range tests {

--- a/misc_test.go
+++ b/misc_test.go
@@ -190,6 +190,8 @@ func TestTokenize(t *testing.T) {
 		{"foo bar", []string{"foo", "bar"}},
 		{`foo\ bar`, []string{`foo\ bar`}},
 		{`"foo bar"`, []string{`"foo bar"`}},
+		{`"foo" "bar"`, []string{`"foo"`, `"bar"`}},
+		{`"foo "bar"`, []string{`"foo "bar"`}},
 		{`"foo\" bar"`, []string{`"foo\" bar"`}},
 		{`\"foo bar\"`, []string{`\"foo`, `bar\"`}},
 		{`:rename foo\ bar`, []string{":rename", `foo\ bar`}},

--- a/misc_test.go
+++ b/misc_test.go
@@ -191,6 +191,7 @@ func TestTokenize(t *testing.T) {
 		{`foo\ bar`, []string{`foo\ bar`}},
 		{`"foo bar"`, []string{`"foo bar"`}},
 		{`"foo\" bar"`, []string{`"foo\" bar"`}},
+		{`\"foo bar\"`, []string{`\"foo`, `bar\"`}},
 		{`:rename foo\ bar`, []string{":rename", `foo\ bar`}},
 		{`:cd "C:\Program Files"`, []string{":cd", `"C:\Program Files"`}},
 	}

--- a/os.go
+++ b/os.go
@@ -233,7 +233,7 @@ func quoteString(s string) string {
 func shellEscape(s string) string {
 	buf := make([]rune, 0, len(s))
 	for _, r := range s {
-		if strings.ContainsRune(" !\"$&'()*,/:;<=>?@[\\]^`{|}", r) {
+		if strings.ContainsRune(" !\"$&'()*,:;<=>?@[\\]^`{|}", r) {
 			buf = append(buf, '\\')
 		}
 		buf = append(buf, r)

--- a/os.go
+++ b/os.go
@@ -229,3 +229,31 @@ func errCrossDevice(err error) bool {
 func quoteString(s string) string {
 	return s
 }
+
+func shellEscape(s string) string {
+	buf := make([]rune, 0, len(s))
+	for _, r := range s {
+		if strings.ContainsRune(" !\"$&'()*,/:;<=>?@[\\]^`{|}", r) {
+			buf = append(buf, '\\')
+		}
+		buf = append(buf, r)
+	}
+	return string(buf)
+}
+
+func shellUnescape(s string) string {
+	esc := false
+	buf := make([]rune, 0, len(s))
+	for _, r := range s {
+		if r == '\\' && !esc {
+			esc = true
+			continue
+		}
+		esc = false
+		buf = append(buf, r)
+	}
+	if esc {
+		buf = append(buf, '\\')
+	}
+	return string(buf)
+}

--- a/os_windows.go
+++ b/os_windows.go
@@ -234,8 +234,5 @@ func shellEscape(s string) string {
 }
 
 func shellUnescape(s string) string {
-	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
-		return s[1 : len(s)-1]
-	}
-	return s
+	return strings.ReplaceAll(s, `"`, "")
 }

--- a/os_windows.go
+++ b/os_windows.go
@@ -223,3 +223,19 @@ func quoteString(s string) string {
 	}
 	return s
 }
+
+func shellEscape(s string) string {
+	for _, r := range s {
+		if strings.ContainsRune(" !%&'()+,;=[]^`{}~", r) {
+			return fmt.Sprintf(`"%s"`, s)
+		}
+	}
+	return s
+}
+
+func shellUnescape(s string) string {
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		return s[1 : len(s)-1]
+	}
+	return s
+}

--- a/ui.go
+++ b/ui.go
@@ -1678,7 +1678,7 @@ func listMatches(screen tcell.Screen, matches []compMatch, selectedInd int) stri
 	wtot, _ := screen.Size()
 	wcol := 0
 	for _, m := range matches {
-		wcol = max(wcol, len(m.name))
+		wcol = max(wcol, runeSliceWidth([]rune(m.name)))
 	}
 	wcol += gOpts.tabstop - wcol%gOpts.tabstop
 	ncol := max(wtot/wcol, 1)
@@ -1688,11 +1688,12 @@ func listMatches(screen tcell.Screen, matches []compMatch, selectedInd int) stri
 	for i := 0; i < mlen; {
 		for j := 0; j < ncol && i < mlen; i, j = i+1, j+1 {
 			name := matches[i].name
+			w := runeSliceWidth([]rune(name))
 
-			if selectedInd == i {
-				fmt.Fprintf(&b, "\033[7m%s\033[0m%*s", name, wcol-len(name), "")
+			if i == selectedInd {
+				fmt.Fprintf(&b, "\033[7m%s\033[0m%*s", name, wcol-w, "")
 			} else {
-				fmt.Fprintf(&b, "%s%*s", name, wcol-len(name), "")
+				fmt.Fprintf(&b, "%s%*s", name, wcol-w, "")
 			}
 		}
 		b.WriteByte('\n')

--- a/ui.go
+++ b/ui.go
@@ -658,7 +658,6 @@ type ui struct {
 	cmdAccLeft  []rune
 	cmdAccRight []rune
 	cmdYankBuf  []rune
-	cmdTmp      []rune
 	keyAcc      []rune
 	keyCount    []rune
 	styles      styleMap
@@ -1668,7 +1667,7 @@ func anyKey() {
 	os.Stdin.Read(b)
 }
 
-func listMatches(screen tcell.Screen, matches []string, selectedInd int) string {
+func listMatches(screen tcell.Screen, matches []compMatch, selectedInd int) string {
 	mlen := len(matches)
 	if mlen < 2 {
 		return ""
@@ -1679,7 +1678,7 @@ func listMatches(screen tcell.Screen, matches []string, selectedInd int) string 
 	wtot, _ := screen.Size()
 	wcol := 0
 	for _, m := range matches {
-		wcol = max(wcol, len(m))
+		wcol = max(wcol, len(m.name))
 	}
 	wcol += gOpts.tabstop - wcol%gOpts.tabstop
 	ncol := max(wtot/wcol, 1)
@@ -1688,12 +1687,12 @@ func listMatches(screen tcell.Screen, matches []string, selectedInd int) string 
 
 	for i := 0; i < mlen; {
 		for j := 0; j < ncol && i < mlen; i, j = i+1, j+1 {
-			target := matches[i]
+			name := matches[i].name
 
 			if selectedInd == i {
-				fmt.Fprintf(&b, "\033[7m%s\033[0m%*s", target, wcol-len(target), "")
+				fmt.Fprintf(&b, "\033[7m%s\033[0m%*s", name, wcol-len(name), "")
 			} else {
-				fmt.Fprintf(&b, "%s%*s", target, wcol-len(target), "")
+				fmt.Fprintf(&b, "%s%*s", name, wcol-len(name), "")
 			}
 		}
 		b.WriteByte('\n')


### PR DESCRIPTION
Changes:

- Refactor of the completion module, primarily to have the `match...` functions return the result for each possible match, so that they can be displayed when the user cycles through the completions using `cmd-menu-complete`/`cmd-menu-complete-back`
- Add support for completing list options (e.g. `set info user:group:size:time`)
- Provide different implementations for escaping/unescaping for `lfrc` command syntax, Unix and Windows. It is a bit hacky, but for now I want to keep `lf` as shell-agnostic as possible which means minimizing the logic based on `gOpts.shell`
- Fix alignment bug in the completion menu when displaying filenames with fullwidth characters