### PR TITLE
Remove padding for text previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - The `dircache` option has now been removed (#2110). This was previously used as a workaround to disable the directory cache since at the time changes to files were not detected reliably, but this is no longer the case.
 - The experimental `locale` option has been removed in favor of the recommendation to use `addcustominfo`/`set sortby custom` for custom sorting (#2111).
 - The existing `doc` command has been renamed to `help` so that it is more natural for users (#2125).
+- Text previews are no longer displayed with a padding of two spaces by default (#2131). A custom padding can be added in the `previewer` script, for example by piping to `sed 's/^/  /'`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - The `dircache` option has now been removed (#2110). This was previously used as a workaround to disable the directory cache since at the time changes to files were not detected reliably, but this is no longer the case.
 - The experimental `locale` option has been removed in favor of the recommendation to use `addcustominfo`/`set sortby custom` for custom sorting (#2111).
 - The existing `doc` command has been renamed to `help` so that it is more natural for users (#2125).
-- Text previews are no longer displayed with a padding of two spaces by default (#2131). A custom padding can be added in the `previewer` script, for example by piping to `sed 's/^/  /'`.
+- Text previews are no longer displayed with a padding of two spaces by default (#2131). Instead, a custom padding can be added in the `previewer` script, for example by piping to `sed 's/^/  /'`.
 
 ### Added
 

--- a/ui.go
+++ b/ui.go
@@ -276,7 +276,7 @@ func (win *win) printReg(screen tcell.Screen, reg *reg, previewLoading bool, sxs
 				break
 			}
 
-			st = win.print(screen, 2, i, st, l)
+			st = win.print(screen, 0, i, st, l)
 		}
 	}
 


### PR DESCRIPTION
- Fixes #2128 

By default, entries in a directory preview are offset by two spaces, as the space is required to display the selection marker and tag. The same padding of two spaces is used for text previews - while the space is not actually used, the padding exists so that the look is consistent with directory previews.

However the fixed padding of two spaces introduces a couple of issues:

- The width passed into the `previewer` script (`$2`) is not adjusted by this padding, which is confusing for users. In addition, the `previewer` script is used to display both text and image previews, but the fixed padding applies for text previews only.
- Users cannot disable the padding, not even by customizing the `previewer` script.

This change removes the default padding so that there is no longer any confusion as to what the width should be for the `previewer` script. Users who wish to obtain the original padding can configure it in the previewer script by piping the text preview content to `| sed 's/^/  /'` - in this case any amount of spaces can be used for the padding.