### PR TITLE
fix integer overflow

### DIFF
--- a/colors.go
+++ b/colors.go
@@ -95,7 +95,7 @@ func parseColor(toks []string) (tcell.Color, int, error) {
 
 	if toks[0] == "5" && len(toks) >= 2 {
 		n, err := strconv.Atoi(toks[1])
-		if err != nil {
+		if err != nil || n < 0 || n > 255 {
 			return tcell.ColorDefault, 0, fmt.Errorf("invalid args: %v", toks)
 		}
 
@@ -104,17 +104,17 @@ func parseColor(toks []string) (tcell.Color, int, error) {
 
 	if toks[0] == "2" && len(toks) >= 4 {
 		r, err := strconv.Atoi(toks[1])
-		if err != nil {
+		if err != nil || r < 0 || r > 255 {
 			return tcell.ColorDefault, 0, fmt.Errorf("invalid args: %v", toks)
 		}
 
 		g, err := strconv.Atoi(toks[2])
-		if err != nil {
+		if err != nil || g < 0 || g > 255 {
 			return tcell.ColorDefault, 0, fmt.Errorf("invalid args: %v", toks)
 		}
 
 		b, err := strconv.Atoi(toks[3])
-		if err != nil {
+		if err != nil || b < 0 || b > 255 {
 			return tcell.ColorDefault, 0, fmt.Errorf("invalid args: %v", toks)
 		}
 

--- a/scan.go
+++ b/scan.go
@@ -236,13 +236,13 @@ scan:
 					buf = append(buf, '\t')
 				case s.chr == 'v':
 					buf = append(buf, '\v')
-				case isDigit(s.chr):
+				case s.chr >= '0' && s.chr <= '7':
 					var oct []byte
-					for isDigit(s.chr) {
+					for !s.eof && s.chr >= '0' && s.chr <= '7' {
 						oct = append(oct, s.chr)
 						s.next()
 					}
-					n, err := strconv.ParseInt(string(oct), 8, 0)
+					n, err := strconv.ParseInt(string(oct), 8, 8)
 					if err != nil {
 						log.Printf("scanning: %s", err)
 					}


### PR DESCRIPTION
Codeql reported this issue and complained about 
https://github.com/valoq/lf/blob/d1c8dfe05f96056524fbf4f2f86848d4dbd404e0/scan.go#L249-L249 and 
https://github.com/valoq/lf/blob/d1c8dfe05f96056524fbf4f2f86848d4dbd404e0/colors.go#L121-L121

```
Incorrect conversion between integer types
Incorrect conversion of an integer with architecture-dependent bit size from strconv.ParseInt/strconv.Atoi to a lower bit size type uint8 without an upper bound check.
```

There appears to be no case where this would lead to any real issues, but checking for the correct size is how it should work anyway.


I would recommend that codeql (default mode) is enabled in the Lf repository since it takes 10 seconds to setup and does not appear to create any false positives. The issues fixed by this PR were the only reported problems so far but I may find new issues automatically.