### PR TITLE
Handle query commands on demand in main loop

### DIFF
--- a/app.go
+++ b/app.go
@@ -595,25 +595,21 @@ func (app *app) runShell(s string, args []string, prefix string) {
 		app.ui.echo("")
 
 		go func() {
-			eol := false
 			reader := bufio.NewReader(out)
 			for {
 				b, err := reader.ReadByte()
 				if err == io.EOF {
 					break
 				}
-				if eol {
-					eol = false
+
+				app.cmdOutBuf = append(app.cmdOutBuf, b)
+				if reader.Buffered() == 0 {
+					app.ui.exprChan <- &callExpr{"echo", []string{string(app.cmdOutBuf)}, 1}
+				}
+
+				if b == '\n' || b == '\r' {
 					app.cmdOutBuf = nil
 				}
-				app.cmdOutBuf = append(app.cmdOutBuf, b)
-				if b == '\n' || b == '\r' {
-					eol = true
-				}
-				if reader.Buffered() > 0 {
-					continue
-				}
-				app.ui.exprChan <- &callExpr{"echo", []string{string(app.cmdOutBuf)}, 1}
 			}
 
 			if err := cmd.Wait(); err != nil {

--- a/app.go
+++ b/app.go
@@ -36,7 +36,6 @@ type app struct {
 	menuCompInd    int
 	selectionOut   []string
 	watch          *watch
-	quitting       bool
 }
 
 func newApp(ui *ui, nav *nav) *app {
@@ -66,14 +65,6 @@ func newApp(ui *ui, nav *nav) *app {
 }
 
 func (app *app) quit() {
-	// Using synchronous shell commands for `on-quit` can cause this to be
-	// called again, so a guard variable is introduced here to prevent an
-	// infinite loop.
-	if app.quitting {
-		return
-	}
-	app.quitting = true
-
 	onQuit(app)
 
 	if gOpts.history {

--- a/app.go
+++ b/app.go
@@ -537,6 +537,10 @@ func (app *app) runShell(s string, args []string, prefix string) {
 
 	switch prefix {
 	case "$", "!":
+		if app.ui.suspended {
+			return
+		}
+
 		app.nav.previewChan <- ""
 		app.ui.suspend()
 


### PR DESCRIPTION
One limitation of `shell` (`$`) and `shell-wait` (`!`) commands is that they run synchronously on the main loop, so it is not possible to do anything else that requires processing from the main loop. For example commands invoked via `lf -remote "send $id <command>"` will not be processed until the shell command finishes.

This is problematic for `lf -remote "query $id <query>"` calls, since they need to access internal state that is owned by the goroutine running the main loop - delegating the query to the main loop will not work as it is stalled when running synchronous shell commands. The current workaround caches the internal state before invoking synchronous shell commands, but this leads to stale cache entries, especially when running `lf -remote "query $id <query>"` from an external source, as mentioned in #2145.

This PR changes synchronous shell commands so that only the UI is suspended, but the main loop continues to run. This allows queries to be resolved on demand instead of retrieving cached content that could potentially be outdated. Some other refactoring is done as well. This is a large change in terms of how synchronous shell commands work fundamentally, so it would be nice to get some feedback for this, especially if this might break something.