### PR TITLE
fix: prevent loading previews with outdated dimensions

### DIFF
--- a/app.go
+++ b/app.go
@@ -432,6 +432,7 @@ func (app *app) loop() {
 			app.ui.draw(app.nav)
 		case r := <-app.nav.regChan:
 			if r.height != app.nav.height {
+				delete(app.nav.regCache, r.path)
 				continue
 			}
 			app.nav.regCache[r.path] = r

--- a/app.go
+++ b/app.go
@@ -431,6 +431,9 @@ func (app *app) loop() {
 
 			app.ui.draw(app.nav)
 		case r := <-app.nav.regChan:
+			if r.height != app.nav.height {
+				continue
+			}
 			app.nav.regCache[r.path] = r
 
 			if curr := app.nav.currFile(); curr != nil {

--- a/nav.go
+++ b/nav.go
@@ -836,7 +836,7 @@ func (nav *nav) preload() {
 			return
 		}
 
-		if _, ok := nav.regCache[file.path]; ok {
+		if r, ok := nav.regCache[file.path]; ok && (r.loading || r.height >= nav.height) {
 			return
 		}
 
@@ -947,6 +947,7 @@ func (nav *nav) preview(path string, win *win, mode string) {
 
 	reg.lines = lines
 	reg.sixel = sixel
+	reg.height = win.h
 }
 
 func (nav *nav) loadReg(path string, volatile bool) *reg {

--- a/nav.go
+++ b/nav.go
@@ -855,7 +855,7 @@ func (nav *nav) preload() {
 }
 
 func (nav *nav) preview(path string, win *win, mode string) {
-	reg := &reg{loadTime: time.Now(), path: path}
+	reg := &reg{loadTime: time.Now(), path: path, height: win.h}
 	defer func() {
 		if (gOpts.preload && mode == "preview") || (!gOpts.preload && reg.volatile) {
 			nav.volatilePreview = true
@@ -947,7 +947,6 @@ func (nav *nav) preview(path string, win *win, mode string) {
 
 	reg.lines = lines
 	reg.sixel = sixel
-	reg.height = win.h
 }
 
 func (nav *nav) loadReg(path string, volatile bool) *reg {

--- a/nav.go
+++ b/nav.go
@@ -836,7 +836,7 @@ func (nav *nav) preload() {
 			return
 		}
 
-		if r, ok := nav.regCache[file.path]; ok && (r.loading || r.height >= nav.height) {
+		if r, ok := nav.regCache[file.path]; ok && r.loading {
 			return
 		}
 

--- a/nav.go
+++ b/nav.go
@@ -836,7 +836,7 @@ func (nav *nav) preload() {
 			return
 		}
 
-		if r, ok := nav.regCache[file.path]; ok && r.loading {
+		if _, ok := nav.regCache[file.path]; ok {
 			return
 		}
 

--- a/ui.go
+++ b/ui.go
@@ -605,6 +605,7 @@ type reg struct {
 	path     string
 	lines    []string
 	sixel    bool
+	height   int
 }
 
 func (ui *ui) loadFile(app *app, volatile bool) {


### PR DESCRIPTION
The cached preview data depends on the initial size of the terminal window where lf is started in.
When the window size is small, or the terminal reports a incorrectly small size during startup, the preview data for the startup directory does not contain enough lines to fill the preview pane.

This patch simply checks if the height of the terminal during preloaded preview generation is at least as large as that of the current terminal.

Fixes #2480 