### PR TITLE
Remove Google Groups and Libra.Chat from `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # LF
 
-[Google Groups](https://groups.google.com/forum/#!forum/lf-fm)
 | [Doc](doc.md)
 | [Wiki](https://github.com/gokcehan/lf/wiki)
-| [#lf](https://web.libera.chat/#lf) (on Libera.Chat)
 | [#lf:matrix.org](https://matrix.to/#/#lf:matrix.org) (with IRC bridge)
 
 [![Go Build](https://github.com/gokcehan/lf/actions/workflows/go.yml/badge.svg)](https://github.com/gokcehan/lf/actions/workflows/go.yml)


### PR DESCRIPTION
This PR removes the `Google Groups` and `Libra.Chat` links from the `README.md` due to them being abandoned and lacking active members.