### PR TITLE
refactor: replace `reflect.DeepEqual` with `slices.Equal`

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"slices"
 	"sort"
@@ -547,7 +546,7 @@ func (nav *nav) checkDir(dir *dir) {
 		dir.dironly != getDirOnly(dir.path) ||
 		dir.hidden != getHidden(dir.path) ||
 		dir.reverse != getReverse(dir.path) ||
-		!reflect.DeepEqual(dir.hiddenfiles, gOpts.hiddenfiles) ||
+		!slices.Equal(dir.hiddenfiles, gOpts.hiddenfiles) ||
 		dir.ignorecase != gOpts.ignorecase ||
 		dir.ignoredia != gOpts.ignoredia:
 		dir.loading = true


### PR DESCRIPTION
- Supersedes https://github.com/gokcehan/lf/pull/2452