### PR TITLE
Fix message clear bug during `shell-pipe` command

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -2292,7 +2292,7 @@ func (e *callExpr) eval(app *app, args []string) {
 		"on-focus-lost",
 		"on-init",
 	}
-	if !slices.Contains(keepMsgCmds, e.name) {
+	if !slices.Contains(keepMsgCmds, e.name) && app.ui.cmdPrefix != ">" {
 		app.ui.echo("")
 	}
 }


### PR DESCRIPTION
Prompt gets cleared when entering input with the following config file:

```sh
cmd test %{{
    printf "type something: "
    read -r input
    printf "you typed: $input"
}}
```