### PR TITLE
fix: sanitize hyperlinks

### DIFF
--- a/termseq.go
+++ b/termseq.go
@@ -83,6 +83,11 @@ func readTermSequence(s string) string {
 			if b == gEscapeCode && i+1 < slen && s[i+1] == '\\' {
 				return s[:i+2]
 			}
+			// reject any other control byte inside the body, which
+			// would otherwise be forwarded to tcell.Style.Url
+			if b < 0x20 || b == 0x7F || b >= 0x80 && b <= 0x9F {
+				return ""
+			}
 		}
 		// TODO: C1 forms?
 		return ""


### PR DESCRIPTION
readTermSequence allows OSC8 formatted hyperlinks, which are passed to tcell.
This patch removes control characters that are not valid OSC8 to prevent escape sequences being interpreted by the terminal. Now only sequence that form valid hyperlinks should be passed.