### PR TITLE
Replace save buffer with clipboard struct

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -432,20 +432,22 @@ Select/unselect files that match the given glob.
 
 ## copy (default `y`)
 
-If there are no selections, save the path of the current file to the copy buffer, otherwise, copy the paths of selected files.
+Save the paths of selected files to the clipboard as files to be copied.
+If there are no selected files, the path of the current file is used instead.
 
 ## cut (default `d`)
 
-If there are no selections, save the path of the current file to the cut buffer, otherwise, copy the paths of selected files.
+Save the paths of selected files to the clipboard as files to be moved.
+If there are no selected files, the path of the current file is used instead.
 
 ## paste (default `p`)
 
-Copy/Move files in the copy/cut buffer to the current working directory.
+Copy/Move files in the clipboard to the current working directory.
 A custom `paste` command can be defined to override this default.
 
 ## clear (default `c`)
 
-Clear file paths in copy/cut buffer.
+Clear file paths in the clipboard.
 
 ## sync
 

--- a/doc.txt
+++ b/doc.txt
@@ -434,22 +434,24 @@ Select/unselect files that match the given glob.
 
 copy (default y)
 
-If there are no selections, save the path of the current file to the
-copy buffer, otherwise, copy the paths of selected files.
+Save the paths of selected files to the clipboard as files to be copied.
+If there are no selected files, the path of the current file is used
+instead.
 
 cut (default d)
 
-If there are no selections, save the path of the current file to the cut
-buffer, otherwise, copy the paths of selected files.
+Save the paths of selected files to the clipboard as files to be moved.
+If there are no selected files, the path of the current file is used
+instead.
 
 paste (default p)
 
-Copy/Move files in the copy/cut buffer to the current working directory.
-A custom paste command can be defined to override this default.
+Copy/Move files in the clipboard to the current working directory. A
+custom paste command can be defined to override this default.
 
 clear (default c)
 
-Clear file paths in copy/cut buffer.
+Clear file paths in the clipboard.
 
 sync
 

--- a/eval.go
+++ b/eval.go
@@ -1271,7 +1271,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 
-		if err := app.nav.save(true); err != nil {
+		if err := app.nav.save(clipboardCopy); err != nil {
 			app.ui.echoerrf("copy: %s", err)
 			return
 		}
@@ -1293,7 +1293,7 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 
-		if err := app.nav.save(false); err != nil {
+		if err := app.nav.save(clipboardCut); err != nil {
 			app.ui.echoerrf("cut: %s", err)
 			return
 		}
@@ -1327,7 +1327,7 @@ func (e *callExpr) eval(app *app, args []string) {
 		if !app.nav.init {
 			return
 		}
-		if err := saveFiles(nil, false); err != nil {
+		if err := saveFiles(clipboard{nil, clipboardCut}); err != nil {
 			app.ui.echoerrf("clear: %s", err)
 			return
 		}

--- a/lf.1
+++ b/lf.1
@@ -451,17 +451,19 @@ Remove the selection of all files in all directories.
 .SS glob\-select, glob\-unselect
 Select/unselect files that match the given glob.
 .SS copy (default \f[CR]y\f[R])
-If there are no selections, save the path of the current file to the
-copy buffer, otherwise, copy the paths of selected files.
+Save the paths of selected files to the clipboard as files to be copied.
+If there are no selected files, the path of the current file is used
+instead.
 .SS cut (default \f[CR]d\f[R])
-If there are no selections, save the path of the current file to the cut
-buffer, otherwise, copy the paths of selected files.
+Save the paths of selected files to the clipboard as files to be moved.
+If there are no selected files, the path of the current file is used
+instead.
 .SS paste (default \f[CR]p\f[R])
-Copy/Move files in the copy/cut buffer to the current working directory.
+Copy/Move files in the clipboard to the current working directory.
 A custom \f[CR]paste\f[R] command can be defined to override this
 default.
 .SS clear (default \f[CR]c\f[R])
-Clear file paths in copy/cut buffer.
+Clear file paths in the clipboard.
 .SS sync
 Synchronize copied/cut files with the server.
 This command is automatically called when required.


### PR DESCRIPTION
Changes:

- Use `struct{[]string, enum}` to represent the clipboard instead of `map[string]bool`, as it is impossible to have files that are cut along with files that are copied.
- Use the term 'clipboard' instead of 'cut/copy buffer', which should be more familiar to users.