### PR TITLE
refactor: use `*uint64` for dir size and count

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -294,16 +294,16 @@ func fileInfo(f *file, d *dir, userWidth, groupWidth, customWidth int) (string, 
 				default:
 					info.WriteString(" 9999+")
 				}
-				continue
-			}
-
-			var sz string
-			if f.IsDir() && f.dirSize == nil {
-				sz = "-"
 			} else {
-				sz = humanize(uint64(f.TotalSize()))
+				switch {
+				case f.dirSize != nil:
+					fmt.Fprintf(&info, " %5s", humanize(*f.dirSize))
+				case f.IsDir():
+					info.WriteString("     -")
+				default:
+					fmt.Fprintf(&info, " %5s", humanize(uint64(f.Size())))
+				}
 			}
-			fmt.Fprintf(&info, " %5s", sz)
 		case "time":
 			fmt.Fprintf(&info, " %*s", max(len(gOpts.infotimefmtnew), len(gOpts.infotimefmtold)), infotimefmt(f.ModTime()))
 		case "atime":


### PR DESCRIPTION
Follow up of #2343 

This PR changes `file.dirCount` and `file.dirSize` to use `*uint64`. Conceptually these values cannot be negative, and furthermore may not actually exist if they are not loaded. The idea of using unsigned integers instead of signed integers started from #2062, possibly inspired from the fact that Rust [uses `u64` to represent file sizes](https://doc.rust-lang.org/std/fs/struct.Metadata.html#method.len).

Also note that currently `dircounts` shows `?` for unloaded entries, and `!` for entries that failed to load. However I think the former is no longer useful since `dircounts` was changed to load immediately in #2049, so the distinction is not necessary for users.