### PR TITLE
Pass all files for `on-load` hook command

### DIFF
--- a/app.go
+++ b/app.go
@@ -430,7 +430,13 @@ func (app *app) loop() {
 			}
 
 			app.watchDir(d)
-			onLoad(app, d.fileNames())
+
+			paths := []string{}
+			for _, file := range d.allFiles {
+				paths = append(paths, file.path)
+			}
+			onLoad(app, paths)
+
 			app.ui.draw(app.nav)
 		case r := <-app.nav.regChan:
 			app.nav.regCache[r.path] = r

--- a/nav.go
+++ b/nav.go
@@ -442,15 +442,6 @@ func (dir *dir) name() string {
 	return dir.files[dir.ind].Name()
 }
 
-func (d *dir) fileNames() []string {
-	names := []string{}
-	for _, file := range d.files {
-		names = append(names, file.path)
-	}
-
-	return names
-}
-
 func (nav *nav) isVisualMode() bool {
 	return nav.init && nav.currDir().visualAnchor != -1
 }


### PR DESCRIPTION
cc https://github.com/gokcehan/lf/issues/618#issuecomment-3156834011

Also got rid of the `fileNames` function, it would have to be renamed to `allFileNames` and it was only being called in one place anyway.