### PR TITLE
Allow extra text in previews with sixels

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -334,7 +334,7 @@ func getFileExtension(file fs.FileInfo) string {
 var (
 	reModKey    = regexp.MustCompile(`<(c|s|a)-(.+)>`)
 	reRulerSub  = regexp.MustCompile(`%[apmcsvfithPd]|%\{[^}]+\}`)
-	reSixelSize = regexp.MustCompile(`"1;1;(\d+);(\d+)`)
+	reAnsiShift = regexp.MustCompile(`\033\[\d+G`)
 )
 
 var (

--- a/nav.go
+++ b/nav.go
@@ -917,11 +917,10 @@ func (nav *nav) preview(path string, win *win) {
 	if gOpts.sixel {
 		prefix, err := reader.Peek(2)
 		if err == nil && string(prefix) == gSixelBegin {
-			b, err := io.ReadAll(reader)
+			str, err := loadSixel(reader)
 			if err != nil {
 				log.Printf("loading sixel: %s", err)
 			}
-			str := string(b)
 			reg.sixel = &str
 			return
 		}


### PR DESCRIPTION
Implements #1765

### Changes
- allow content outside sixel region (extra text from previewer scripts)
- fix extra text from sixel to appear in preview box
- remove sixel dimension calculations as they are no longer needed

### Motivation
Prior to #1943 I was able to add extra info to previews containing sixels (e.g. show both cover art and song title for music files) using workarounds. My hacks (workarounds) were somewhat broken by the recent sixel changes in r36 (output was effectively restricted to just the area of the sixel itself); so I decided that it's probably time to open a PR (or at least maintain a personal fork).

### Other
I'm not a go developer, so any comments are appreciated.