### PR TITLE
docs: add unreleased section for `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `Added`
 - `Fixed`
 
-## r41 (Unreleased)
+## Unreleased
+
+## [r41](https://github.com/gokcehan/lf/releases/tag/r41)
 
 ### Changed
 


### PR DESCRIPTION
To prevent changing header names and breaking links (e.g. `## r123 (Unreleased)` to `## r123`), I have decided to add an `Unreleased` section to the changelog.

When a new version `r123` has been (or is about to be) created, the changelog should look like this:

```markdown
## Unreleased

## [r123](https://github.com/gokcehan/lf/releases/tag/r123)

### Changed

- Something was changed
- Something else was changed

### Added

- Something was added
- Something else was added
```

As new unreleased changes are added, the changelog should look like this:

```markdown
## Unreleased

### Changed

- Another thing was changed

## [r123](https://github.com/gokcehan/lf/releases/tag/r123)

### Changed

- Something was changed
- Something else was changed

### Added

- Something was added
- Something else was added
```

When the subsequent release is created, the changelog should look like this:

```markdown
## Unreleased

## [r124](https://github.com/gokcehan/lf/releases/tag/r124)

### Changed

- Another thing was changed

## [r123](https://github.com/gokcehan/lf/releases/tag/r123)

### Changed

- Something was changed
- Something else was changed

### Added

- Something was added
- Something else was added
```