### PR TITLE
fix: add missing init check when sorting

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -982,6 +982,10 @@ func (nav *nav) startPreview() {
 }
 
 func (nav *nav) sort() {
+	if !nav.init {
+		return
+	}
+
 	for _, d := range nav.dirs {
 		name := d.name()
 		d.sort()


### PR DESCRIPTION
- Fixes #2302

Follow up of #2300 

To reproduce the crash, run `lf -config /dev/null -command 'set hidden'`