### PR TITLE
Replace `rulerfmt` with ruler file

### DIFF
--- a/app.go
+++ b/app.go
@@ -421,9 +421,6 @@ func (app *app) loop() {
 			if err == nil {
 				if curr.path != oldCurrPath {
 					app.ui.loadFile(app, true)
-					if app.ui.msgIsStat {
-						app.ui.loadFileInfo(app.nav)
-					}
 				}
 				if d.path == curr.path {
 					app.ui.dirPrev = d
@@ -472,9 +469,6 @@ func (app *app) loop() {
 			}
 
 			app.ui.loadFile(app, false)
-			if app.ui.msgIsStat {
-				app.ui.loadFileInfo(app.nav)
-			}
 
 			onLoad(app, []string{f.path})
 			app.ui.draw(app.nav)

--- a/doc.md
+++ b/doc.md
@@ -191,7 +191,6 @@ The following options can be used to customize the behavior of lf:
 	relativenumber    bool      (default false)
 	reverse           bool      (default false)
 	roundbox          bool      (default false)
-	rulerfmt          string    (default "  %a|  %p|  \033[7;31m %m \033[0m|  \033[7;33m %c \033[0m|  \033[7;35m %s \033[0m|  \033[7;34m %f \033[0m|  %i/%t")
 	scrolloff         int       (default 0)
 	searchmethod      string    (default 'text')
 	selectfmt         string    (default "\033[7;35m")
@@ -204,7 +203,6 @@ The following options can be used to customize the behavior of lf:
 	smartcase         bool      (default true)
 	smartdia          bool      (default false)
 	sortby            string    (default 'natural')
-	statfmt           string    (default "\033[36m%p\033[0m| %c| %u| %g| %S| %t| -> %l")
 	tabstop           int       (default 8)
 	tagfmt            string    (default "\033[31m")
 	tempmarks         string    (default '')
@@ -334,6 +332,12 @@ The icons file should be located at:
 	OS       system-wide               user-specific
 	Unix     /etc/lf/icons             ~/.config/lf/icons
 	Windows  C:\ProgramData\lf\icons   C:\Users\<user>\AppData\Roaming\lf\icons
+
+The ruler file should be located at:
+
+	OS       system-wide               user-specific
+	Unix     /etc/lf/ruler             ~/.config/lf/ruler
+	Windows  C:\ProgramData\lf\ruler   C:\Users\<user>\AppData\Roaming\lf\ruler
 
 The selection file should be located at:
 
@@ -947,14 +951,6 @@ Reverse the direction of sort.
 
 Draw rounded outer corners when the `drawbox` option is enabled.
 
-## rulerfmt (string) (default `  %a|  %p|  \033[7;31m %m \033[0m|  \033[7;33m %c \033[0m|  \033[7;35m %s \033[0m|  \033[7;36m %v \033[0m|  \033[7;34m %f \033[0m|  %i/%t`)
-
-Format string of the ruler shown in the bottom right corner.
-Special expansions are provided, `%a` as the pressed keys, `%p` as the progress of file operations, `%m` as the number of files to be cut (moved), `%c` as the number of files to be copied, `%s` as the number of selected files, `%v` as the number of visually selected files, `%f` as the filter, `%i` as the position of the cursor, `%t` as the number of files shown in the current directory, `%h` as the number of files hidden in the current directory, `%P` as the scroll percentage, and `%d` as the amount of free disk space remaining.
-Additional expansions are provided for environment variables exported by lf, in the form `%{lf_<name>}` (e.g. `%{lf_selmode}`). This is useful for displaying the current settings.
-Expansions are also provided for user-defined options, in the form `%{lf_user_<name>}` (e.g. `%{lf_user_foo}`).
-The `|` character splits the format string into sections. Any section containing a failed expansion (result is a blank string) is discarded and not shown.
-
 ## scrolloff (int) (default 0)
 
 Minimum number of offset lines shown at all times at the top and bottom of the screen when scrolling.
@@ -1024,15 +1020,6 @@ Meaning of each sort type:
 	ctime     time of last status (inode) change
 	ext       file extension
 	custom    property defined via `addcustominfo`
-
-## statfmt (string) (default `\033[36m%p\033[0m| %c| %u| %g| %S| %t| -> %l`)
-
-Format string of the file info shown in the bottom left corner.
-Special expansions are provided, `%p` as the file permissions, `%c` as the link count, `%u` as the user, `%g` as the group, `%s` as the file size, `%S` as the file size but with a fixed width of five characters (left-padded with spaces), `%t` as the last modified time, `%l` as the link target, `%m` as the current mode and `%M` as the current mode but also shown in Normal mode (displaying `NORMAL` instead of a blank string).
-
-The `|` character splits the format string into sections. Any section containing a failed expansion (result is a blank string) is discarded and not shown.
-
-File size is formatted using first letter of IEC 80000-13:2025 prefixes for binary multiples (i.e. 1024 bytes is `1.0K`).
 
 ## tabstop (int) (default 8)
 
@@ -2018,3 +2005,48 @@ https://github.com/gokcehan/lf/blob/master/etc/icons.example
 
 A sample colored icons file can be found at
 https://github.com/gokcehan/lf/blob/master/etc/icons_colored.example
+
+# RULER
+
+The ruler can be configured using a ruler file (refer to the [CONFIGURATION section](https://github.com/gokcehan/lf/blob/master/doc.md#configuration)).
+The contents of the ruler file should be a Go template which is then rendered to create the actual output (refer to https://pkg.go.dev/text/template for more details on the syntax).
+
+The following data fields are exported:
+
+	.Acc              string              Key accumulator
+	.Progress         []string            Progress indicators for copied, moved and deleted files
+	.Copy             []string            List of files in the clipboard to be copied
+	.Cut              []string            List of files in the clipboard to be moved
+	.Select           []string            Selection list
+	.Visual           []string            Visual selection
+	.Index            int                 Index of the cursor
+	.Total            int                 Number of visible files in the current directory
+	.Hidden           int                 Number of hidden files in the current directory
+	.Percentage       string              Scroll percentage
+	.Filter           []string            Filter currently being applied
+	.Mode             string              Current mode ("NORMAL" for Normal mode, and "VISUAL" for Visual mode)
+	.Options          map[string]string   The value of options (e.g. {{.Options.hidden}})
+	.UserOptions      map[string]string   The value of user-defined options (e.g. {{.UserOptions.foo}})
+	.Stat.Path        string              Path of the current file
+	.Stat.Name        string              Name of the current file
+	.Stat.Size        uint64              Size of the current file
+	.Stat.Permissions string              Permissions of the current file
+	.Stat.ModTime     time.Time           Last modified time of the current file
+	.Stat.LinkCount   string              Number of hard links for the current file
+	.Stat.User        string              User of the current file
+	.Stat.Group       string              Group of the current file
+	.Stat.Target      string              Target if the current file is a symbolic link, otherwise a blank string
+
+The following functions are exported:
+
+	df       func() string                   Get an indicator representing the amount of free disk space available
+	env      func(string) string             Get the value of an environment variable
+	humanize func(uint64) string             Express a file size in a human-readable format
+	join     func([]string, string) string   Join a string array by a separator
+	substr   func(string, int, int) string   Get a substring based on starting index and length
+
+The special identifier `{{.ESC}}` can be used to output a literal escape character, which can be used in terminal escape sequences to apply colors and styles.
+The special identifier `{{.SPACER}}` can be used once to separate the ruler into left and right components.
+
+The default ruler file can be found at
+https://github.com/gokcehan/lf/blob/master/etc/ruler.default

--- a/doc.txt
+++ b/doc.txt
@@ -181,7 +181,6 @@ The following options can be used to customize the behavior of lf:
     relativenumber    bool      (default false)
     reverse           bool      (default false)
     roundbox          bool      (default false)
-    rulerfmt          string    (default "  %a|  %p|  \033[7;31m %m \033[0m|  \033[7;33m %c \033[0m|  \033[7;35m %s \033[0m|  \033[7;34m %f \033[0m|  %i/%t")
     scrolloff         int       (default 0)
     searchmethod      string    (default 'text')
     selectfmt         string    (default "\033[7;35m")
@@ -194,7 +193,6 @@ The following options can be used to customize the behavior of lf:
     smartcase         bool      (default true)
     smartdia          bool      (default false)
     sortby            string    (default 'natural')
-    statfmt           string    (default "\033[36m%p\033[0m| %c| %u| %g| %S| %t| -> %l")
     tabstop           int       (default 8)
     tagfmt            string    (default "\033[31m")
     tempmarks         string    (default '')
@@ -326,6 +324,12 @@ The icons file should be located at:
     OS       system-wide               user-specific
     Unix     /etc/lf/icons             ~/.config/lf/icons
     Windows  C:\ProgramData\lf\icons   C:\Users\<user>\AppData\Roaming\lf\icons
+
+The ruler file should be located at:
+
+    OS       system-wide               user-specific
+    Unix     /etc/lf/ruler             ~/.config/lf/ruler
+    Windows  C:\ProgramData\lf\ruler   C:\Users\<user>\AppData\Roaming\lf\ruler
 
 The selection file should be located at:
 
@@ -1020,24 +1024,6 @@ roundbox (bool) (default false)
 
 Draw rounded outer corners when the drawbox option is enabled.
 
-rulerfmt (string) (default   %a|  %p|  \033[7;31m %m \033[0m|  \033[7;33m %c \033[0m|  \033[7;35m %s \033[0m|  \033[7;36m %v \033[0m|  \033[7;34m %f \033[0m|  %i/%t)
-
-Format string of the ruler shown in the bottom right corner. Special
-expansions are provided, %a as the pressed keys, %p as the progress of
-file operations, %m as the number of files to be cut (moved), %c as the
-number of files to be copied, %s as the number of selected files, %v as
-the number of visually selected files, %f as the filter, %i as the
-position of the cursor, %t as the number of files shown in the current
-directory, %h as the number of files hidden in the current directory, %P
-as the scroll percentage, and %d as the amount of free disk space
-remaining. Additional expansions are provided for environment variables
-exported by lf, in the form %{lf_<name>} (e.g. %{lf_selmode}). This is
-useful for displaying the current settings. Expansions are also provided
-for user-defined options, in the form %{lf_user_<name>} (e.g.
-%{lf_user_foo}). The | character splits the format string into sections.
-Any section containing a failed expansion (result is a blank string) is
-discarded and not shown.
-
 scrolloff (int) (default 0)
 
 Minimum number of offset lines shown at all times at the top and bottom
@@ -1110,23 +1096,6 @@ Meaning of each sort type:
     ctime     time of last status (inode) change
     ext       file extension
     custom    property defined via `addcustominfo`
-
-statfmt (string) (default \033[36m%p\033[0m| %c| %u| %g| %S| %t| -> %l)
-
-Format string of the file info shown in the bottom left corner. Special
-expansions are provided, %p as the file permissions, %c as the link
-count, %u as the user, %g as the group, %s as the file size, %S as the
-file size but with a fixed width of five characters (left-padded with
-spaces), %t as the last modified time, %l as the link target, %m as the
-current mode and %M as the current mode but also shown in Normal mode
-(displaying NORMAL instead of a blank string).
-
-The | character splits the format string into sections. Any section
-containing a failed expansion (result is a blank string) is discarded
-and not shown.
-
-File size is formatted using first letter of IEC 80000-13:2025 prefixes
-for binary multiples (i.e. 1024 bytes is 1.0K).
 
 tabstop (int) (default 8)
 
@@ -2273,3 +2242,52 @@ https://github.com/gokcehan/lf/blob/master/etc/icons.example
 
 A sample colored icons file can be found at
 https://github.com/gokcehan/lf/blob/master/etc/icons_colored.example
+
+RULER
+
+The ruler can be configured using a ruler file (refer to the
+CONFIGURATION section). The contents of the ruler file should be a Go
+template which is then rendered to create the actual output (refer to
+https://pkg.go.dev/text/template for more details on the syntax).
+
+The following data fields are exported:
+
+    .Acc              string              Key accumulator
+    .Progress         []string            Progress indicators for copied, moved and deleted files
+    .Copy             []string            List of files in the clipboard to be copied
+    .Cut              []string            List of files in the clipboard to be moved
+    .Select           []string            Selection list
+    .Visual           []string            Visual selection
+    .Index            int                 Index of the cursor
+    .Total            int                 Number of visible files in the current directory
+    .Hidden           int                 Number of hidden files in the current directory
+    .Percentage       string              Scroll percentage
+    .Filter           []string            Filter currently being applied
+    .Mode             string              Current mode ("NORMAL" for Normal mode, and "VISUAL" for Visual mode)
+    .Options          map[string]string   The value of options (e.g. {{.Options.hidden}})
+    .UserOptions      map[string]string   The value of user-defined options (e.g. {{.UserOptions.foo}})
+    .Stat.Path        string              Path of the current file
+    .Stat.Name        string              Name of the current file
+    .Stat.Size        uint64              Size of the current file
+    .Stat.Permissions string              Permissions of the current file
+    .Stat.ModTime     time.Time           Last modified time of the current file
+    .Stat.LinkCount   string              Number of hard links for the current file
+    .Stat.User        string              User of the current file
+    .Stat.Group       string              Group of the current file
+    .Stat.Target      string              Target if the current file is a symbolic link, otherwise a blank string
+
+The following functions are exported:
+
+    df       func() string                   Get an indicator representing the amount of free disk space available
+    env      func(string) string             Get the value of an environment variable
+    humanize func(uint64) string             Express a file size in a human-readable format
+    join     func([]string, string) string   Join a string array by a separator
+    substr   func(string, int, int) string   Get a substring based on starting index and length
+
+The special identifier {{.ESC}} can be used to output a literal escape
+character, which can be used in terminal escape sequences to apply
+colors and styles. The special identifier {{.SPACER}} can be used once
+to separate the ruler into left and right components.
+
+The default ruler file can be found at
+https://github.com/gokcehan/lf/blob/master/etc/ruler.default

--- a/etc/ruler.default
+++ b/etc/ruler.default
@@ -1,0 +1,18 @@
+{{if .Stat}}
+{{.ESC}}[36m{{.Stat.Permissions}}{{.ESC}}[0m
+{{if .Stat.LinkCount}} {{.Stat.LinkCount}}{{end}}
+{{if .Stat.User}} {{.Stat.User}}{{end}}
+{{if .Stat.Group}} {{.Stat.Group}}{{end}}
+ {{humanize .Stat.Size | printf "%5s"}}
+ {{.Stat.ModTime.Format .Options.timefmt}}
+{{if .Stat.Target}} -> {{.Stat.Target}}{{end}}
+{{end}}
+{{.SPACER}}
+  {{.Acc}}
+{{if .Progress}}  {{join .Progress " "}}{{end}}
+{{if .Copy}}  {{.ESC}}[7;33m {{len .Copy}} {{.ESC}}[0m{{end}}
+{{if .Cut}}  {{.ESC}}[7;31m {{len .Cut}} {{.ESC}}[0m{{end}}
+{{if .Select}}  {{.ESC}}[7;35m {{len .Select}} {{.ESC}}[0m{{end}}
+{{if .Visual}}  {{.ESC}}[7;36m {{len .Visual}} {{.ESC}}[0m{{end}}
+{{if .Filter}}  {{.ESC}}[7;34m {{join .Filter " "}} {{.ESC}}[0m{{end}}
+  {{.Index}}/{{.Total}}

--- a/eval.go
+++ b/eval.go
@@ -365,8 +365,9 @@ func (e *setExpr) eval(app *app, args []string) {
 			clear(app.nav.regCache)
 		}
 		app.ui.loadFile(app, true)
+	// DEPRECATED: remove after r37 is released
 	case "rulerfmt":
-		gOpts.rulerfmt = e.val
+		app.ui.echoerr("option 'rulerfmt' is deprecated, use ruler file instead")
 	case "scrolloff":
 		n, err := strconv.Atoi(e.val)
 		if err != nil {
@@ -415,8 +416,9 @@ func (e *setExpr) eval(app *app, args []string) {
 		gOpts.sortby = method
 		app.nav.sort()
 		app.ui.sort()
+	// DEPRECATED: remove after r37 is released
 	case "statfmt":
-		gOpts.statfmt = e.val
+		app.ui.echoerr("option 'statfmt' is deprecated, use ruler file instead")
 	case "tabstop":
 		n, err := strconv.Atoi(e.val)
 		if err != nil {
@@ -474,7 +476,7 @@ func (e *setExpr) eval(app *app, args []string) {
 		return
 	}
 
-	app.ui.loadFileInfo(app.nav)
+	app.ui.clearmsg()
 }
 
 func (e *setLocalExpr) eval(app *app, args []string) {
@@ -560,7 +562,7 @@ func (e *setLocalExpr) eval(app *app, args []string) {
 		return
 	}
 
-	app.ui.loadFileInfo(app.nav)
+	app.ui.clearmsg()
 }
 
 func (e *mapExpr) eval(app *app, args []string) {
@@ -571,7 +573,7 @@ func (e *mapExpr) eval(app *app, args []string) {
 		gOpts.nkeys[e.keys] = e.expr
 		gOpts.vkeys[e.keys] = e.expr
 	}
-	app.ui.loadFileInfo(app.nav)
+	app.ui.clearmsg()
 }
 
 func (e *nmapExpr) eval(app *app, args []string) {
@@ -580,7 +582,7 @@ func (e *nmapExpr) eval(app *app, args []string) {
 	} else {
 		gOpts.nkeys[e.keys] = e.expr
 	}
-	app.ui.loadFileInfo(app.nav)
+	app.ui.clearmsg()
 }
 
 func (e *vmapExpr) eval(app *app, args []string) {
@@ -589,7 +591,7 @@ func (e *vmapExpr) eval(app *app, args []string) {
 	} else {
 		gOpts.vkeys[e.keys] = e.expr
 	}
-	app.ui.loadFileInfo(app.nav)
+	app.ui.clearmsg()
 }
 
 func (e *cmapExpr) eval(app *app, args []string) {
@@ -598,7 +600,7 @@ func (e *cmapExpr) eval(app *app, args []string) {
 	} else {
 		gOpts.cmdkeys[e.key] = e.expr
 	}
-	app.ui.loadFileInfo(app.nav)
+	app.ui.clearmsg()
 }
 
 func (e *cmdExpr) eval(app *app, args []string) {
@@ -619,7 +621,7 @@ func (e *cmdExpr) eval(app *app, args []string) {
 		}
 	}
 
-	app.ui.loadFileInfo(app.nav)
+	app.ui.clearmsg()
 }
 
 func preChdir(app *app) {
@@ -721,7 +723,6 @@ func update(app *app) {
 			app.ui.echoerrf("search: %s: %s", err, app.nav.search)
 		} else if old != dir.ind {
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	case gOpts.incsearch && app.ui.cmdPrefix == "?":
 		app.nav.search = string(app.ui.cmdAccLeft) + string(app.ui.cmdAccRight)
@@ -738,7 +739,6 @@ func update(app *app) {
 			app.ui.echoerrf("search: %s: %s", err, app.nav.search)
 		} else if old != dir.ind {
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	case gOpts.incfilter && app.ui.cmdPrefix == "filter: ":
 		filter := string(app.ui.cmdAccLeft) + string(app.ui.cmdAccRight)
@@ -749,7 +749,6 @@ func update(app *app) {
 			app.ui.echoerrf("filter: %s", err)
 		} else if old != dir.ind {
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	}
 }
@@ -774,7 +773,6 @@ func resetIncCmd(app *app) {
 		if dir.ind != app.nav.searchInd {
 			dir.ind = app.nav.searchInd
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	} else if gOpts.incfilter && app.ui.cmdPrefix == "filter: " {
 		dir := app.nav.currDir()
@@ -782,7 +780,6 @@ func resetIncCmd(app *app) {
 		app.nav.setFilter(app.nav.prevFilter)
 		if old != dir.ind {
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	}
 }
@@ -797,17 +794,6 @@ func normal(app *app) {
 	app.ui.cmdAccLeft = nil
 	app.ui.cmdAccRight = nil
 	app.ui.cmdPrefix = ""
-
-	// ensure the mode indicator in `statfmt` is updated properly
-	app.ui.loadFileInfo(app.nav)
-}
-
-func visual(app *app) {
-	dir := app.nav.currDir()
-	dir.visualAnchor = dir.ind
-	dir.visualWrap = 0
-
-	app.ui.loadFileInfo(app.nav)
 }
 
 func insert(app *app, arg string) {
@@ -827,7 +813,6 @@ func insert(app *app, arg string) {
 				app.ui.echoerrf("find: pattern not found: %s", app.nav.find)
 			case 1:
 				app.ui.loadFile(app, true)
-				app.ui.loadFileInfo(app.nav)
 			default:
 				app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(arg)...)
 				return
@@ -842,7 +827,6 @@ func insert(app *app, arg string) {
 				app.ui.echoerrf("find: pattern not found: %s", app.nav.find)
 			} else if moved {
 				app.ui.loadFile(app, true)
-				app.ui.loadFileInfo(app.nav)
 			}
 		}
 
@@ -856,7 +840,6 @@ func insert(app *app, arg string) {
 				app.ui.echoerrf("find-back: pattern not found: %s", app.nav.find)
 			case 1:
 				app.ui.loadFile(app, true)
-				app.ui.loadFileInfo(app.nav)
 			default:
 				app.ui.cmdAccLeft = append(app.ui.cmdAccLeft, []rune(arg)...)
 				return
@@ -871,7 +854,6 @@ func insert(app *app, arg string) {
 				app.ui.echoerrf("find-back: pattern not found: %s", app.nav.find)
 			} else if moved {
 				app.ui.loadFile(app, true)
-				app.ui.loadFileInfo(app.nav)
 			}
 		}
 
@@ -886,7 +868,6 @@ func insert(app *app, arg string) {
 			}
 			app.nav.unselect()
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	case strings.HasPrefix(app.ui.cmdPrefix, "replace"):
 		normal(app)
@@ -906,7 +887,6 @@ func insert(app *app, arg string) {
 				}
 			}
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	case strings.HasPrefix(app.ui.cmdPrefix, "create"):
 		normal(app)
@@ -930,7 +910,6 @@ func insert(app *app, arg string) {
 				}
 			}
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	case app.ui.cmdPrefix == "mark-save: ":
 		normal(app)
@@ -951,7 +930,6 @@ func insert(app *app, arg string) {
 				return
 			}
 		}
-		app.ui.loadFileInfo(app.nav)
 	case app.ui.cmdPrefix == "mark-load: ":
 		normal(app)
 
@@ -976,7 +954,6 @@ func insert(app *app, arg string) {
 			return
 		}
 		app.ui.loadFile(app, true)
-		app.ui.loadFileInfo(app.nav)
 
 		if wd != path {
 			app.nav.marks["'"] = wd
@@ -1004,7 +981,6 @@ func insert(app *app, arg string) {
 				return
 			}
 		}
-		app.ui.loadFileInfo(app.nav)
 	case app.ui.cmdPrefix == ":" && len(app.ui.cmdAccLeft) == 0:
 		switch arg {
 		case "!", "$", "%", "&":
@@ -1031,7 +1007,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 		if app.nav.up(e.count) {
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	case "half-up":
 		if !app.nav.init {
@@ -1039,7 +1014,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 		if app.nav.up(e.count * app.nav.height / 2) {
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	case "page-up":
 		if !app.nav.init {
@@ -1047,7 +1021,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 		if app.nav.up(e.count * app.nav.height) {
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	case "scroll-up":
 		if !app.nav.init {
@@ -1055,7 +1028,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 		if app.nav.scrollUp(e.count) {
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	case "down":
 		if !app.nav.init {
@@ -1063,7 +1035,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 		if app.nav.down(e.count) {
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	case "half-down":
 		if !app.nav.init {
@@ -1071,7 +1042,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 		if app.nav.down(e.count * app.nav.height / 2) {
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	case "page-down":
 		if !app.nav.init {
@@ -1079,7 +1049,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 		if app.nav.down(e.count * app.nav.height) {
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	case "scroll-down":
 		if !app.nav.init {
@@ -1087,7 +1056,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 		if app.nav.scrollDown(e.count) {
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	case "updir":
 		if !app.nav.init {
@@ -1102,7 +1070,6 @@ func (e *callExpr) eval(app *app, args []string) {
 			}
 		}
 		app.ui.loadFile(app, true)
-		app.ui.loadFileInfo(app.nav)
 		restartIncCmd(app)
 		onChdir(app)
 	case "open":
@@ -1124,7 +1091,6 @@ func (e *callExpr) eval(app *app, args []string) {
 				return
 			}
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 			restartIncCmd(app)
 			onChdir(app)
 			return
@@ -1136,8 +1102,6 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 
-		app.ui.loadFileInfo(app.nav)
-
 		if cmd, ok := gOpts.cmds["open"]; ok {
 			cmd.eval(app, e.args)
 		}
@@ -1148,7 +1112,6 @@ func (e *callExpr) eval(app *app, args []string) {
 			app.nav.cdJumpListNext()
 		}
 		app.ui.loadFile(app, true)
-		app.ui.loadFileInfo(app.nav)
 		restartIncCmd(app)
 		onChdir(app)
 	case "jump-prev":
@@ -1158,7 +1121,6 @@ func (e *callExpr) eval(app *app, args []string) {
 			app.nav.cdJumpListPrev()
 		}
 		app.ui.loadFile(app, true)
-		app.ui.loadFileInfo(app.nav)
 		restartIncCmd(app)
 		onChdir(app)
 	case "top":
@@ -1173,7 +1135,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 		if moved {
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	case "bottom":
 		if !app.nav.init {
@@ -1189,7 +1150,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 		if moved {
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	case "high":
 		if !app.nav.init {
@@ -1197,7 +1157,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 		if app.nav.high() {
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	case "middle":
 		if !app.nav.init {
@@ -1205,7 +1164,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 		if app.nav.middle() {
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	case "low":
 		if !app.nav.init {
@@ -1213,7 +1171,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 		if app.nav.low() {
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	case "toggle":
 		if !app.nav.init {
@@ -1287,7 +1244,6 @@ func (e *callExpr) eval(app *app, args []string) {
 				return
 			}
 		}
-		app.ui.loadFileInfo(app.nav)
 	case "cut":
 		if !app.nav.init {
 			return
@@ -1309,7 +1265,6 @@ func (e *callExpr) eval(app *app, args []string) {
 				return
 			}
 		}
-		app.ui.loadFileInfo(app.nav)
 	case "paste":
 		if !app.nav.init {
 			return
@@ -1322,7 +1277,6 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 		app.ui.loadFile(app, true)
-		app.ui.loadFileInfo(app.nav)
 	case "clear":
 		if !app.nav.init {
 			return
@@ -1342,7 +1296,6 @@ func (e *callExpr) eval(app *app, args []string) {
 				return
 			}
 		}
-		app.ui.loadFileInfo(app.nav)
 	case "sync":
 		if err := app.nav.sync(); err != nil {
 			app.ui.echoerrf("sync: %s", err)
@@ -1381,7 +1334,6 @@ func (e *callExpr) eval(app *app, args []string) {
 			app.ui.echoerrf("reload: %s", err)
 		}
 		app.ui.loadFile(app, true)
-		app.ui.loadFileInfo(app.nav)
 	case "delete":
 		if !app.nav.init {
 			return
@@ -1416,7 +1368,6 @@ func (e *callExpr) eval(app *app, args []string) {
 				app.ui.cmdPrefix = "delete " + strconv.Itoa(len(list)) + " items? [y/N] "
 			}
 		}
-		app.ui.loadFileInfo(app.nav)
 	case "rename":
 		if !app.nav.init {
 			return
@@ -1452,42 +1403,36 @@ func (e *callExpr) eval(app *app, args []string) {
 				app.ui.cmdAccRight = append(app.ui.cmdAccRight, []rune(extension)...)
 			}
 		}
-		app.ui.loadFileInfo(app.nav)
 	case "read":
 		if app.ui.cmdPrefix == ">" {
 			return
 		}
 		normal(app)
 		app.ui.cmdPrefix = ":"
-		app.ui.loadFileInfo(app.nav)
 	case "shell":
 		if app.ui.cmdPrefix == ">" {
 			return
 		}
 		normal(app)
 		app.ui.cmdPrefix = "$"
-		app.ui.loadFileInfo(app.nav)
 	case "shell-pipe":
 		if app.ui.cmdPrefix == ">" {
 			return
 		}
 		normal(app)
 		app.ui.cmdPrefix = "%"
-		app.ui.loadFileInfo(app.nav)
 	case "shell-wait":
 		if app.ui.cmdPrefix == ">" {
 			return
 		}
 		normal(app)
 		app.ui.cmdPrefix = "!"
-		app.ui.loadFileInfo(app.nav)
 	case "shell-async":
 		if app.ui.cmdPrefix == ">" {
 			return
 		}
 		normal(app)
 		app.ui.cmdPrefix = "&"
-		app.ui.loadFileInfo(app.nav)
 	case "find":
 		if app.ui.cmdPrefix == ">" {
 			return
@@ -1495,7 +1440,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		normal(app)
 		app.ui.cmdPrefix = "find: "
 		app.nav.findBack = false
-		app.ui.loadFileInfo(app.nav)
 	case "find-back":
 		if app.ui.cmdPrefix == ">" {
 			return
@@ -1503,7 +1447,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		normal(app)
 		app.ui.cmdPrefix = "find-back: "
 		app.nav.findBack = true
-		app.ui.loadFileInfo(app.nav)
 	case "find-next":
 		if !app.nav.init {
 			return
@@ -1519,7 +1462,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 		if old != dir.ind {
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	case "find-prev":
 		if !app.nav.init {
@@ -1536,7 +1478,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 		if old != dir.ind {
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		}
 	case "search":
 		if !app.nav.init {
@@ -1551,7 +1492,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.nav.searchInd = dir.ind
 		app.nav.searchPos = dir.pos
 		app.nav.searchBack = false
-		app.ui.loadFileInfo(app.nav)
 	case "search-back":
 		if !app.nav.init {
 			return
@@ -1565,7 +1505,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		app.nav.searchInd = dir.ind
 		app.nav.searchPos = dir.pos
 		app.nav.searchBack = true
-		app.ui.loadFileInfo(app.nav)
 	case "search-next":
 		if !app.nav.init {
 			return
@@ -1576,14 +1515,12 @@ func (e *callExpr) eval(app *app, args []string) {
 					app.ui.echoerrf("search-back: %s: %s", err, app.nav.search)
 				} else if moved {
 					app.ui.loadFile(app, true)
-					app.ui.loadFileInfo(app.nav)
 				}
 			} else {
 				if moved, err := app.nav.searchNext(); err != nil {
 					app.ui.echoerrf("search: %s: %s", err, app.nav.search)
 				} else if moved {
 					app.ui.loadFile(app, true)
-					app.ui.loadFileInfo(app.nav)
 				}
 			}
 		}
@@ -1597,14 +1534,12 @@ func (e *callExpr) eval(app *app, args []string) {
 					app.ui.echoerrf("search-back: %s: %s", err, app.nav.search)
 				} else if moved {
 					app.ui.loadFile(app, true)
-					app.ui.loadFileInfo(app.nav)
 				}
 			} else {
 				if moved, err := app.nav.searchPrev(); err != nil {
 					app.ui.echoerrf("search: %s: %s", err, app.nav.search)
 				} else if moved {
 					app.ui.loadFile(app, true)
-					app.ui.loadFileInfo(app.nav)
 				}
 			}
 		}
@@ -1624,7 +1559,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		} else {
 			app.ui.cmdAccLeft = []rune(strings.Join(e.args, " "))
 		}
-		app.ui.loadFileInfo(app.nav)
 	case "setfilter":
 		if !app.nav.init {
 			return
@@ -1634,7 +1568,6 @@ func (e *callExpr) eval(app *app, args []string) {
 			app.ui.echoerrf("filter: %s", err)
 		}
 		app.ui.loadFile(app, true)
-		app.ui.loadFileInfo(app.nav)
 	case "mark-save":
 		if app.ui.cmdPrefix == ">" {
 			return
@@ -1740,7 +1673,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 
 		app.ui.loadFile(app, true)
-		app.ui.loadFileInfo(app.nav)
 
 		if wd != path {
 			app.nav.marks["'"] = wd
@@ -1780,7 +1712,6 @@ func (e *callExpr) eval(app *app, args []string) {
 		}
 
 		app.ui.loadFile(app, true)
-		app.ui.loadFileInfo(app.nav)
 
 		if wd != path {
 			app.nav.marks["'"] = wd
@@ -1793,7 +1724,6 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 		app.readFile(replaceTilde(e.args[0]))
-		app.ui.loadFileInfo(app.nav)
 	case "push":
 		if len(e.args) != 1 {
 			app.ui.echoerr("push: requires an argument")
@@ -1859,7 +1789,6 @@ func (e *callExpr) eval(app *app, args []string) {
 			app.ui.echoerrf("calcdirsize: %s", err)
 			return
 		}
-		app.ui.loadFileInfo(app.nav)
 		app.nav.sort()
 		app.ui.sort()
 	case "clearmaps":
@@ -1885,7 +1814,9 @@ func (e *callExpr) eval(app *app, args []string) {
 		if !app.nav.init {
 			return
 		}
-		visual(app)
+		dir := app.nav.currDir()
+		dir.visualAnchor = dir.ind
+		dir.visualWrap = 0
 	case "visual-accept":
 		if !app.nav.init {
 			return
@@ -1897,10 +1828,7 @@ func (e *callExpr) eval(app *app, args []string) {
 				app.nav.selectionInd++
 			}
 		}
-		// resetting Visual mode here instead of inside `normal()`
-		// allows us to use Visual mode inside search, find etc.
 		dir.visualAnchor = -1
-		normal(app)
 	case "visual-unselect":
 		if !app.nav.init {
 			return
@@ -1913,14 +1841,12 @@ func (e *callExpr) eval(app *app, args []string) {
 			app.nav.selectionInd = 0
 		}
 		dir.visualAnchor = -1
-		normal(app)
 	case "visual-discard":
 		if !app.nav.init {
 			return
 		}
 		dir := app.nav.currDir()
 		dir.visualAnchor = -1
-		normal(app)
 	case "visual-change":
 		if !app.nav.isVisualMode() {
 			return
@@ -2010,7 +1936,6 @@ func (e *callExpr) eval(app *app, args []string) {
 				app.ui.echoerrf("search: %s: %s", err, app.nav.search)
 			} else if old != dir.ind {
 				app.ui.loadFile(app, true)
-				app.ui.loadFileInfo(app.nav)
 			}
 		case "?":
 			dir := app.nav.currDir()
@@ -2026,7 +1951,6 @@ func (e *callExpr) eval(app *app, args []string) {
 				app.ui.echoerrf("search-back: %s: %s", err, app.nav.search)
 			} else if old != dir.ind {
 				app.ui.loadFile(app, true)
-				app.ui.loadFileInfo(app.nav)
 			}
 		case "filter: ":
 			log.Printf("filter: %s", s)
@@ -2035,14 +1959,12 @@ func (e *callExpr) eval(app *app, args []string) {
 				app.ui.echoerrf("filter: %s", err)
 			}
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		case "find: ":
 			app.ui.cmdPrefix = ""
 			if moved, found := app.nav.findNext(); !found {
 				app.ui.echoerrf("find: pattern not found: %s", app.nav.find)
 			} else if moved {
 				app.ui.loadFile(app, true)
-				app.ui.loadFileInfo(app.nav)
 			}
 		case "find-back: ":
 			app.ui.cmdPrefix = ""
@@ -2050,7 +1972,6 @@ func (e *callExpr) eval(app *app, args []string) {
 				app.ui.echoerrf("find-back: pattern not found: %s", app.nav.find)
 			} else if moved {
 				app.ui.loadFile(app, true)
-				app.ui.loadFileInfo(app.nav)
 			}
 		case "rename: ":
 			app.ui.cmdPrefix = ""
@@ -2107,7 +2028,6 @@ func (e *callExpr) eval(app *app, args []string) {
 				}
 			}
 			app.ui.loadFile(app, true)
-			app.ui.loadFileInfo(app.nav)
 		default:
 			log.Printf("entering unknown execution prefix: %q", app.ui.cmdPrefix)
 		}
@@ -2355,6 +2275,55 @@ func (e *callExpr) eval(app *app, args []string) {
 			return
 		}
 		cmd.eval(app, e.args)
+	}
+
+	// commands that run silently or write messages shouldn't clear existing messages
+	keepMsgCmds := []string{
+		"addcustominfo",
+		"draw",
+		"echo",
+		"echoerr",
+		"echomsg",
+		"load",
+		"push",
+		"redraw",
+		"sync",
+		"tty-write",
+		"cmd-insert",
+		"cmd-escape",
+		"cmd-complete",
+		"cmd-menu-complete",
+		"cmd-menu-complete-back",
+		"cmd-menu-accept",
+		"cmd-enter",
+		"cmd-interrupt",
+		"cmd-history-next",
+		"cmd-history-prev",
+		"cmd-left",
+		"cmd-right",
+		"cmd-home",
+		"cmd-end",
+		"cmd-delete",
+		"cmd-delete-back",
+		"cmd-delete-home",
+		"cmd-delete-end",
+		"cmd-delete-unix-word",
+		"cmd-yank",
+		"cmd-transpose",
+		"cmd-transpose-word",
+		"cmd-word",
+		"cmd-word-back",
+		"cmd-delete-word",
+		"cmd-delete-word-back",
+		"cmd-capitalize-word",
+		"cmd-uppercase-word",
+		"cmd-lowercase-word",
+		"on-focus-gained",
+		"on-focus-lost",
+		"on-init",
+	}
+	if !slices.Contains(keepMsgCmds, e.name) {
+		app.ui.clearmsg()
 	}
 }
 

--- a/lf.1
+++ b/lf.1
@@ -196,7 +196,6 @@ ratios            []int     (default \(aq1:2:3\(aq)
 relativenumber    bool      (default false)
 reverse           bool      (default false)
 roundbox          bool      (default false)
-rulerfmt          string    (default \(dq  %a|  %p|  \(rs033[7;31m %m \(rs033[0m|  \(rs033[7;33m %c \(rs033[0m|  \(rs033[7;35m %s \(rs033[0m|  \(rs033[7;34m %f \(rs033[0m|  %i/%t\(dq)
 scrolloff         int       (default 0)
 searchmethod      string    (default \(aqtext\(aq)
 selectfmt         string    (default \(dq\(rs033[7;35m\(dq)
@@ -209,7 +208,6 @@ sixel             bool      (default false)
 smartcase         bool      (default true)
 smartdia          bool      (default false)
 sortby            string    (default \(aqnatural\(aq)
-statfmt           string    (default \(dq\(rs033[36m%p\(rs033[0m| %c| %u| %g| %S| %t| \-> %l\(dq)
 tabstop           int       (default 8)
 tagfmt            string    (default \(dq\(rs033[31m\(dq)
 tempmarks         string    (default \(aq\(aq)
@@ -355,6 +353,14 @@ The icons file should be located at:
 OS       system\-wide               user\-specific
 Unix     /etc/lf/icons             \(ti/.config/lf/icons
 Windows  C:\(rsProgramData\(rslf\(rsicons   C:\(rsUsers\(rs<user>\(rsAppData\(rsRoaming\(rslf\(rsicons
+.EE
+.PP
+The ruler file should be located at:
+.IP
+.EX
+OS       system\-wide               user\-specific
+Unix     /etc/lf/ruler             \(ti/.config/lf/ruler
+Windows  C:\(rsProgramData\(rslf\(rsruler   C:\(rsUsers\(rs<user>\(rsAppData\(rsRoaming\(rslf\(rsruler
 .EE
 .PP
 The selection file should be located at:
@@ -890,28 +896,6 @@ Reverse the direction of sort.
 .SS roundbox (bool) (default false)
 Draw rounded outer corners when the \f[CR]drawbox\f[R] option is
 enabled.
-.SS rulerfmt (string) (default \f[CR]  %a|  %p|  \(rs033[7;31m %m \(rs033[0m|  \(rs033[7;33m %c \(rs033[0m|  \(rs033[7;35m %s \(rs033[0m|  \(rs033[7;36m %v \(rs033[0m|  \(rs033[7;34m %f \(rs033[0m|  %i/%t\f[R])
-Format string of the ruler shown in the bottom right corner.
-Special expansions are provided, \f[CR]%a\f[R] as the pressed keys,
-\f[CR]%p\f[R] as the progress of file operations, \f[CR]%m\f[R] as the
-number of files to be cut (moved), \f[CR]%c\f[R] as the number of files
-to be copied, \f[CR]%s\f[R] as the number of selected files,
-\f[CR]%v\f[R] as the number of visually selected files, \f[CR]%f\f[R] as
-the filter, \f[CR]%i\f[R] as the position of the cursor, \f[CR]%t\f[R]
-as the number of files shown in the current directory, \f[CR]%h\f[R] as
-the number of files hidden in the current directory, \f[CR]%P\f[R] as
-the scroll percentage, and \f[CR]%d\f[R] as the amount of free disk
-space remaining.
-Additional expansions are provided for environment variables exported by
-lf, in the form \f[CR]%{lf_<name>}\f[R] (e.g.
-\f[CR]%{lf_selmode}\f[R]).
-This is useful for displaying the current settings.
-Expansions are also provided for user\-defined options, in the form
-\f[CR]%{lf_user_<name>}\f[R] (e.g.
-\f[CR]%{lf_user_foo}\f[R]).
-The \f[CR]|\f[R] character splits the format string into sections.
-Any section containing a failed expansion (result is a blank string) is
-discarded and not shown.
 .SS scrolloff (int) (default 0)
 Minimum number of offset lines shown at all times at the top and bottom
 of the screen when scrolling.
@@ -973,24 +957,6 @@ ctime     time of last status (inode) change
 ext       file extension
 custom    property defined via \(gaaddcustominfo\(ga
 .EE
-.SS statfmt (string) (default \f[CR]\(rs033[36m%p\(rs033[0m| %c| %u| %g| %S| %t| \-> %l\f[R])
-Format string of the file info shown in the bottom left corner.
-Special expansions are provided, \f[CR]%p\f[R] as the file permissions,
-\f[CR]%c\f[R] as the link count, \f[CR]%u\f[R] as the user,
-\f[CR]%g\f[R] as the group, \f[CR]%s\f[R] as the file size,
-\f[CR]%S\f[R] as the file size but with a fixed width of five characters
-(left\-padded with spaces), \f[CR]%t\f[R] as the last modified time,
-\f[CR]%l\f[R] as the link target, \f[CR]%m\f[R] as the current mode and
-\f[CR]%M\f[R] as the current mode but also shown in Normal mode
-(displaying \f[CR]NORMAL\f[R] instead of a blank string).
-.PP
-The \f[CR]|\f[R] character splits the format string into sections.
-Any section containing a failed expansion (result is a blank string) is
-discarded and not shown.
-.PP
-File size is formatted using first letter of IEC 80000\-13:2025 prefixes
-for binary multiples (i.e.
-1024 bytes is \f[CR]1.0K\f[R]).
 .SS tabstop (int) (default 8)
 Number of space characters to show for horizontal tabulation (U+0009)
 character.
@@ -2309,4 +2275,63 @@ A sample icons file can be found at \c
 .PP
 A sample colored icons file can be found at \c
 .UR https://github.com/gokcehan/lf/blob/master/etc/icons_colored.example
+.UE \c
+.SH RULER
+The ruler can be configured using a ruler file (refer to the \c
+.UR https://github.com/gokcehan/lf/blob/master/doc.md#configuration
+CONFIGURATION section
+.UE \c
+).
+The contents of the ruler file should be a Go template which is then
+rendered to create the actual output (refer to \c
+.UR https://pkg.go.dev/text/template
+.UE \c
+\ for more details on the syntax).
+.PP
+The following data fields are exported:
+.IP
+.EX
+\&.Acc              string              Key accumulator
+\&.Progress         []string            Progress indicators for copied, moved and deleted files
+\&.Copy             []string            List of files in the clipboard to be copied
+\&.Cut              []string            List of files in the clipboard to be moved
+\&.Select           []string            Selection list
+\&.Visual           []string            Visual selection
+\&.Index            int                 Index of the cursor
+\&.Total            int                 Number of visible files in the current directory
+\&.Hidden           int                 Number of hidden files in the current directory
+\&.Percentage       string              Scroll percentage
+\&.Filter           []string            Filter currently being applied
+\&.Mode             string              Current mode (\(dqNORMAL\(dq for Normal mode, and \(dqVISUAL\(dq for Visual mode)
+\&.Options          map[string]string   The value of options (e.g. {{.Options.hidden}})
+\&.UserOptions      map[string]string   The value of user\-defined options (e.g. {{.UserOptions.foo}})
+\&.Stat.Path        string              Path of the current file
+\&.Stat.Name        string              Name of the current file
+\&.Stat.Size        uint64              Size of the current file
+\&.Stat.Permissions string              Permissions of the current file
+\&.Stat.ModTime     time.Time           Last modified time of the current file
+\&.Stat.LinkCount   string              Number of hard links for the current file
+\&.Stat.User        string              User of the current file
+\&.Stat.Group       string              Group of the current file
+\&.Stat.Target      string              Target if the current file is a symbolic link, otherwise a blank string
+.EE
+.PP
+The following functions are exported:
+.IP
+.EX
+df       func() string                   Get an indicator representing the amount of free disk space available
+env      func(string) string             Get the value of an environment variable
+humanize func(uint64) string             Express a file size in a human\-readable format
+join     func([]string, string) string   Join a string array by a separator
+substr   func(string, int, int) string   Get a substring based on starting index and length
+.EE
+.PP
+The special identifier \f[CR]{{.ESC}}\f[R] can be used to output a
+literal escape character, which can be used in terminal escape sequences
+to apply colors and styles.
+The special identifier \f[CR]{{.SPACER}}\f[R] can be used once to
+separate the ruler into left and right components.
+.PP
+The default ruler file can be found at \c
+.UR https://github.com/gokcehan/lf/blob/master/etc/ruler.default
 .UE \c

--- a/misc.go
+++ b/misc.go
@@ -333,7 +333,6 @@ func getFileExtension(file fs.FileInfo) string {
 
 var (
 	reModKey    = regexp.MustCompile(`<(c|s|a)-(.+)>`)
-	reRulerSub  = regexp.MustCompile(`%[apmcsvfithPd]|%\{[^}]+\}`)
 	reSixelSize = regexp.MustCompile(`"1;1;(\d+);(\d+)`)
 )
 

--- a/opts.go
+++ b/opts.go
@@ -89,7 +89,6 @@ var gOpts struct {
 	relativenumber   bool
 	reverse          bool
 	roundbox         bool
-	rulerfmt         string
 	scrolloff        int
 	searchmethod     searchMethod
 	selectfmt        string
@@ -102,7 +101,6 @@ var gOpts struct {
 	smartcase        bool
 	smartdia         bool
 	sortby           sortMethod
-	statfmt          string
 	tabstop          int
 	tagfmt           string
 	tempmarks        string
@@ -258,7 +256,6 @@ func init() {
 	gOpts.relativenumber = false
 	gOpts.reverse = false
 	gOpts.roundbox = false
-	gOpts.rulerfmt = "  %a|  %p|  \033[7;31m %m \033[0m|  \033[7;33m %c \033[0m|  \033[7;35m %s \033[0m|  \033[7;36m %v \033[0m|  \033[7;34m %f \033[0m|  %i/%t"
 	gOpts.scrolloff = 0
 	gOpts.searchmethod = textSearch
 	gOpts.selectfmt = "\033[7;35m"
@@ -271,7 +268,6 @@ func init() {
 	gOpts.smartcase = true
 	gOpts.smartdia = false
 	gOpts.sortby = naturalSort
-	gOpts.statfmt = "\033[36m%p\033[0m| %c| %u| %g| %S| %t| -> %l"
 	gOpts.tabstop = 8
 	gOpts.tagfmt = "\033[31m"
 	gOpts.tempmarks = "'"

--- a/os.go
+++ b/os.go
@@ -38,6 +38,7 @@ var (
 	gConfigPaths []string
 	gColorsPaths []string
 	gIconsPaths  []string
+	gRulerPaths  []string
 	gFilesPath   string
 	gMarksPath   string
 	gTagsPath    string
@@ -103,6 +104,11 @@ func init() {
 	gIconsPaths = []string{
 		filepath.Join("/etc", "lf", "icons"),
 		filepath.Join(config, "lf", "icons"),
+	}
+
+	gRulerPaths = []string{
+		filepath.Join("/etc", "lf", "ruler"),
+		filepath.Join(config, "lf", "ruler"),
 	}
 
 	data := cmp.Or(

--- a/os_windows.go
+++ b/os_windows.go
@@ -36,6 +36,7 @@ var (
 	gConfigPaths []string
 	gColorsPaths []string
 	gIconsPaths  []string
+	gRulerPaths  []string
 	gFilesPath   string
 	gTagsPath    string
 	gMarksPath   string
@@ -89,6 +90,11 @@ func init() {
 	gIconsPaths = []string{
 		filepath.Join(os.Getenv("ProgramData"), "lf", "icons"),
 		filepath.Join(config, "lf", "icons"),
+	}
+
+	gRulerPaths = []string{
+		filepath.Join(os.Getenv("ProgramData"), "lf", "ruler"),
+		filepath.Join(config, "lf", "ruler"),
 	}
 
 	data := cmp.Or(os.Getenv("LF_DATA_HOME"), os.Getenv("LOCALAPPDATA"))

--- a/ruler.go
+++ b/ruler.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"log"
+	"os"
+	"strings"
+	"text/template"
+	"time"
+
+	_ "embed"
+)
+
+//go:embed etc/ruler.default
+var gDefaultRuler string
+
+type statData struct {
+	Path        string
+	Name        string
+	Size        uint64
+	Permissions string
+	ModTime     time.Time
+	LinkCount   string
+	User        string
+	Group       string
+	Target      string
+}
+
+type rulerData struct {
+	ESC         string
+	SPACER      string
+	Acc         string
+	Progress    []string
+	Copy        []string
+	Cut         []string
+	Select      []string
+	Visual      []string
+	Index       int
+	Total       int
+	Hidden      int
+	Percentage  string
+	Filter      []string
+	Mode        string
+	Options     map[string]string
+	UserOptions map[string]string
+	Stat        *statData
+}
+
+func parseRuler() *template.Template {
+	funcs := template.FuncMap{
+		"df":       func() string { return diskFree(".") },
+		"env":      os.Getenv,
+		"humanize": humanize,
+		"join":     strings.Join,
+		"substr":   func(s string, start, length int) string { return string([]rune(s)[start : start+length]) },
+	}
+
+	var ruler *template.Template
+
+	for i := len(gRulerPaths) - 1; i >= 0; i-- {
+		path := gRulerPaths[i]
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			continue
+		}
+
+		log.Printf("reading file: %s", path)
+
+		tmpl, err := template.New("ruler").Funcs(funcs).ParseFiles(path)
+		if err != nil {
+			log.Printf("parsing ruler file: %s", err)
+			continue
+		}
+
+		ruler = tmpl
+		break
+	}
+
+	if ruler == nil {
+		ruler, _ = template.New("ruler").Funcs(funcs).Parse(gDefaultRuler)
+	}
+
+	return ruler
+}
+
+func renderRuler(ruler *template.Template, data rulerData) (string, string, error) {
+	var b strings.Builder
+	if err := ruler.Execute(&b, data); err != nil {
+		return "", "", err
+	}
+
+	s := strings.ReplaceAll(b.String(), "\n", "")
+	left, right, found := strings.Cut(s, "\x1f")
+	if !found {
+		return s, "", nil
+	}
+
+	return left, right, nil
+}

--- a/ui.go
+++ b/ui.go
@@ -6,11 +6,13 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"sort"
 	"strconv"
 	"strings"
 	"text/tabwriter"
+	"text/template"
 	"time"
 	"unicode"
 	"unicode/utf8"
@@ -646,7 +648,7 @@ type ui struct {
 	msgWin      *win
 	menuWin     *win
 	msg         string
-	msgIsStat   bool
+	msgActive   bool
 	regPrev     *reg
 	dirPrev     *dir
 	exprChan    chan expr
@@ -662,6 +664,7 @@ type ui struct {
 	keyCount    []rune
 	styles      styleMap
 	icons       iconMap
+	ruler       *template.Template
 	currentFile string
 	pasteEvent  bool
 }
@@ -676,13 +679,13 @@ func newUI(screen tcell.Screen) *ui {
 		promptWin:   newWin(wtot, 1, 0, 0),
 		msgWin:      newWin(wtot, 1, 0, htot-1),
 		menuWin:     newWin(wtot, 1, 0, htot-2),
-		msgIsStat:   true,
 		exprChan:    make(chan expr, 1000),
 		keyChan:     make(chan string, 1000),
 		tevChan:     make(chan tcell.Event, 1000),
 		evChan:      make(chan tcell.Event, 1000),
 		styles:      parseStyles(),
 		icons:       parseIcons(),
+		ruler:       parseRuler(),
 		currentFile: "",
 		sxScreen:    sixelScreen{},
 	}
@@ -734,12 +737,17 @@ func (ui *ui) sort() {
 
 func (ui *ui) echo(msg string) {
 	ui.msg = msg
-	ui.msgIsStat = false
+	ui.msgActive = true
 }
 
 func (ui *ui) echomsg(msg string) {
 	ui.echo(msg)
 	log.Print(msg)
+}
+
+func (ui *ui) clearmsg() {
+	ui.msg = ""
+	ui.msgActive = false
 }
 
 func optionToFmtstr(optstr string) string {
@@ -799,57 +807,6 @@ func (ui *ui) loadFile(app *app, volatile bool) {
 	} else if curr.IsDir() {
 		ui.dirPrev = app.nav.loadDir(curr.path)
 	}
-}
-
-func (ui *ui) loadFileInfo(nav *nav) {
-	if !nav.init {
-		return
-	}
-
-	ui.msg = ""
-	ui.msgIsStat = true
-
-	curr, err := nav.currFile()
-	if err != nil {
-		return
-	}
-
-	if curr.err != nil {
-		ui.echoerrf("stat: %s", curr.err)
-		return
-	}
-
-	statfmt := strings.ReplaceAll(gOpts.statfmt, "|", "\x1f")
-	replace := func(s string, val string) {
-		if val == "" {
-			val = "\x00"
-		}
-		statfmt = strings.ReplaceAll(statfmt, s, val)
-	}
-	if nav.isVisualMode() {
-		replace("%m", "VISUAL")
-		replace("%M", "VISUAL")
-	} else {
-		replace("%m", "")
-		replace("%M", "NORMAL")
-	}
-	replace("%p", curr.Mode().String())
-	replace("%c", linkCount(curr))
-	replace("%u", userName(curr))
-	replace("%g", groupName(curr))
-	replace("%s", humanize(uint64(curr.Size())))
-	replace("%S", fmt.Sprintf("%5s", humanize(uint64(curr.Size()))))
-	replace("%t", curr.ModTime().Format(gOpts.timefmt))
-	replace("%l", curr.linkTarget)
-
-	var fileInfo strings.Builder
-	for _, section := range strings.Split(statfmt, "\x1f") {
-		if !strings.Contains(section, "\x00") {
-			fileInfo.WriteString(section)
-		}
-	}
-
-	ui.msg = fileInfo.String()
 }
 
 func (ui *ui) drawPromptLine(nav *nav) {
@@ -913,24 +870,39 @@ func (ui *ui) drawPromptLine(nav *nav) {
 	ui.promptWin.print(ui.screen, 0, 0, st, prompt)
 }
 
-func formatRulerOpt(name string, val string) string {
-	// handle escape character so it doesn't mess up the ruler
-	val = strings.ReplaceAll(val, "\033", "\033[7m\\033\033[0m")
-
-	// display name of builtin options for clarity
-	if !strings.HasPrefix(name, "lf_user_") {
-		return fmt.Sprintf("%s=%s", strings.TrimPrefix(name, "lf_"), val)
+func (ui *ui) drawRuler(nav *nav) {
+	if ui.msgActive {
+		ui.msgWin.print(ui.screen, 0, 0, tcell.StyleDefault, ui.msg)
+		return
 	}
 
-	return val
-}
+	var stat *statData
+	curr, err := nav.currFile()
+	if err == nil {
+		if curr.err != nil {
+			ui.echoerrf("stat: %s", curr.err)
+			ui.msgWin.print(ui.screen, 0, 0, tcell.StyleDefault, ui.msg)
+			return
+		}
 
-func (ui *ui) drawRuler(nav *nav) {
-	st := tcell.StyleDefault
+		stat = &statData{
+			Path:        curr.path,
+			Name:        curr.Name(),
+			Size:        uint64(curr.Size()),
+			Permissions: curr.Mode().String(),
+			ModTime:     curr.ModTime(),
+			LinkCount:   linkCount(curr),
+			User:        userName(curr),
+			Group:       groupName(curr),
+			Target:      curr.linkTarget,
+		}
+	}
+
+	if ui.ruler == nil {
+		return
+	}
 
 	dir := nav.currDir()
-
-	ui.msgWin.print(ui.screen, 0, 0, st, ui.msg)
 
 	tot := len(dir.files)
 	ind := min(dir.ind+1, tot)
@@ -950,12 +922,12 @@ func (ui *ui) drawRuler(nav *nav) {
 		percentage = fmt.Sprintf("%2d%%", beg*100/(tot-nav.height))
 	}
 
-	copy := 0
-	move := 0
+	var copy []string
+	var cut []string
 	if nav.clipboard.mode == clipboardCopy {
-		copy = len(nav.clipboard.paths)
+		copy = nav.clipboard.paths
 	} else {
-		move = len(nav.clipboard.paths)
+		cut = nav.clipboard.paths
 	}
 
 	currSelections := nav.currSelections()
@@ -975,54 +947,52 @@ func (ui *ui) drawRuler(nav *nav) {
 		progress = append(progress, fmt.Sprintf("[%d/%d]", nav.deleteCount, nav.deleteTotal))
 	}
 
-	opts := getOptsMap()
+	mode := "NORMAL"
+	if nav.isVisualMode() {
+		mode = "VISUAL"
+	}
 
-	rulerfmt := strings.ReplaceAll(gOpts.rulerfmt, "|", "\x1f")
-	rulerfmt = reRulerSub.ReplaceAllStringFunc(rulerfmt, func(s string) string {
-		var result string
-		switch s {
-		case "%a":
-			result = acc
-		case "%p":
-			result = strings.Join(progress, " ")
-		case "%m":
-			result = fmt.Sprintf("%.d", move)
-		case "%c":
-			result = fmt.Sprintf("%.d", copy)
-		case "%s":
-			result = fmt.Sprintf("%.d", len(currSelections))
-		case "%v":
-			result = fmt.Sprintf("%.d", len(currVSelections))
-		case "%f":
-			result = strings.Join(dir.filter, " ")
-		case "%i":
-			result = strconv.Itoa(ind)
-		case "%t":
-			result = strconv.Itoa(tot)
-		case "%h":
-			result = strconv.Itoa(hid)
-		case "%P":
-			result = percentage
-		case "%d":
-			result = diskFree(dir.path)
+	options := make(map[string]string)
+	v := reflect.ValueOf(gOpts)
+	t := v.Type()
+	for i := range v.NumField() {
+		name := t.Field(i).Name
+		switch name {
+		case "nkeys", "vkeys", "cmdkeys", "cmds", "user":
+			continue
 		default:
-			s = strings.TrimSuffix(strings.TrimPrefix(s, "%{"), "}")
-			if val, ok := opts[s]; ok {
-				result = formatRulerOpt(s, val)
-			}
-		}
-		if result == "" {
-			return "\x00"
-		}
-		return result
-	})
-	var ruler strings.Builder
-	for _, section := range strings.Split(rulerfmt, "\x1f") {
-		if !strings.Contains(section, "\x00") {
-			ruler.WriteString(section)
+			options[name] = fieldToString(v.Field(i))
 		}
 	}
-	ui.msgWin.printRight(ui.screen, 0, st, ruler.String())
+
+	data := rulerData{
+		ESC:         "\033",
+		SPACER:      "\x1f",
+		Acc:         acc,
+		Progress:    progress,
+		Copy:        copy,
+		Cut:         cut,
+		Select:      currSelections,
+		Visual:      currVSelections,
+		Index:       ind,
+		Total:       tot,
+		Hidden:      hid,
+		Percentage:  percentage,
+		Filter:      dir.filter,
+		Mode:        mode,
+		Options:     options,
+		UserOptions: gOpts.user,
+		Stat:        stat,
+	}
+
+	left, right, err := renderRuler(ui.ruler, data)
+	if err != nil {
+		log.Printf("rendering ruler: %s", err)
+		return
+	}
+
+	ui.msgWin.print(ui.screen, 0, 0, tcell.StyleDefault, left)
+	ui.msgWin.printRight(ui.screen, 0, tcell.StyleDefault, right)
 }
 
 func (ui *ui) drawBox() {


### PR DESCRIPTION
From discussion in #2057

This PR changes ruler configuration from a format string (similar to `promptfmt`) to a [Go template](https://pkg.go.dev/text/template). This is to allow even more powerful customization than what `rulerfmt` was capable of.

Some examples below

---

Default ruler:

```handlebars
{{if .Stat}}
{{.ESC}}[36m{{.Stat.Permissions}}{{.ESC}}[0m
{{if .Stat.LinkCount}} {{.Stat.LinkCount}}{{end}}
{{if .Stat.User}} {{.Stat.User}}{{end}}
{{if .Stat.Group}} {{.Stat.Group}}{{end}}
 {{humanize .Stat.Size | printf "%5s"}}
 {{.Stat.ModTime.Format .Options.timefmt}}
{{if .Stat.Target}} -> {{.Stat.Target}}{{end}}
{{end}}
{{.SPACER}}
  {{.Acc}}
{{if .Progress}}  {{join .Progress " "}}{{end}}
{{if .Copy}}  {{.ESC}}[7;33m {{len .Copy}} {{.ESC}}[0m{{end}}
{{if .Cut}}  {{.ESC}}[7;31m {{len .Cut}} {{.ESC}}[0m{{end}}
{{if .Select}}  {{.ESC}}[7;35m {{len .Select}} {{.ESC}}[0m{{end}}
{{if .Visual}}  {{.ESC}}[7;36m {{len .Visual}} {{.ESC}}[0m{{end}}
{{if .Filter}}  {{.ESC}}[7;34m {{join .Filter " "}} {{.ESC}}[0m{{end}}
  {{.Index}}/{{.Total}}
```

Display options:

```handlebars
hidden={{.Options.hidden}}
```

Display user options:

> [!NOTE]  
> Add `set user_foo bar` to the `lfrc` file.

```handlebars
foo={{.UserOptions.foo}}
```

Display environment variables:

```handlebars
LF_LEVEL={{env "LF_LEVEL"}}
```

A single `{{.SPACER}}` can be used to split into left and right sections:

```handlebars
left{{.SPACER}}right
```

Padding with spaces:

```handlebars
[{{"left" | printf "%-8s"}}]
[{{"right" | printf "%8s"}}]
```

Colors and styles can be applied using terminal escape sequences:

```handlebars
{{$text := "hello world"}}
{{.ESC}}[4;31m{{$text}}{{.ESC}}[0m
```

Conditional logic:

```handlebars
{{with .Stat}}
{{.Path}}
{{if .Target}} -> {{.Target}}{{end}}
{{else}}
empty directory
{{end}}
```

Different colors for modes:

```handlebars
{{$color := 32}}{{if eq .Mode "VISUAL"}}{{$color = 34}}{{end}}
{{.ESC}}[7;{{$color}}m {{.Mode}} {{.ESC}}[0m
```

Different colors for file permissions:

```handlebars
{{if .Stat}}
{{.ESC}}[34m{{substr .Stat.Permissions 0 1}}
{{.ESC}}[33m{{substr .Stat.Permissions 1 1}}
{{.ESC}}[31m{{substr .Stat.Permissions 2 1}}
{{.ESC}}[32m{{substr .Stat.Permissions 3 1}}
{{.ESC}}[33m{{substr .Stat.Permissions 4 1}}
{{.ESC}}[31m{{substr .Stat.Permissions 5 1}}
{{.ESC}}[32m{{substr .Stat.Permissions 6 1}}
{{.ESC}}[33m{{substr .Stat.Permissions 7 1}}
{{.ESC}}[31m{{substr .Stat.Permissions 8 1}}
{{.ESC}}[32m{{substr .Stat.Permissions 9 1}}
{{.ESC}}[0m
{{end}}
```

Comments are allowed:

```handlebars
{{/* this is a comment */}}
this will be shown
```