### PR TITLE
Refactor directory sorting code

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -295,7 +295,7 @@ func humanize(size uint64) string {
 // account the values of numbers in strings. For example, '2' is ordered before
 // '10', and similarly 'foo2bar' ordered before 'foo10bar'. When comparing
 // numbers, if they have the same value then the length of the string is
-// compared, so '0' is ordered before '00'.
+// also compared, so '0' is ordered before '00'.
 func naturalCmp(s1, s2 string) int {
 	s1len := len(s1)
 	s2len := len(s2)

--- a/misc.go
+++ b/misc.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"cmp"
 	"fmt"
 	"io"
 	"io/fs"
@@ -330,6 +331,58 @@ func naturalLess(s1, s2 string) bool {
 		}
 
 		return s1[lo1:hi1] < s2[lo2:hi2]
+	}
+}
+
+// This function compares two strings for natural sorting which takes into
+// account the values of numbers in strings. For example, '2' is ordered before
+// '10', and similarly 'foo2bar' ordered before 'foo10bar'. When comparing
+// numbers, if they have the same value then the length of the string is
+// compared, so '0' is ordered before '00'.
+func naturalCmp(s1, s2 string) int {
+	s1len := len(s1)
+	s2len := len(s2)
+
+	var lo1, lo2, hi1, hi2 int
+	for {
+		switch {
+		case hi1 >= s1len && hi2 >= s2len:
+			return 0
+		case hi1 >= s1len && hi2 < s2len:
+			return -1
+		case hi1 < s1len && hi2 >= s2len:
+			return 1
+		}
+
+		lo1 = hi1
+		isDigit1 := isDigit(s1[hi1])
+		for hi1 < s1len && isDigit(s1[hi1]) == isDigit1 {
+			hi1++
+		}
+		tok1 := s1[lo1:hi1]
+
+		lo2 = hi2
+		isDigit2 := isDigit(s2[hi2])
+		for hi2 < s2len && isDigit(s2[hi2]) == isDigit2 {
+			hi2++
+		}
+		tok2 := s2[lo2:hi2]
+
+		if isDigit1 && isDigit2 {
+			num1, err1 := strconv.Atoi(tok1)
+			num2, err2 := strconv.Atoi(tok2)
+			if err1 == nil && err2 == nil {
+				if num1 != num2 {
+					return cmp.Compare(num1, num2)
+				} else if len(tok1) != len(tok2) {
+					return cmp.Compare(len(tok1), len(tok2))
+				}
+			}
+		}
+
+		if tok1 != tok2 {
+			return cmp.Compare(tok1, tok2)
+		}
 	}
 }
 

--- a/misc.go
+++ b/misc.go
@@ -292,49 +292,6 @@ func humanize(size uint64) string {
 }
 
 // This function compares two strings for natural sorting which takes into
-// account values of numbers in strings. For example, '2' is less than '10',
-// and similarly 'foo2bar' is less than 'foo10bar', but 'bar2bar' is greater
-// than 'foo10bar'.
-func naturalLess(s1, s2 string) bool {
-	lo1, lo2, hi1, hi2 := 0, 0, 0, 0
-	s1len := len(s1)
-	s2len := len(s2)
-	for {
-		if hi1 >= s1len {
-			return hi2 != s2len
-		}
-
-		if hi2 >= s2len {
-			return false
-		}
-
-		isDigit1 := isDigit(s1[hi1])
-		isDigit2 := isDigit(s2[hi2])
-
-		for lo1 = hi1; hi1 < s1len && isDigit(s1[hi1]) == isDigit1; hi1++ {
-		}
-
-		for lo2 = hi2; hi2 < s2len && isDigit(s2[hi2]) == isDigit2; hi2++ {
-		}
-
-		if s1[lo1:hi1] == s2[lo2:hi2] {
-			continue
-		}
-
-		if isDigit1 && isDigit2 {
-			num1, err1 := strconv.Atoi(s1[lo1:hi1])
-			num2, err2 := strconv.Atoi(s2[lo2:hi2])
-
-			if err1 == nil && err2 == nil {
-				return num1 < num2
-			}
-		}
-
-		return s1[lo1:hi1] < s2[lo2:hi2]
-	}
-}
-
-// This function compares two strings for natural sorting which takes into
 // account the values of numbers in strings. For example, '2' is ordered before
 // '10', and similarly 'foo2bar' ordered before 'foo10bar'. When comparing
 // numbers, if they have the same value then the length of the string is

--- a/misc.go
+++ b/misc.go
@@ -294,8 +294,8 @@ func humanize(size uint64) string {
 // This function compares two strings for natural sorting which takes into
 // account the values of numbers in strings. For example, '2' is ordered before
 // '10', and similarly 'foo2bar' ordered before 'foo10bar'. When comparing
-// numbers, if they have the same value then the length of the string is
-// also compared, so '0' is ordered before '00'.
+// numbers, if they have the same value then the length of the string is also
+// compared, so '0' is ordered before '00'.
 func naturalCmp(s1, s2 string) int {
 	s1len := len(s1)
 	s2len := len(s2)

--- a/misc_test.go
+++ b/misc_test.go
@@ -346,33 +346,6 @@ func TestHumanize(t *testing.T) {
 	}
 }
 
-func TestNaturalLess(t *testing.T) {
-	tests := []struct {
-		s1  string
-		s2  string
-		exp bool
-	}{
-		{"foo", "bar", false},
-		{"bar", "baz", true},
-		{"foo", "123", false},
-		{"foo1", "foobar", true},
-		{"foo1", "foo10", true},
-		{"foo2", "foo10", true},
-		{"foo1", "foo10bar", true},
-		{"foo2", "foo10bar", true},
-		{"foo1bar", "foo10bar", true},
-		{"foo2bar", "foo10bar", true},
-		{"foo1bar", "foo10", true},
-		{"foo2bar", "foo10", true},
-	}
-
-	for _, test := range tests {
-		if got := naturalLess(test.s1, test.s2); got != test.exp {
-			t.Errorf("at input '%s' and '%s' expected '%t' but got '%t'", test.s1, test.s2, test.exp, got)
-		}
-	}
-}
-
 func TestNaturalCmp(t *testing.T) {
 	tests := []struct {
 		s1  string

--- a/misc_test.go
+++ b/misc_test.go
@@ -373,6 +373,45 @@ func TestNaturalLess(t *testing.T) {
 	}
 }
 
+func TestNaturalCmp(t *testing.T) {
+	tests := []struct {
+		s1  string
+		s2  string
+		exp int
+	}{
+		{"", "", 0},
+		{"a", "a", 0},
+		{"", "a", -1},
+		{"a", "b", -1},
+		{"a", "ab", -1},
+		{"0", "0", 0},
+		{"0", "00", -1},
+		{"1", "1", 0},
+		{"1", "01", -1},
+		{"2", "10", -1},
+		{"123", "foo", -1},
+		{"foo", "foo1", -1},
+		{"foo1", "foobar", -1},
+		{"foo1", "foobar1", -1},
+		{"foo2", "foo10", -1},
+		{"foo2bar", "foo10bar", -1},
+		{"foo0", "foo00", -1},
+		{"foo0bar", "foo00bar", -1},
+		{"foo1", "foo01", -1},
+		{"foo1bar", "foo01bar", -1},
+	}
+
+	for _, test := range tests {
+		if got := naturalCmp(test.s1, test.s2); got != test.exp {
+			t.Errorf("at input '%s' and '%s' expected '%d' but got '%d'", test.s1, test.s2, test.exp, got)
+		}
+
+		if got := naturalCmp(test.s2, test.s1); got != -test.exp {
+			t.Errorf("at input '%s' and '%s' expected '%d' but got '%d'", test.s2, test.s1, -test.exp, got)
+		}
+	}
+}
+
 type fakeFileInfo struct {
 	name  string
 	isDir bool

--- a/nav.go
+++ b/nav.go
@@ -248,12 +248,12 @@ func (dir *dir) sort() {
 	applyFilter := func(fn func(f *file) bool) {
 		slices.SortStableFunc(dir.files, func(i, j *file) int {
 			switch {
-			case fn(i) == fn(j):
-				return 0
 			case !fn(i) && fn(j):
 				return -1
-			default:
+			case fn(i) && !fn(j):
 				return 1
+			default:
+				return 0
 			}
 		})
 

--- a/nav.go
+++ b/nav.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"cmp"
 	"errors"
 	"fmt"
 	"io"
@@ -207,28 +208,6 @@ func newDir(path string) *dir {
 	}
 }
 
-func normalize(s1, s2 string, ignorecase, ignoredia bool) (string, string) {
-	if ignorecase {
-		s1 = strings.ToLower(s1)
-		s2 = strings.ToLower(s2)
-	}
-	if ignoredia {
-		s1 = removeDiacritics(s1)
-		s2 = removeDiacritics(s2)
-	}
-	return s1, s2
-}
-
-func normalize2(s string, ignorecase, ignoredia bool) string {
-	if ignorecase {
-		s = strings.ToLower(s)
-	}
-	if ignoredia {
-		s = removeDiacritics(s)
-	}
-	return s
-}
-
 func (dir *dir) sort() {
 	dir.sortby = getSortBy(dir.path)
 	dir.dircounts = getDirCounts(dir.path)
@@ -276,17 +255,7 @@ func (dir *dir) sort() {
 		applyFilter(func(f *file) bool { return !isFiltered(f, dir.filter) })
 	}
 
-	// reverse order cannot be applied after stable sorting, otherwise the order
-	// of equivalent elements will be reversed
-	applySort := func(fn func(i, j int) bool) {
-		if !dir.reverse {
-			sort.SliceStable(dir.files, fn)
-		} else {
-			sort.SliceStable(dir.files, func(i, j int) bool { return fn(j, i) })
-		}
-	}
-
-	applySort2 := func(fn func(f1, f2 *file) int) {
+	applySort := func(fn func(f1, f2 *file) int) {
 		if !dir.reverse {
 			slices.SortStableFunc(dir.files, fn)
 		} else {
@@ -294,17 +263,24 @@ func (dir *dir) sort() {
 		}
 	}
 
+	normalize := func(s string) string {
+		if dir.ignorecase {
+			s = strings.ToLower(s)
+		}
+		if dir.ignoredia {
+			s = removeDiacritics(s)
+		}
+		return s
+	}
+
 	switch dir.sortby {
 	case naturalSort:
-		applySort2(func(f1, f2 *file) int {
-			s1 := normalize2(f1.Name(), dir.ignorecase, dir.ignoredia)
-			s2 := normalize2(f2.Name(), dir.ignorecase, dir.ignoredia)
-			return naturalCmp(s1, s2)
+		applySort(func(f1, f2 *file) int {
+			return naturalCmp(normalize(f1.Name()), normalize(f2.Name()))
 		})
 	case nameSort:
-		applySort(func(i, j int) bool {
-			s1, s2 := normalize(dir.files[i].Name(), dir.files[j].Name(), dir.ignorecase, dir.ignoredia)
-			return s1 < s2
+		applySort(func(f1, f2 *file) int {
+			return cmp.Compare(normalize(f1.Name()), normalize(f2.Name()))
 		})
 	case sizeSort:
 		sizeVal := func(f *file) int64 {
@@ -313,36 +289,39 @@ func (dir *dir) sort() {
 			}
 			return f.TotalSize()
 		}
-		applySort(func(i, j int) bool {
-			s1, s2 := sizeVal(dir.files[i]), sizeVal(dir.files[j])
-			return s1 < s2
+		applySort(func(f1, f2 *file) int {
+			return cmp.Compare(sizeVal(f1), sizeVal(f2))
 		})
 	case timeSort:
-		applySort(func(i, j int) bool {
-			return dir.files[i].ModTime().Before(dir.files[j].ModTime())
+		applySort(func(f1, f2 *file) int {
+			return f1.ModTime().Compare(f2.ModTime())
 		})
 	case atimeSort:
-		applySort(func(i, j int) bool {
-			return dir.files[i].accessTime.Before(dir.files[j].accessTime)
+		applySort(func(f1, f2 *file) int {
+			return f1.accessTime.Compare(f2.accessTime)
 		})
 	case btimeSort:
-		applySort(func(i, j int) bool {
-			return dir.files[i].birthTime.Before(dir.files[j].birthTime)
+		applySort(func(f1, f2 *file) int {
+			return f1.birthTime.Compare(f2.birthTime)
 		})
 	case ctimeSort:
-		applySort(func(i, j int) bool {
-			return dir.files[i].changeTime.Before(dir.files[j].changeTime)
+		applySort(func(f1, f2 *file) int {
+			return f1.changeTime.Compare(f2.changeTime)
 		})
 	case extSort:
-		applySort(func(i, j int) bool {
-			ext1, ext2 := normalize(dir.files[i].ext, dir.files[j].ext, dir.ignorecase, dir.ignoredia)
-			name1, name2 := normalize(dir.files[i].Name(), dir.files[j].Name(), dir.ignorecase, dir.ignoredia)
-			return ext1 < ext2 || ext1 == ext2 && name1 < name2
+		applySort(func(f1, f2 *file) int {
+			ext1 := normalize(f1.ext)
+			ext2 := normalize(f2.ext)
+			if ext1 != ext2 {
+				return cmp.Compare(ext1, ext2)
+			}
+			return cmp.Compare(normalize(f1.Name()), normalize(f2.Name()))
 		})
 	case customSort:
-		applySort(func(i, j int) bool {
-			s1, s2 := normalize(stripAnsi(dir.files[i].customInfo), stripAnsi(dir.files[j].customInfo), dir.ignorecase, dir.ignoredia)
-			return naturalLess(s1, s2)
+		applySort(func(f1, f2 *file) int {
+			s1 := normalize(stripAnsi(f1.customInfo))
+			s2 := normalize(stripAnsi(f2.customInfo))
+			return naturalCmp(s1, s2)
 		})
 	}
 

--- a/nav.go
+++ b/nav.go
@@ -328,11 +328,15 @@ func (dir *dir) sort() {
 	// when sorting by size while also showing dircounts, we always display files
 	// and directories separately to avoid mixing file sizes and file counts
 	if dir.dirfirst || (dir.sortby == sizeSort && dir.dircounts) {
-		sort.SliceStable(dir.files, func(i, j int) bool {
-			if dir.files[i].IsDir() == dir.files[j].IsDir() {
-				return i < j
+		applySort(func(f1, f2 *file) int {
+			switch {
+			case f1.IsDir() && !f2.IsDir():
+				return -1
+			case !f1.IsDir() && f2.IsDir():
+				return 1
+			default:
+				return 0
 			}
-			return dir.files[i].IsDir()
 		})
 	}
 


### PR DESCRIPTION
- Fixes #942 

Use `slices.SortStableFunc` which is recommended over `sort.SliceStable`.

Also changed the natural sorting algorithm so that numbers of the same value are compared by the string length as well (i.e. `0` is ordered before `00`).

---

Natural sort now matches https://github.com/gokcehan/lf/issues/942#issuecomment-1256152498:

<img width="974" height="662" alt="image" src="https://github.com/user-attachments/assets/30f1fde1-6bb3-4271-ab1e-3d071b72d075" />
