### PR TITLE
Remove explicit token in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,6 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         files: dist/*
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   winget:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is used by default anyway