### PR TITLE
shell-pipe: fix excessive waiting for output

### DIFF
--- a/app.go
+++ b/app.go
@@ -572,8 +572,6 @@ func (app *app) runShell(s string, args []string, prefix string) {
 
 	cmd := shellCommand(s, args)
 
-	var out io.Reader
-	var err error
 	switch prefix {
 	case "$", "!":
 		cmd.Stdin = os.Stdin
@@ -585,22 +583,30 @@ func (app *app) runShell(s string, args []string, prefix string) {
 	}
 
 	// We are running the command asynchronously
+	var inReader, outReader, outWriter *os.File
+	var err error
 	if prefix == "%" {
 		if app.ui.cmdPrefix == ">" {
 			return
 		}
-		stdin, err := cmd.StdinPipe()
+		// Hook up stdin and stdout.
+		// We don't use Cmd.StdoutPipe and friends because its docs say
+		// "It is … incorrect to call Wait before all reads from the pipe have completed."
+		// (see also https://github.com/golang/go/issues/60908).
+		// But we are going to be calling Wait concurrently with reading from the stdout pipe.
+		inReader, app.cmdIn, err = os.Pipe()
 		if err != nil {
-			log.Printf("writing stdin: %s", err)
+			log.Printf("creating input pipe: %s", err)
+			return
 		}
-		app.cmdIn = stdin
-		stdout, err := cmd.StdoutPipe()
+		cmd.Stdin = inReader
+		outReader, outWriter, err = os.Pipe()
 		if err != nil {
-			log.Printf("reading stdout: %s", err)
+			log.Printf("creating output pipe: %s", err)
+			return
 		}
-		out = stdout
-		cmd.Stderr = cmd.Stdout
-		cmd.WaitDelay = time.Second
+		cmd.Stdout = outWriter
+		cmd.Stderr = outWriter
 	}
 
 	shellSetPG(cmd)
@@ -617,7 +623,7 @@ func (app *app) runShell(s string, args []string, prefix string) {
 		app.ui.echo("")
 
 		go func() {
-			reader := bufio.NewReader(out)
+			reader := bufio.NewReader(outReader)
 			for {
 				b, err := reader.ReadByte()
 				if err != nil {
@@ -642,6 +648,10 @@ func (app *app) runShell(s string, args []string, prefix string) {
 			if err := cmd.Wait(); err != nil {
 				log.Printf("running shell: %s", err)
 			}
+			outWriter.Close()
+			outReader.Close()
+			app.cmdIn.Close()
+			inReader.Close()
 			app.cmd = nil
 			app.ui.cmdPrefix = ""
 			app.ui.exprChan <- &callExpr{"load", nil, 1}


### PR DESCRIPTION
There are some programs that keep their stdin/stdout/stderr open beyond their process lifetime. An example is [wl-copy](https://github.com/bugaevc/wl-clipboard), which forks off into the background and keeps stderr open (which is intentional: https://github.com/bugaevc/wl-clipboard/issues/212, https://github.com/bugaevc/wl-clipboard/issues/245).

Before this change, the behaviour of `lf`'s `shell-pipe` (aka `%`) was to first wait for an EOF from the stdout/stderr pipe of the process, and only then to wait for the process to exit.

As a result, a command such as `%wl-copy foo` never stops showing the `>` command prefix indicator.

Fix this, by waiting for the EOF from the pipe and the process exit in parallel, as well as setting the `exec.Cmd.WaitDelay` field.

(For some reason, the fix works even without setting `WaitDelay`, and it also doesn't seem to wait for one second; I haven't investigated why this is; the behaviour is an improvement either way.)

Additionally, improve handling errors when reading from the stdout/stderr pipe:
- Always give up reading from the pipe, regardless of error kind
- Unless it is an expected error (`EOF` or (now) `ErrClosed`), log the error
- Compare errors using `errors.Is`