### PR TITLE
Silence `gopls` hints

### DIFF
--- a/app.go
+++ b/app.go
@@ -511,7 +511,7 @@ func (app *app) loop() {
 	}
 }
 
-func (app *app) runCmdSync(cmd *exec.Cmd, pause_after bool) {
+func (app *app) runCmdSync(cmd *exec.Cmd, pauseAfter bool) {
 	app.nav.previewChan <- ""
 
 	if err := app.ui.suspend(); err != nil {
@@ -527,7 +527,7 @@ func (app *app) runCmdSync(cmd *exec.Cmd, pause_after bool) {
 	if err := cmd.Run(); err != nil {
 		app.ui.echoerrf("running shell: %s", err)
 	}
-	if pause_after {
+	if pauseAfter {
 		anyKey()
 	}
 

--- a/colors.go
+++ b/colors.go
@@ -242,7 +242,7 @@ func (sm styleMap) parseFile(path string) {
 
 // This function parses $LS_COLORS environment variable.
 func (sm *styleMap) parseGNU(env string) {
-	for _, entry := range strings.Split(env, ":") {
+	for entry := range strings.SplitSeq(env, ":") {
 		if entry == "" {
 			continue
 		}

--- a/complete.go
+++ b/complete.go
@@ -312,7 +312,7 @@ func matchShellFile(s string) (matches []compMatch, result string) {
 
 func matchExec(s string) (matches []compMatch, result string) {
 	var words []string
-	for _, p := range strings.Split(envPath, string(filepath.ListSeparator)) {
+	for p := range strings.SplitSeq(envPath, string(filepath.ListSeparator)) {
 		files, err := os.ReadDir(p)
 		if err != nil {
 			if !os.IsNotExist(err) {

--- a/copy.go
+++ b/copy.go
@@ -61,11 +61,11 @@ func copyFile(src, dst string, preserve []string, info os.FileInfo, nums chan in
 	}
 	defer r.Close()
 
-	var dst_mode os.FileMode = 0o666
+	var dstMode os.FileMode = 0o666
 	if slices.Contains(preserve, "mode") {
-		dst_mode = info.Mode()
+		dstMode = info.Mode()
 	}
-	w, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, dst_mode)
+	w, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, dstMode)
 	if err != nil {
 		return err
 	}
@@ -132,11 +132,11 @@ func copyAll(srcs []string, dstDir string, preserve []string) (nums chan int64, 
 				newPath := filepath.Join(dst, rel)
 				switch {
 				case info.IsDir():
-					var dst_mode = os.ModePerm
+					dstMode := os.ModePerm
 					if slices.Contains(preserve, "mode") {
-						dst_mode = info.Mode()
+						dstMode = info.Mode()
 					}
-					if err := os.MkdirAll(newPath, dst_mode); err != nil {
+					if err := os.MkdirAll(newPath, dstMode); err != nil {
 						errs <- fmt.Errorf("mkdir: %s", err)
 					}
 					if slices.Contains(preserve, "timestamps") {

--- a/icons.go
+++ b/icons.go
@@ -88,7 +88,7 @@ func (im *iconMap) parseFile(path string) {
 }
 
 func (im *iconMap) parseEnv(env string) {
-	for _, entry := range strings.Split(env, ":") {
+	for entry := range strings.SplitSeq(env, ":") {
 		if entry == "" {
 			continue
 		}

--- a/misc.go
+++ b/misc.go
@@ -173,7 +173,7 @@ func splitWord(s string) (word, rest string) {
 // or double quotes can be used to escape whitespaces. Hash characters can be
 // used to add a comment until the end of line. Leading and trailing space is
 // trimmed. Empty lines are skipped.
-func readArrays(r io.Reader, min_cols, max_cols int) ([][]string, error) {
+func readArrays(r io.Reader, minCols, maxCols int) ([][]string, error) {
 	var arrays [][]string
 	s := bufio.NewScanner(r)
 	for s.Scan() {
@@ -209,11 +209,11 @@ func readArrays(r io.Reader, min_cols, max_cols int) ([][]string, error) {
 		})
 		arrlen := len(arr)
 
-		if arrlen < min_cols || arrlen > max_cols {
-			if min_cols == max_cols {
-				return nil, fmt.Errorf("expected %d columns but found: %s", min_cols, s.Text())
+		if arrlen < minCols || arrlen > maxCols {
+			if minCols == maxCols {
+				return nil, fmt.Errorf("expected %d columns but found: %s", minCols, s.Text())
 			}
-			return nil, fmt.Errorf("expected %d~%d columns but found: %s", min_cols, max_cols, s.Text())
+			return nil, fmt.Errorf("expected %d~%d columns but found: %s", minCols, maxCols, s.Text())
 		}
 
 		for i := range arrlen {

--- a/misc_test.go
+++ b/misc_test.go
@@ -231,10 +231,10 @@ func TestSplitWord(t *testing.T) {
 
 func TestReadArrays(t *testing.T) {
 	tests := []struct {
-		s        string
-		min_cols int
-		max_cols int
-		exp      [][]string
+		s       string
+		minCols int
+		maxCols int
+		exp     [][]string
 	}{
 		{"foo bar", 2, 2, [][]string{{"foo", "bar"}}},
 		{"foo bar ", 2, 2, [][]string{{"foo", "bar"}}},
@@ -249,7 +249,7 @@ func TestReadArrays(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if got, _ := readArrays(strings.NewReader(test.s), test.min_cols, test.max_cols); !reflect.DeepEqual(got, test.exp) {
+		if got, _ := readArrays(strings.NewReader(test.s), test.minCols, test.maxCols); !reflect.DeepEqual(got, test.exp) {
 			t.Errorf("at input '%v' expected '%v' but got '%v'", test.s, test.exp, got)
 		}
 	}

--- a/os_windows.go
+++ b/os_windows.go
@@ -174,8 +174,7 @@ func setDefaults() {
 func setUserUmask() {}
 
 func isExecutable(f os.FileInfo) bool {
-	exts := strings.Split(envPathExt, string(filepath.ListSeparator))
-	for _, e := range exts {
+	for e := range strings.SplitSeq(envPathExt, string(filepath.ListSeparator)) {
 		if strings.HasSuffix(strings.ToLower(f.Name()), strings.ToLower(e)) {
 			log.Print(f.Name(), e)
 			return true

--- a/ui.go
+++ b/ui.go
@@ -797,8 +797,8 @@ func (ui *ui) drawPromptLine(nav *nav) {
 	dir := nav.currDir()
 	pwd := dir.path
 
-	if strings.HasPrefix(pwd, gUser.HomeDir) {
-		pwd = filepath.Join("~", strings.TrimPrefix(pwd, gUser.HomeDir))
+	if after, ok := strings.CutPrefix(pwd, gUser.HomeDir); ok {
+		pwd = filepath.Join("~", after)
 	}
 
 	sep := string(filepath.Separator)
@@ -905,7 +905,7 @@ func (ui *ui) drawStat(nav *nav) {
 	replace("%l", curr.linkTarget)
 
 	var fileInfo strings.Builder
-	for _, section := range strings.Split(statfmt, "\x1f") {
+	for section := range strings.SplitSeq(statfmt, "\x1f") {
 		if !strings.Contains(section, "\x00") {
 			fileInfo.WriteString(section)
 		}
@@ -1008,7 +1008,7 @@ func (ui *ui) drawRuler(nav *nav) {
 		return result
 	})
 	var ruler strings.Builder
-	for _, section := range strings.Split(rulerfmt, "\x1f") {
+	for section := range strings.SplitSeq(rulerfmt, "\x1f") {
 		if !strings.Contains(section, "\x00") {
 			ruler.WriteString(section)
 		}


### PR DESCRIPTION
This pull requests adds suggestions by `gopls`:
- should not use underscores in Go names; var foo_bar should be fooBar
- Ranging over SplitSeq is more efficient
- HasPrefix + TrimPrefix can be simplified to CutPrefix