### PR TITLE
fix: improve sixel limits

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	reRulerSub  = regexp.MustCompile(`%[apmcsvfithPd]|%\{[^}]+\}`)
+	reRulerSub = regexp.MustCompile(`%[apmcsvfithPd]|%\{[^}]+\}`)
 	// only match real sixel frames, not other DCS commands that happen
 	// to contain the raster attributes substring in their body
 	reSixelSize = regexp.MustCompile(`^\x1bP[0-9;]*q.*"1;1;(\d+);(\d+)`)

--- a/misc.go
+++ b/misc.go
@@ -472,7 +472,7 @@ func deletePathRecursive[T any](m map[string]T, path string) {
 // The presence of a null byte outside a sixel image indicates a binary file.
 func readLines(reader io.ByteReader, maxLines int) (lines []string, binary bool, sixel bool) {
 	const maxLineBytes = 1 << 16  // 64 KiB per line
-	const maxSixelBytes = 1 << 26 // 64 MiB per sixel frame
+	const maxSixelBytes = 1 << 24 // 16 MiB per sixel frame
 
 	type state int
 	const (

--- a/misc.go
+++ b/misc.go
@@ -21,7 +21,9 @@ import (
 
 var (
 	reRulerSub  = regexp.MustCompile(`%[apmcsvfithPd]|%\{[^}]+\}`)
-	reSixelSize = regexp.MustCompile(`"1;1;(\d+);(\d+)`)
+	// only match real sixel frames, not other DCS commands that happen
+	// to contain the raster attributes substring in their body
+	reSixelSize = regexp.MustCompile(`^\x1bP[0-9;]*q.*"1;1;(\d+);(\d+)`)
 )
 
 var (
@@ -469,7 +471,8 @@ func deletePathRecursive[T any](m map[string]T, path string) {
 // Sixel images are also detected and stored as separate lines.
 // The presence of a null byte outside a sixel image indicates a binary file.
 func readLines(reader io.ByteReader, maxLines int) (lines []string, binary bool, sixel bool) {
-	const maxLineBytes = 1 << 16 // 64 KiB per line
+	const maxLineBytes = 1 << 16  // 64 KiB per line
+	const maxSixelBytes = 1 << 26 // 64 MiB per sixel frame
 
 	type state int
 	const (
@@ -533,7 +536,7 @@ func readLines(reader io.ByteReader, maxLines int) (lines []string, binary bool,
 			case b == '\033':
 				buf.WriteByte(b)
 				currState = stateSixelEsc
-			case b >= 0x20 && b <= 0x7E:
+			case b >= 0x20 && b <= 0x7E && buf.Len() < maxSixelBytes:
 				buf.WriteByte(b)
 			default:
 				buf.Reset()

--- a/misc.go
+++ b/misc.go
@@ -543,13 +543,17 @@ func readLines(reader io.ByteReader, maxLines int) (lines []string, binary bool,
 				currState = stateNormal
 			}
 		case stateSixelEsc:
-			buf.WriteByte(b)
 			if b == '\\' {
+				buf.WriteByte(b)
 				flush(true)
 				sixel = true
 				currState = stateNormal
-			} else {
+			} else if b >= 0x20 && b <= 0x7E {
+				buf.WriteByte(b)
 				currState = stateSixel
+			} else {
+				buf.Reset()
+				currState = stateNormal
 			}
 		}
 	}


### PR DESCRIPTION
This adds a limit to the sixel frame size to prevent very large image files being parsed automatically.
The size limit is very large and could probably be reduced to 32 or even 16 Mib

This also changes the sixel filter to match only valid sixel frames according to the specification.


Edit: changed the limit for sixel frames to 16MiB as a more reasonable default. If there are any complains this could be made higher but frankly I dont think there are any common use cases for displaying image files that large as preview.