### PR TITLE
Fix lines/columns reporting in preview

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -775,6 +775,10 @@ func (nav *nav) preview(path string, win *win) {
 			strconv.Itoa(win.x),
 			strconv.Itoa(win.y))
 
+		// This will report lines and columns correctly
+		// instead of being hardcoded to 24x80
+		cmd.Stdin = os.Stdin
+
 		out, err := cmd.StdoutPipe()
 		if err != nil {
 			log.Printf("previewing file: %s", err)


### PR DESCRIPTION
I noticed when trying to speedup my previewer script by doing `head -n "$(tput lines)" "$1"` instead of `cat "$1"` that lines and columns are not reported correctly, but instead are always hardcoded to 24x80. It seems like passing `os.Stdin` to the command fixes it. 

It has been reported previously in https://github.com/gokcehan/lf/issues/718

Small previewer script to replicate the issue:
```
#!/bin/sh
echo "$(tput lines)" "$(tput cols)"
```