### PR TITLE
Show progress immediately when copying files

### DIFF
--- a/app.go
+++ b/app.go
@@ -318,7 +318,7 @@ func (app *app) loop() {
 	for {
 		select {
 		case <-app.quitChan:
-			if app.nav.copyTotal > 0 {
+			if app.nav.copyJobs > 0 {
 				app.ui.echoerr("quit: copy operation in progress")
 				continue
 			}
@@ -340,6 +340,9 @@ func (app *app) loop() {
 			log.Print("bye!")
 
 			return
+		case <-app.nav.copyJobsChan:
+			app.nav.copyJobs += 1
+			app.ui.draw(app.nav)
 		case n := <-app.nav.copyBytesChan:
 			app.nav.copyBytes += n
 			// n is usually 32*1024B (default io.Copy() buffer) so update roughly per 32KB x 128 = 4MB copied
@@ -351,6 +354,7 @@ func (app *app) loop() {
 			app.nav.copyTotal += n
 			if n < 0 {
 				app.nav.copyBytes += n
+				app.nav.copyJobs -= 1
 			}
 			if app.nav.copyTotal == 0 {
 				app.nav.copyUpdate = 0

--- a/ui.go
+++ b/ui.go
@@ -963,8 +963,12 @@ func (ui *ui) drawRuler(nav *nav) {
 
 	progress := []string{}
 
-	if nav.copyTotal > 0 {
-		progress = append(progress, fmt.Sprintf("[%d%%]", nav.copyBytes*100/nav.copyTotal))
+	if nav.copyJobs > 0 {
+		if nav.copyTotal == 0 {
+			progress = append(progress, fmt.Sprintf("[0%%]"))
+		} else {
+			progress = append(progress, fmt.Sprintf("[%d%%]", nav.copyBytes*100/nav.copyTotal))
+		}
 	}
 
 	if nav.moveTotal > 0 {


### PR DESCRIPTION
- Fixes #2090 

Currently `nav.copyTotal` (total number of bytes to be copied) is used to determine whether the copy progress should be displayed at all. The problem is that when the user presses `p` to initiate a copy operation, it can take some time for `copySize` to calculate this value, and as a result nothing is displayed in the UI until that is done.

This change introduces a new variable `nav.copyJobs` (number of copy operations running) to keep track of this, and provide a more accurate status in the UI.