### PR TITLE
Remove dircache option

### DIFF
--- a/app.go
+++ b/app.go
@@ -391,22 +391,17 @@ func (app *app) loop() {
 			}
 			app.ui.draw(app.nav)
 		case d := <-app.nav.dirChan:
-			if gOpts.dircache {
-				prev, ok := app.nav.dirCache[d.path]
-				if ok {
-					d.ind = prev.ind
-					d.pos = prev.pos
-					d.visualAnchor = min(prev.visualAnchor, len(d.files)-1)
-					d.visualWrap = prev.visualWrap
-					d.filter = prev.filter
-					d.sort()
-					d.sel(prev.name(), app.nav.height)
-				}
-
-				app.nav.dirCache[d.path] = d
-			} else {
+			prev, ok := app.nav.dirCache[d.path]
+			if ok {
+				d.ind = prev.ind
+				d.pos = prev.pos
+				d.visualAnchor = min(prev.visualAnchor, len(d.files)-1)
+				d.visualWrap = prev.visualWrap
+				d.filter = prev.filter
 				d.sort()
+				d.sel(prev.name(), app.nav.height)
 			}
+			app.nav.dirCache[d.path] = d
 
 			var oldCurrPath string
 			if curr, err := app.nav.currFile(); err == nil {

--- a/doc.md
+++ b/doc.md
@@ -155,7 +155,6 @@ The following options can be used to customize the behavior of lf:
 	cursorparentfmt   string    (default "\033[7m")
 	cursorpreviewfmt  string    (default "\033[4m")
 	cutfmt            string    (default "\033[7;31m")
-	dircache          bool      (default true)
 	dircounts         bool      (default false)
 	dirfirst          bool      (default true)
 	dironly           bool      (default false)
@@ -754,10 +753,6 @@ For example, `\033[4m%s\033[0m` has the same effect as `\033[4m`.
 ## cutfmt (string) (default `\033[7;31m`)
 
 Format string of the indicator for files to be cut.
-
-## dircache (bool) (default true)
-
-Cache directory contents.
 
 ## dircounts (bool) (default false)
 

--- a/doc.txt
+++ b/doc.txt
@@ -145,7 +145,6 @@ The following options can be used to customize the behavior of lf:
     cursorparentfmt   string    (default "\033[7m")
     cursorpreviewfmt  string    (default "\033[4m")
     cutfmt            string    (default "\033[7;31m")
-    dircache          bool      (default true)
     dircounts         bool      (default false)
     dirfirst          bool      (default true)
     dironly           bool      (default false)
@@ -793,10 +792,6 @@ effect as \033[4m.
 cutfmt (string) (default \033[7;31m)
 
 Format string of the indicator for files to be cut.
-
-dircache (bool) (default true)
-
-Cache directory contents.
 
 dircounts (bool) (default false)
 

--- a/eval.go
+++ b/eval.go
@@ -64,8 +64,6 @@ func (e *setExpr) eval(app *app, args []string) {
 		err = applyBoolOpt(&gOpts.anchorfind, e)
 	case "autoquit", "noautoquit", "autoquit!":
 		err = applyBoolOpt(&gOpts.autoquit, e)
-	case "dircache", "nodircache", "dircache!":
-		err = applyBoolOpt(&gOpts.dircache, e)
 	case "dircounts", "nodircounts", "dircounts!":
 		err = applyBoolOpt(&gOpts.dircounts, e)
 		if err == nil {
@@ -630,11 +628,6 @@ func onChdir(app *app) {
 }
 
 func onLoad(app *app, files []string) {
-	// prevent infinite loops
-	if !gOpts.dircache {
-		return
-	}
-
 	if cmd, ok := gOpts.cmds["on-load"]; ok {
 		cmd.eval(app, files)
 	}

--- a/lf.1
+++ b/lf.1
@@ -160,7 +160,6 @@ cursoractivefmt   string    (default \(dq\(rs033[7m\(dq)
 cursorparentfmt   string    (default \(dq\(rs033[7m\(dq)
 cursorpreviewfmt  string    (default \(dq\(rs033[4m\(dq)
 cutfmt            string    (default \(dq\(rs033[7;31m\(dq)
-dircache          bool      (default true)
 dircounts         bool      (default false)
 dirfirst          bool      (default true)
 dironly           bool      (default false)
@@ -699,8 +698,6 @@ For example, \f[CR]\(rs033[4m%s\(rs033[0m\f[R] has the same effect as
 \f[CR]\(rs033[4m\f[R].
 .SS cutfmt (string) (default \f[CR]\(rs033[7;31m\f[R])
 Format string of the indicator for files to be cut.
-.SS dircache (bool) (default true)
-Cache directory contents.
 .SS dircounts (bool) (default false)
 When this option is enabled, directory sizes show the number of items
 inside instead of the total size of the directory, which needs to be

--- a/nav.go
+++ b/nav.go
@@ -574,42 +574,34 @@ type nav struct {
 	jumpListInd     int
 }
 
-func (nav *nav) loadDirInternal(path string) *dir {
-	d := &dir{
-		loading:      true,
-		path:         path,
-		sortby:       getSortBy(path),
-		dircounts:    getDirCounts(path),
-		dirfirst:     getDirFirst(path),
-		dironly:      getDirOnly(path),
-		hidden:       getHidden(path),
-		reverse:      getReverse(path),
-		locale:       getLocale(path),
-		visualAnchor: -1,
-		hiddenfiles:  gOpts.hiddenfiles,
-		ignorecase:   gOpts.ignorecase,
-		ignoredia:    gOpts.ignoredia,
-	}
-	go func() {
-		nav.dirChan <- newDir(path)
-	}()
-	return d
-}
-
 func (nav *nav) loadDir(path string) *dir {
-	if gOpts.dircache {
-		d, ok := nav.dirCache[path]
-		if !ok {
-			d = nav.loadDirInternal(path)
-			nav.dirCache[path] = d
-			return d
+	d, ok := nav.dirCache[path]
+	if !ok {
+		go func() {
+			nav.dirChan <- newDir(path)
+		}()
+
+		d := &dir{
+			loading:      true,
+			path:         path,
+			sortby:       getSortBy(path),
+			dircounts:    getDirCounts(path),
+			dirfirst:     getDirFirst(path),
+			dironly:      getDirOnly(path),
+			hidden:       getHidden(path),
+			reverse:      getReverse(path),
+			locale:       getLocale(path),
+			visualAnchor: -1,
+			hiddenfiles:  gOpts.hiddenfiles,
+			ignorecase:   gOpts.ignorecase,
+			ignoredia:    gOpts.ignoredia,
 		}
-
-		nav.checkDir(d)
-
+		nav.dirCache[path] = d
 		return d
 	}
-	return nav.loadDirInternal(path)
+
+	nav.checkDir(d)
+	return d
 }
 
 func (nav *nav) checkDir(dir *dir) {

--- a/opts.go
+++ b/opts.go
@@ -53,7 +53,6 @@ var gOpts struct {
 	cursorparentfmt  string
 	cursorpreviewfmt string
 	cutfmt           string
-	dircache         bool
 	dircounts        bool
 	dirfirst         bool
 	dironly          bool
@@ -222,7 +221,6 @@ func init() {
 	gOpts.cursorparentfmt = "\033[7m"
 	gOpts.cursorpreviewfmt = "\033[4m"
 	gOpts.cutfmt = "\033[7;31m"
-	gOpts.dircache = true
 	gOpts.dircounts = false
 	gOpts.dirfirst = true
 	gOpts.dironly = false


### PR DESCRIPTION
The `dircache` option was originally introduced in #673 because at the time the `period` mechanism for detecting file changes and updating the cache was unreliable. Since then there have been various improvements, and now there is also the `watch` option which uses filesystem notifications to detect file changes more reliably.

So I think there is no longer any real need to disable the directory cache, and that it is time to remove this option.