### PR TITLE
refactor: remove internal ID for URL sequences

### DIFF
--- a/termseq.go
+++ b/termseq.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"log"
 	"strconv"
 	"strings"
@@ -236,10 +234,6 @@ loop:
 // It currently supports OSC 8 hyperlinks only, implemented as specified by
 // https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda.
 func applyOSC(body string, st tcell.Style) tcell.Style {
-	genAutoID := func(url string) string {
-		sum := sha256.Sum256([]byte(url))
-		return "lf_hyperlink_" + hex.EncodeToString(sum[:8])
-	}
 	extractID := func(params string) string {
 		for seg := range strings.SplitSeq(params, ":") {
 			if seg == "" {
@@ -265,14 +259,13 @@ func applyOSC(body string, st tcell.Style) tcell.Style {
 		if url == "" {
 			return st
 		}
+
+		st = st.Url(url)
 		// Optional property used to identify grouped hyperlinks.
-		// Use hash as a fallback to ensure a "unique" id.
 		if id := extractID(toks[1]); id != "" {
 			st = st.UrlId(id)
-		} else {
-			st = st.UrlId(genAutoID(url))
 		}
-		return st.Url(url)
+		return st
 	default:
 		return st
 	}

--- a/termseq_test.go
+++ b/termseq_test.go
@@ -125,18 +125,9 @@ func TestApplyTermSequence(t *testing.T) {
 		{"", tcell.StyleDefault},
 		{"\x1b[1m", tcell.StyleDefault.Bold(true)},
 		{"\x1b[1;7;31;42m", tcell.StyleDefault.Bold(true).Reverse(true).Foreground(color.XTerm1).Background(color.XTerm2)},
-		{
-			"\x1b]8;;https://example.com\x1b\\",
-			tcell.StyleDefault.UrlId("lf_hyperlink_100680ad546ce6a5").Url("https://example.com"),
-		}, // OSC 8 terminated with ST (ESC\), no `id` provided
-		{
-			"\x1b]8;;https://example.com\x07",
-			tcell.StyleDefault.UrlId("lf_hyperlink_100680ad546ce6a5").Url("https://example.com"),
-		}, // OSC 8 terminated with BEL, no `id` provided
-		{
-			"\x1b]8;id=42;https://example.com\x1b\\",
-			tcell.StyleDefault.UrlId("42").Url("https://example.com"),
-		}, // OSC 8, `id` provided
+		{"\x1b]8;;https://example.com\x1b\\", tcell.StyleDefault.Url("https://example.com")},                  // OSC 8 terminated with ST (ESC\), no `id` provided
+		{"\x1b]8;;https://example.com\x07", tcell.StyleDefault.Url("https://example.com")},                    // OSC 8 terminated with BEL, no `id` provided
+		{"\x1b]8;id=42;https://example.com\x1b\\", tcell.StyleDefault.Url("https://example.com").UrlId("42")}, // OSC 8, `id` provided
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
- Follow up of #2243 

Now that Tcell has been upgraded to v3 in #2286, I think we no longer need the autogenerated ID workaround since Tcell now handles spaces correctly.