### PR TITLE
Dircounts should have a width of 5 when displaying

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -105,7 +105,7 @@ func newFile(path string) *file {
 		if err != nil {
 			dirCount = -2
 		} else {
-			names, err := d.Readdirnames(1000)
+			names, err := d.Readdirnames(10000)
 			d.Close()
 
 			if names == nil && err != io.EOF {

--- a/ui.go
+++ b/ui.go
@@ -301,13 +301,13 @@ func fileInfo(f *file, d *dir, userWidth int, groupWidth int, customWidth int) (
 			if f.IsDir() && getDirCounts(d.path) {
 				switch {
 				case f.dirCount < -1:
-					info.WriteString("    !")
+					info.WriteString("     !")
 				case f.dirCount < 0:
-					info.WriteString("    ?")
-				case f.dirCount < 1000:
-					fmt.Fprintf(&info, " %4d", f.dirCount)
+					info.WriteString("     ?")
+				case f.dirCount < 10000:
+					fmt.Fprintf(&info, " %5d", f.dirCount)
 				default:
-					info.WriteString(" 999+")
+					info.WriteString(" 9999+")
 				}
 				continue
 			}


### PR DESCRIPTION
The width for displaying file sizes was changed from 4 to 5 in #2062 to display binary sizes. The same width should apply to `dircounts` as well.