### PR TITLE
.github: staticcheck-action → golangci-lint-action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,10 +39,10 @@ jobs:
       - name: Test
         run: go test -v ./...
 
-      - uses: dominikh/staticcheck-action@v1.4.0
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: "2025.1.1"
-          install-go: false
+          version: v2.5.0
 
   build:
     runs-on: ubuntu-latest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,7 @@
+version: "2"
+linters:
+  disable:
+    - errcheck
+issues:
+  max-issues-per-linter: 0  # no limit
+  max-same-issues: 0        # no limit


### PR DESCRIPTION
This PR was split out of #2203.

`golangci-lint` bundles [many Go linters](https://golangci-lint.run/docs/linters/). For now, we are going with its default set of linters, which includes `staticcheck`, but we are excluding the `errcheck` linter because it generates a lot of lints; I plan to address those (partly through suppressions) and add `errcheck` in a subsequent contribution.

All the other default-enabled linters (`govet`, `ineffassign`, `unused`) have no complaints. Once this is merged, we'll be guaranteed to keep it that way. 🙂