### PR TITLE
Alternate implementation for matching `setlocal` path

### DIFF
--- a/complete.go
+++ b/complete.go
@@ -320,16 +320,20 @@ func matchSetlocalDir(s string) (matches []compMatch, result string) {
 		return strings.TrimSuffix(path, string(filepath.Separator))
 	}
 
+	trimSepEsc := func(path string) string {
+		return cmdEscape(trimSep(cmdUnescape(path)))
+	}
+
 	// add separate matches for path and recursive path
 	tmp := make([]compMatch, 0, len(matches)*2)
 	for _, match := range matches {
-		trimmedMatch := compMatch{trimSep(match.name), trimSep(match.result)}
+		trimmedMatch := compMatch{trimSep(match.name), trimSepEsc(match.result)}
 		tmp = append(tmp, trimmedMatch, match)
 	}
 	matches = tmp
 
 	if result != s {
-		result = trimSep(result)
+		result = trimSepEsc(result)
 	}
 	return
 }


### PR DESCRIPTION
Hi @CatsDeservePets,

I saw you add completion support for the `setlocal` path in #2254. I couldn't help but notice that it was largely a copy and paste of the `matchFile` function. From what I understand, the requirement is slightly different for `setlocal` where each directory has two match results (an extra one ending in `/` to specify recursive paths).

So I was wondering whether it would be a good idea to just use the existing function and then adjust the results afterwards, something like what is done in this PR.