### PR TITLE
Keep text previews after horizontal resize

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -1285,6 +1285,12 @@ func (e *callExpr) eval(app *app, args []string) {
 		if app.nav.height != app.ui.wins[0].h {
 			app.nav.height = app.ui.wins[0].h
 			clear(app.nav.regCache)
+		} else {
+			for path, r := range app.nav.regCache {
+				if r.sixel {
+					delete(app.nav.regCache, path)
+				}
+			}
 		}
 		for _, dir := range app.nav.dirs {
 			dir.boundPos(app.nav.height)

--- a/ui.go
+++ b/ui.go
@@ -1574,7 +1574,6 @@ func (ui *ui) readNormalEvent(ev tcell.Event, nav *nav) expr {
 			return &callExpr{"cd", []string{dir.path}, 1}
 		}
 	case *tcell.EventResize:
-		clear(nav.regCache)
 		return &callExpr{"redraw", nil, 1}
 	case *tcell.EventError:
 		log.Printf("Got EventError: '%s' at %s", tev.Error(), tev.When())


### PR DESCRIPTION
I noticed that text previews are removed from the cache when the terminal is resized horizontally (i.e. the width changes but not the height). It makes sense for images to be reloaded, but there's no need for text previews since the number of lines hasn't changed and it causes unnecessary flickering.