### PR TITLE
Add `shelldash` Option to Disable `--` Appending in Shell Commands

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -377,6 +377,8 @@ func (e *setExpr) eval(app *app, _ []string) {
 			return
 		}
 		gOpts.shellopts = strings.Split(e.val, ":")
+	case "shelldash", "noshelldash", "shelldash!":
+		err = applyBoolOpt(&gOpts.shelldash, e)
 	case "sizeunits":
 		switch e.val {
 		case "binary", "decimal":

--- a/opts.go
+++ b/opts.go
@@ -101,6 +101,7 @@ var gOpts struct {
 	shell            string
 	shellflag        string
 	shellopts        []string
+	shelldash        bool
 	showbinds        bool
 	sizeunits        string
 	smartcase        bool
@@ -264,6 +265,7 @@ func init() {
 	gOpts.shell = gDefaultShell
 	gOpts.shellflag = gDefaultShellFlag
 	gOpts.shellopts = nil
+	gOpts.shelldash = true
 	gOpts.showbinds = true
 	gOpts.sizeunits = "binary"
 	gOpts.smartcase = true

--- a/os.go
+++ b/os.go
@@ -138,7 +138,11 @@ func shellCommand(s string, args []string) *exec.Cmd {
 		s = fmt.Sprintf("IFS='%s'; %s", gOpts.ifs, s)
 	}
 
-	args = append([]string{gOpts.shellflag, s, "--"}, args...)
+	if gOpts.shelldash {
+		args = append([]string{gOpts.shellflag, s, "--"}, args...)
+	} else {
+		args = append([]string{gOpts.shellflag, s}, args...)
+	}
 
 	args = append(gOpts.shellopts, args...)
 


### PR DESCRIPTION
# Pull Request: Add `shelldash` Option to Disable `--` Appending in Shell Commands

## Summary

This PR adds a new `shelldash` option to control whether lf appends `--` to shell command arguments. This fixes compatibility issues with shells like nushell that do not support the `--` argument separator in the same way as traditional POSIX shells.

## Problem Description

lf currently unconditionally appends `--` to shell command arguments on Unix/Linux systems to prevent arguments from being interpreted as shell options. While this works correctly for POSIX-compliant shells (sh, bash, zsh), it causes errors with nushell.

### Example Error with Nushell

**lfrc configuration:**
```bash
set shell nu
set shellflag "-c"
cmd open $echo test
```

**Error when invoking the command:**
```
Error: nu::parser::unknown_flag
× The `nu` command doesn't have flag named empty.
╭─[source:2:3]
" -- nu -c "echo test
·                   ─┬
·                    ╰── unknown flag
╰────
help: Use `--help` to see available flags
```

The issue is that nushell interprets the `--` as a flag (or incorrectly parses it), whereas traditional shells use `--` as a standard end-of-options marker.

## Solution

Added a new boolean option `shelldash` that defaults to `true` (preserving current behavior for existing users). Users working with nushell or other incompatible shells can now disable the `--` appending.

### After Fix - Working Configuration

```bash
set shell nu
set shelldash false
set shellflag "-c"

cmd open $print test; input
```

This configuration now works correctly - it prints "test" and waits for user input.

## Changes Made

| File | Change |
|------|--------|
| `opts.go` | Added `shelldash bool` field to `gOpts` struct |
| `opts.go` | Set default value `gOpts.shelldash = true` in `init()` |
| `eval.go` | Added option parsing for `shelldash`, `noshelldash`, `shelldash!` |
| `os.go` | Modified `shellCommand()` to conditionally append `--` based on `gOpts.shelldash` |

### Key Implementation Detail

**Before** (`os.go`):
```go
args = append([]string{gOpts.shellflag, s, "--"}, args...)
```

**After** (`os.go`):
```go
if gOpts.shelldash {
    args = append([]string{gOpts.shellflag, s, "--"}, args...)
} else {
    args = append([]string{gOpts.shellflag, s}, args...)
}
```

## Usage

Users can control the behavior in their `lfrc`:

```bash
# Default behavior (append --)
set shelldash

# Disable the -- appending (for nushell, etc.)
set noshelldash
# or
set shelldash false

# Toggle with !
set shelldash!
```

## Backward Compatibility

- The option defaults to `true`, so existing configurations continue to work unchanged
- No breaking changes to the API or existing behavior

## Testing Environment

- **lf version**: r40
- **nushell version**: 0.109.1

## Checklist

- [x] Default behavior unchanged (`--` is still appended by default)
- [x] `set shelldash` enables `--` appending
- [x] `set noshelldash` disables `--` appending
- [x] `set shelldash!` toggles the behavior
- [x] Tested with nushell (the primary use case)
- [x] Verified compatibility with POSIX shells (sh, bash)
