### PR TITLE
fix: apply filename sanitization in more places

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -646,7 +646,7 @@ func (ui *ui) drawPromptLine(nav *nav) {
 	st := tcell.StyleDefault
 
 	dir := nav.currDir()
-	pwd := dir.path
+	pwd := sanitizeName(dir.path)
 
 	if after, ok := strings.CutPrefix(pwd, gUser.HomeDir); ok {
 		pwd = filepath.Join("~", after)
@@ -892,7 +892,7 @@ func (ui *ui) drawRulerFile(nav *nav) {
 			stat = &statData{
 				Path:        sanitizeName(curr.path),
 				Name:        sanitizeName(curr.Name()),
-				Extension:   curr.ext,
+				Extension:   sanitizeName(curr.ext),
 				Size:        curr.Size(),
 				DirSize:     curr.dirSize,
 				DirCount:    curr.dirCount,


### PR DESCRIPTION
- Follow-up to https://github.com/gokcehan/lf/pull/2467

The current pwd was previously not filtered and broken when navigating to directories with special characters like tabs

```
mkdir -p "/tmp/test_lf/has$(printf '\t')tab/subdir" 
cd /tmp/test_lf/subdir && lf

```

before patch:
<img width="874" height="126" alt="screenshot_2026-04-12-123630" src="https://github.com/user-attachments/assets/2cb4fa12-1651-45fc-b6c2-a80d4bd32b01" />

after patch:

<img width="870" height="152" alt="screenshot_2026-04-12-123735" src="https://github.com/user-attachments/assets/66fc9bff-5a63-4f03-806e-05eafdbaecd1" />
