### PR TITLE
refactor: avoid storing current preview separately

### DIFF
--- a/app.go
+++ b/app.go
@@ -423,9 +423,6 @@ func (app *app) loop() {
 				if curr.path != oldCurrPath {
 					app.ui.loadFile(app, true)
 				}
-				if d.path == curr.path {
-					app.ui.dirPrev = d
-				}
 			}
 
 			app.watchDir(d)
@@ -447,7 +444,6 @@ func (app *app) loop() {
 			curr, err := app.nav.currFile()
 			if err == nil {
 				if r.path == curr.path {
-					app.ui.regPrev = r
 					app.ui.sxScreen.forceClear = true
 					if gOpts.preload && r.volatile {
 						app.ui.loadFile(app, true)

--- a/eval.go
+++ b/eval.go
@@ -74,14 +74,12 @@ func (e *setExpr) eval(app *app, _ []string) {
 		err = applyBoolOpt(&gOpts.dirfirst, e)
 		if err == nil {
 			app.nav.sort()
-			app.ui.sort()
 		}
 	case "dironly", "nodironly", "dironly!":
 		err = applyBoolOpt(&gOpts.dironly, e)
 		if err == nil {
 			app.nav.sort()
 			app.nav.position()
-			app.ui.sort()
 			app.ui.loadFile(app, true)
 		}
 	case "dirpreviews", "nodirpreviews", "dirpreviews!":
@@ -98,7 +96,6 @@ func (e *setExpr) eval(app *app, _ []string) {
 		if err == nil {
 			app.nav.sort()
 			app.nav.position()
-			app.ui.sort()
 			app.ui.loadFile(app, true)
 		}
 	case "history", "nohistory", "history!":
@@ -110,7 +107,6 @@ func (e *setExpr) eval(app *app, _ []string) {
 		if err == nil {
 			app.nav.sort()
 			app.nav.position()
-			app.ui.sort()
 			app.ui.loadFile(app, true)
 		}
 	case "ignoredia", "noignoredia", "ignoredia!":
@@ -118,7 +114,6 @@ func (e *setExpr) eval(app *app, _ []string) {
 		if err == nil {
 			app.nav.sort()
 			app.nav.position()
-			app.ui.sort()
 			app.ui.loadFile(app, true)
 		}
 	case "incfilter", "noincfilter", "incfilter!":
@@ -155,7 +150,6 @@ func (e *setExpr) eval(app *app, _ []string) {
 		err = applyBoolOpt(&gOpts.reverse, e)
 		if err == nil {
 			app.nav.sort()
-			app.ui.sort()
 		}
 	case "roundbox", "noroundbox", "roundbox!":
 		err = applyBoolOpt(&gOpts.roundbox, e)
@@ -168,7 +162,6 @@ func (e *setExpr) eval(app *app, _ []string) {
 		if err == nil {
 			app.nav.sort()
 			app.nav.position()
-			app.ui.sort()
 			app.ui.loadFile(app, true)
 		}
 	case "smartdia", "nosmartdia", "smartdia!":
@@ -176,7 +169,6 @@ func (e *setExpr) eval(app *app, _ []string) {
 		if err == nil {
 			app.nav.sort()
 			app.nav.position()
-			app.ui.sort()
 			app.ui.loadFile(app, true)
 		}
 	case "watch", "nowatch", "watch!":
@@ -225,7 +217,6 @@ func (e *setExpr) eval(app *app, _ []string) {
 		}
 		app.nav.sort()
 		app.nav.position()
-		app.ui.sort()
 		app.ui.loadFile(app, true)
 	case "findlen":
 		n, err := strconv.Atoi(e.val)
@@ -254,7 +245,6 @@ func (e *setExpr) eval(app *app, _ []string) {
 		gOpts.hiddenfiles = toks
 		app.nav.sort()
 		app.nav.position()
-		app.ui.sort()
 		app.ui.loadFile(app, true)
 	case "ifs":
 		gOpts.ifs = e.val
@@ -401,7 +391,6 @@ func (e *setExpr) eval(app *app, _ []string) {
 		}
 		gOpts.sortby = method
 		app.nav.sort()
-		app.ui.sort()
 	case "statfmt":
 		gOpts.statfmt = e.val
 	case "tabstop":
@@ -485,14 +474,12 @@ func (e *setLocalExpr) eval(app *app, _ []string) {
 		err = applyLocalBoolOpt(gLocalOpts.dirfirst, gOpts.dirfirst, e)
 		if err == nil {
 			app.nav.sort()
-			app.ui.sort()
 		}
 	case "dironly", "nodironly", "dironly!":
 		err = applyLocalBoolOpt(gLocalOpts.dironly, gOpts.dironly, e)
 		if err == nil {
 			app.nav.sort()
 			app.nav.position()
-			app.ui.sort()
 			app.ui.loadFile(app, true)
 		}
 	case "hidden", "nohidden", "hidden!":
@@ -500,14 +487,12 @@ func (e *setLocalExpr) eval(app *app, _ []string) {
 		if err == nil {
 			app.nav.sort()
 			app.nav.position()
-			app.ui.sort()
 			app.ui.loadFile(app, true)
 		}
 	case "reverse", "noreverse", "reverse!":
 		err = applyLocalBoolOpt(gLocalOpts.reverse, gOpts.reverse, e)
 		if err == nil {
 			app.nav.sort()
-			app.ui.sort()
 		}
 	case "info":
 		if e.val == "" {
@@ -532,7 +517,6 @@ func (e *setLocalExpr) eval(app *app, _ []string) {
 		}
 		gLocalOpts.sortby[e.path] = method
 		app.nav.sort()
-		app.ui.sort()
 	default:
 		err = fmt.Errorf("unknown option: %s", e.opt)
 	}
@@ -1772,7 +1756,6 @@ func (e *callExpr) eval(app *app, _ []string) {
 			return
 		}
 		app.nav.sort()
-		app.ui.sort()
 	case "clearmaps":
 		// leave `:` and cmaps bound so the user can still exit using `:quit`
 		clear(gOpts.nkeys)

--- a/nav.go
+++ b/nav.go
@@ -987,6 +987,14 @@ func (nav *nav) sort() {
 		d.sort()
 		d.sel(name, nav.height)
 	}
+
+	if curr, err := nav.currFile(); err == nil {
+		if d, ok := nav.dirCache[curr.path]; ok {
+			name := d.name()
+			d.sort()
+			d.sel(name, nav.height)
+		}
+	}
 }
 
 func (nav *nav) setFilter(filter []string) error {

--- a/ui.go
+++ b/ui.go
@@ -244,21 +244,16 @@ func (win *win) printRight(screen tcell.Screen, y int, st tcell.Style, s string)
 }
 
 func (win *win) printReg(screen tcell.Screen, reg *reg, previewLoading bool, sxs *sixelScreen) {
-	if reg == nil {
-		return
-	}
-
-	st := tcell.StyleDefault
-
 	if reg.loading {
 		if previewLoading {
-			st = st.Reverse(true)
+			st := tcell.StyleDefault.Reverse(true)
 			win.print(screen, 2, 0, st, "loading...")
 		}
 		return
 	}
 
 	if !reg.sixel {
+		st := tcell.StyleDefault
 		for i, l := range reg.lines {
 			if i > win.h-1 {
 				break
@@ -642,8 +637,6 @@ type ui struct {
 	msgWin      *win
 	menuWin     *win
 	msg         string
-	regPrev     *reg
-	dirPrev     *dir
 	exprChan    chan expr
 	keyChan     chan string
 	tevChan     chan tcell.Event
@@ -721,15 +714,6 @@ func (ui *ui) renew() {
 	ui.menuWin.renew(wtot, 1, 0, htot-2)
 }
 
-func (ui *ui) sort() {
-	if ui.dirPrev == nil {
-		return
-	}
-	name := ui.dirPrev.name()
-	ui.dirPrev.sort()
-	ui.dirPrev.sel(name, ui.wins[0].h)
-}
-
 func (ui *ui) echo(msg string) {
 	ui.msg = msg
 }
@@ -784,9 +768,9 @@ func (ui *ui) loadFile(app *app, volatile bool) {
 	}
 
 	if curr.isPreviewable() {
-		ui.regPrev = app.nav.loadReg(curr.path, volatile)
+		app.nav.loadReg(curr.path, volatile)
 	} else if curr.IsDir() {
-		ui.dirPrev = app.nav.loadDir(curr.path)
+		app.nav.loadDir(curr.path)
 	}
 }
 
@@ -1146,6 +1130,30 @@ func (ui *ui) drawRulerFile(nav *nav) {
 	ui.msgWin.printRight(ui.screen, 0, tcell.StyleDefault, right)
 }
 
+func (ui *ui) drawPreview(nav *nav, context *dirContext) {
+	curr, err := nav.currFile()
+	if err != nil {
+		return
+	}
+
+	win := ui.wins[len(ui.wins)-1]
+	ui.sxScreen.clearSixel(win, ui.screen, curr.path)
+
+	if gOpts.preview {
+		if curr.isPreviewable() {
+			if reg, ok := nav.regCache[curr.path]; ok {
+				win.printReg(ui.screen, reg, nav.previewLoading, &ui.sxScreen)
+			}
+		} else if curr.IsDir() {
+			ui.sxScreen.lastFile = ""
+			if dir, ok := nav.dirCache[curr.path]; ok {
+				dirStyle := &dirStyle{colors: ui.styles, icons: ui.icons, role: Preview}
+				win.printDir(ui, dir, context, dirStyle)
+			}
+		}
+	}
+}
+
 func (ui *ui) drawBox() {
 	st := parseEscapeSequence(gOpts.borderfmt)
 
@@ -1275,20 +1283,7 @@ func (ui *ui) draw(nav *nav) {
 		ui.screen.ShowCursor(ui.msgWin.x+runeSliceWidth(prefix)+runeSliceWidth(left), ui.msgWin.y)
 	}
 
-	curr, err := nav.currFile()
-	if err == nil {
-		preview := ui.wins[len(ui.wins)-1]
-		ui.sxScreen.clearSixel(preview, ui.screen, curr.path)
-		if gOpts.preview {
-			if curr.isPreviewable() {
-				preview.printReg(ui.screen, ui.regPrev, nav.previewLoading, &ui.sxScreen)
-			} else if curr.IsDir() {
-				ui.sxScreen.lastFile = ""
-				preview.printDir(ui, ui.dirPrev, &context,
-					&dirStyle{colors: ui.styles, icons: ui.icons, role: Preview})
-			}
-		}
-	}
+	ui.drawPreview(nav, &context)
 
 	if gOpts.drawbox {
 		ui.drawBox()
@@ -1699,7 +1694,12 @@ func (ui *ui) readNormalEvent(ev tcell.Event, nav *nav) expr {
 				}
 				return &callExpr{"open", nil, 1}
 			}
-			dir = ui.dirPrev
+
+			var ok bool
+			dir, ok = nav.dirCache[curr.path]
+			if !ok {
+				return nil
+			}
 		} else {
 			dir = ui.dirOfWin(nav, wind)
 			if dir == nil {


### PR DESCRIPTION
Currently the code contains the `regPrev` and `dirPrev` variables, which store object for the current preview. However this is unnecessary, as the current preview can be looked up from the directory/preview cache by the path of the current file.