### PR TITLE
Hide mode when listing single-mode binds

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -1329,6 +1329,7 @@ func listBinds(binds map[string]map[string]expr) string {
 	t := new(tabwriter.Writer)
 	b := new(bytes.Buffer)
 
+	// merge keys by command across modes
 	m := make(map[string]map[string]string)
 	for mode, keys := range binds {
 		for key, expr := range keys {
@@ -1343,6 +1344,7 @@ func listBinds(binds map[string]map[string]expr) string {
 		mode, key, cmd string
 	}
 
+	// collect normalized entries
 	var entries []entry
 	for key, cmds := range m {
 		for cmd, modes := range cmds {
@@ -1360,9 +1362,18 @@ func listBinds(binds map[string]map[string]expr) string {
 	})
 
 	t.Init(b, 0, gOpts.tabstop, 2, '\t', 0)
-	fmt.Fprintln(t, "mode\tkeys\tcommand")
-	for _, e := range entries {
-		fmt.Fprintf(t, "%s\t%s\t%s\n", e.mode, e.key, e.cmd)
+
+	if len(binds) == 1 {
+		fmt.Fprintln(t, "keys\tcommand")
+		for _, e := range entries {
+			fmt.Fprintf(t, "%s\t%s\n", e.key, e.cmd)
+		}
+	} else {
+		// include mode field when listing combined maps
+		fmt.Fprintln(t, "mode\tkeys\tcommand")
+		for _, e := range entries {
+			fmt.Fprintf(t, "%s\t%s\t%s\n", e.mode, e.key, e.cmd)
+		}
 	}
 	t.Flush()
 


### PR DESCRIPTION
This PR hides the unnecessary `mode` column when listing keybindings for one mode only.

- the `showbinds` menu no longer shows `mode` (it always displayed the current one):

 <img width="212" height="141" src="https://github.com/user-attachments/assets/de921c10-eee2-422f-b42c-fbfb638770ac" /> <img width="212" height="141" src="https://github.com/user-attachments/assets/c91f1f8b-0283-49d4-813a-8c9d15a76bba" /> 

- the `cmaps` command still displays `mode` as it's a combination of `nmaps` and `vmaps` whose keymaps can either be valid in one or both `modes`:
<img width="212" height="141" alt="Screenshot 2025-10-26 at 8 50 26 AM" src="https://github.com/user-attachments/assets/1e0673a3-4428-4e47-8a55-60077c7a461d" />
