### PR TITLE
Fix string representation of `expr` objects

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -57,7 +57,12 @@ type setExpr struct {
 	val string
 }
 
-func (e *setExpr) String() string { return fmt.Sprintf("set %s %s", e.opt, e.val) }
+func (e *setExpr) String() string {
+	if e.val == "" {
+		return fmt.Sprintf("set %s", e.opt)
+	}
+	return fmt.Sprintf("set %s %s", e.opt, e.val)
+}
 
 type setLocalExpr struct {
 	path string
@@ -65,42 +70,72 @@ type setLocalExpr struct {
 	val  string
 }
 
-func (e *setLocalExpr) String() string { return fmt.Sprintf("setlocal %s %s %s", e.path, e.opt, e.val) }
+func (e *setLocalExpr) String() string {
+	if e.val == "" {
+		return fmt.Sprintf("setlocal %s %s", e.path, e.opt)
+	}
+	return fmt.Sprintf("setlocal %s %s %s", e.path, e.opt, e.val)
+}
 
 type mapExpr struct {
 	keys string
 	expr expr
 }
 
-func (e *mapExpr) String() string { return fmt.Sprintf("map %s %s", e.keys, e.expr) }
+func (e *mapExpr) String() string {
+	if e.expr == nil {
+		return fmt.Sprintf("map %s", e.keys)
+	}
+	return fmt.Sprintf("map %s %s", e.keys, e.expr)
+}
 
 type nmapExpr struct {
 	keys string
 	expr expr
 }
 
-func (e *nmapExpr) String() string { return fmt.Sprintf("nmap %s %s", e.keys, e.expr) }
+func (e *nmapExpr) String() string {
+	if e.expr == nil {
+		return fmt.Sprintf("nmap %s", e.keys)
+	}
+	return fmt.Sprintf("nmap %s %s", e.keys, e.expr)
+}
 
 type vmapExpr struct {
 	keys string
 	expr expr
 }
 
-func (e *vmapExpr) String() string { return fmt.Sprintf("vmap %s %s", e.keys, e.expr) }
+func (e *vmapExpr) String() string {
+	if e.expr == nil {
+		return fmt.Sprintf("vmap %s", e.keys)
+	}
+	return fmt.Sprintf("vmap %s %s", e.keys, e.expr)
+}
 
 type cmapExpr struct {
 	key  string
 	expr expr
 }
 
-func (e *cmapExpr) String() string { return fmt.Sprintf("cmap %s %s", e.key, e.expr) }
+func (e *cmapExpr) String() string {
+	if e.expr == nil {
+		return fmt.Sprintf("cmap %s", e.key)
+	}
+	return fmt.Sprintf("cmap %s %s", e.key, e.expr)
+}
 
 type cmdExpr struct {
 	name string
 	expr expr
 }
 
-func (e *cmdExpr) String() string { return fmt.Sprintf("cmd %s %s", e.name, e.expr) }
+func (e *cmdExpr) String() string {
+	if e.expr == nil {
+		return fmt.Sprintf("cmd %s", e.name)
+	}
+	return fmt.Sprintf("cmd %s %s", e.name, e.expr)
+}
 
 type callExpr struct {
 	name  string
@@ -108,7 +143,9 @@ type callExpr struct {
 	count int
 }
 
-func (e *callExpr) String() string { return fmt.Sprintf("%s -- %s", e.name, e.args) }
+func (e *callExpr) String() string {
+	return strings.Join(append([]string{e.name}, e.args...), " ")
+}
 
 type execExpr struct {
 	prefix string


### PR DESCRIPTION
- Fixes #2152 
- Supersedes #2158

Run `:cmds` using the following test config file:

```
cmd test01 :set hidden!
cmd test02 :set hidden true
cmd test03 :setlocal ~ hidden!
cmd test04 :setlocal ~ hidden true
cmd test05 :map q
cmd test06 :map q quit
cmd test07 :nmap q
cmd test08 :nmap q quit
cmd test09 :vmap q
cmd test10 :vmap q quit
cmd test11 :cmap q
cmd test12 :cmap q quit
cmd test13 :cmd foo
cmd test14 :cmd foo quit
cmd test15 :quit
cmd test16 :cd ~
cmd test17 :toggle; down
```

Before:

```
test01  :{{ set hidden! ; }}
test02  :{{ set hidden true; }}
test03  :{{ setlocal ~ hidden! ; }}
test04  :{{ setlocal ~ hidden true; }}
test05  :{{ map q %!s(<nil>); }}
test06  :{{ map q quit -- []; }}
test07  :{{ nmap q %!s(<nil>); }}
test08  :{{ nmap q quit -- []; }}
test09  :{{ vmap q %!s(<nil>); }}
test10  :{{ vmap q quit -- []; }}
test11  :{{ cmap q %!s(<nil>); }}
test12  :{{ cmap q quit -- []; }}
test13  :{{ cmd foo %!s(<nil>); }}
test14  :{{ cmd foo quit -- []; }}
test15  :{{ quit -- []; }}
test16  :{{ cd -- [~]; }}
test17  :{{ toggle -- []; down -- []; }}
```

After

```
test01  :{{ set hidden!; }}
test02  :{{ set hidden true; }}
test03  :{{ setlocal ~ hidden!; }}
test04  :{{ setlocal ~ hidden true; }}
test05  :{{ map q; }}
test06  :{{ map q quit; }}
test07  :{{ nmap q; }}
test08  :{{ nmap q quit; }}
test09  :{{ vmap q; }}
test10  :{{ vmap q quit; }}
test11  :{{ cmap q; }}
test12  :{{ cmap q quit; }}
test13  :{{ cmd foo; }}
test14  :{{ cmd foo quit; }}
test15  :{{ quit; }}
test16  :{{ cd ~; }}
test17  :{{ toggle; down; }}
```
