### PR TITLE
limit preview cache size

### DIFF
--- a/app.go
+++ b/app.go
@@ -432,6 +432,7 @@ func (app *app) loop() {
 			app.ui.draw(app.nav)
 		case r := <-app.nav.regChan:
 			app.nav.regCache[r.path] = r
+			app.nav.evictRegCache()
 
 			if curr := app.nav.currFile(); curr != nil {
 				if r.path == curr.path {

--- a/nav.go
+++ b/nav.go
@@ -841,6 +841,7 @@ func (nav *nav) preload() {
 		}
 
 		nav.regCache[file.path] = &reg{loading: true, loadTime: time.Now(), path: file.path}
+		nav.evictRegCache()
 		select {
 		case nav.preloadChan <- file.path:
 		default:
@@ -955,6 +956,7 @@ func (nav *nav) loadReg(path string, volatile bool) *reg {
 	if !ok || (!gOpts.preload && r.loading) {
 		r = &reg{loading: true, loadTime: time.Now(), path: path}
 		nav.regCache[path] = r
+		nav.evictRegCache()
 		if gOpts.preload {
 			select {
 			case nav.preloadChan <- path:
@@ -2020,4 +2022,21 @@ func (nav *nav) calcDirSize() error {
 	}
 
 	return nil
+}
+
+const maxRegCacheSize = 512
+
+func (nav *nav) evictRegCache() {
+	if len(nav.regCache) <= maxRegCacheSize {
+		return
+	}
+	var oldestKey string
+	var oldestTime time.Time
+	for k, r := range nav.regCache {
+		if oldestKey == "" || r.loadTime.Before(oldestTime) {
+			oldestKey = k
+			oldestTime = r.loadTime
+		}
+	}
+	delete(nav.regCache, oldestKey)
 }


### PR DESCRIPTION
Preview data is only reset on reload or resize, which can become an issue if combined with the preload option when navigating large directories.

This is an attempt to limit the number of cached preview entries by deleting the oldest ones after the limit is reached. 

Update: I think the limit needs to be higher to avoid running into it when scrolling through large directories. But I will wait for some general feedback on the approach for now.
