### PR TITLE
fix preload

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -965,6 +965,23 @@ func (nav *nav) loadReg(path string, volatile bool) *reg {
 		return r
 	}
 
+	// Rerun preview if the cached result has fewer lines than the current
+	// window height
+	if !r.loading && !r.sixel && len(r.lines) < nav.height && len(r.lines) > 0 {
+		delete(nav.regCache, path)
+		r = &reg{loading: true, loadTime: time.Now(), path: path}
+		nav.regCache[path] = r
+		if gOpts.preload {
+			select {
+			case nav.preloadChan <- path:
+			default:
+			}
+		} else {
+			nav.previewChan <- path
+		}
+		return r
+	}
+
 	if volatile && r.volatile {
 		if !gOpts.preload {
 			r.loadTime = time.Now()


### PR DESCRIPTION
Some files are shown in the preview only partly when the preload option is enabled.
This appears to be caused by a race condition between the terminal size and lf, where the preload feature runs before the full size has been reached. This PR simply runs the preload again when the height changed. There may be a better solution though