### PR TITLE
add new unit tests

### DIFF
--- a/copy_test.go
+++ b/copy_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopySize(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b"), []byte("world!"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	size, err := copySize([]string{filepath.Join(dir, "a"), filepath.Join(dir, "b")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if size != 11 {
+		t.Errorf("expected 11 but got %d", size)
+	}
+}
+
+func TestCopySizeNonexistent(t *testing.T) {
+	if _, err := copySize([]string{"/nonexistent/path"}); err == nil {
+		t.Error("expected error for nonexistent file")
+	}
+}
+
+func TestCopyFile(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	content := []byte("test content")
+
+	if err := os.WriteFile(src, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nums := make(chan int64, 100)
+	errs := make(chan error, 10)
+	copyFile(src, dst, nil, info, nums, errs)
+
+	select {
+	case err := <-errs:
+		t.Fatalf("copy error: %s", err)
+	default:
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("expected %q but got %q", content, got)
+	}
+}
+
+// drainCopyAll consumes the nums channel concurrently while collecting errors
+// from errs. copyAll closes errs but not nums; the test owns nums and stops
+// draining once errs closes.
+func drainCopyAll(t *testing.T, nums chan int64, errs chan error) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		for range nums {
+		}
+		close(done)
+	}()
+	for err := range errs {
+		t.Errorf("copy error: %s", err)
+	}
+	// errs closed; copyAll goroutine is done writing to nums.
+	close(nums)
+	<-done
+}
+
+func TestCopyAll(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(srcDir, "a.txt"), []byte("aaa"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "b.txt"), []byte("bbb"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	nums, errs := copyAll(
+		[]string{filepath.Join(srcDir, "a.txt"), filepath.Join(srcDir, "b.txt")},
+		dstDir, nil,
+	)
+	drainCopyAll(t, nums, errs)
+
+	for _, name := range []string{"a.txt", "b.txt"} {
+		if _, err := os.Stat(filepath.Join(dstDir, name)); err != nil {
+			t.Errorf("file %s not copied: %s", name, err)
+		}
+	}
+}
+
+func TestCopyAllDuplicate(t *testing.T) {
+	gOpts.dupfilefmt = "%f.~%n~"
+
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(srcDir, "f.txt"), []byte("src"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dstDir, "f.txt"), []byte("existing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	nums, errs := copyAll([]string{filepath.Join(srcDir, "f.txt")}, dstDir, nil)
+	drainCopyAll(t, nums, errs)
+
+	orig, err := os.ReadFile(filepath.Join(dstDir, "f.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(orig) != "existing" {
+		t.Errorf("original overwritten: %q", orig)
+	}
+
+	entries, err := os.ReadDir(dstDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) < 2 {
+		t.Errorf("expected duplicate, got %d files", len(entries))
+	}
+}

--- a/eval_test.go
+++ b/eval_test.go
@@ -661,3 +661,21 @@ func TestApplyLocalBoolOpt(t *testing.T) {
 		}
 	}
 }
+
+func TestParseMalformed(t *testing.T) {
+	inputs := []string{
+		"set",
+		"map",
+		"cmd foo {{ echo hello",
+		`set shell "unclosed`,
+		`set shell 'unclosed`,
+		"",
+		"# comment only",
+	}
+
+	for _, inp := range inputs {
+		p := newParser(strings.NewReader(inp))
+		for p.parse() {
+		}
+	}
+}

--- a/termseq_test.go
+++ b/termseq_test.go
@@ -288,3 +288,127 @@ func TestApplySGR(t *testing.T) {
 		}
 	}
 }
+
+func TestIsControlChar(t *testing.T) {
+	tests := []struct {
+		r   rune
+		exp bool
+	}{
+		{0x00, true},   // NUL
+		{0x07, true},   // BEL
+		{'\t', true},   // tab (caller decides whether to keep)
+		{'\n', true},   // LF
+		{0x1B, true},   // ESC
+		{0x1F, true},   // last C0
+		{' ', false},   // space
+		{'a', false},   // ASCII letter
+		{0x7E, false},  // ~
+		{0x7F, true},   // DEL
+		{0x80, true},   // first C1
+		{0x9B, true},   // CSI as single byte
+		{0x9F, true},   // last C1
+		{0xA0, false},  // NBSP
+		{'日', false},   // CJK
+	}
+	for _, test := range tests {
+		if got := isControlChar(test.r); got != test.exp {
+			t.Errorf("isControlChar(%U) = %v, want %v", test.r, got, test.exp)
+		}
+	}
+}
+
+func TestIsPrintable(t *testing.T) {
+	tests := []struct {
+		s   string
+		exp bool
+	}{
+		{"a", true},
+		{"日", true},
+		{" ", true},
+		{"\x00", false},
+		{"\t", false},
+		{"\n", false},
+		{"\x1b", false},
+		{"\x7f", false},
+		{"\x80", false},
+		{"\x9b", false},
+		{"\xc3", false}, // invalid UTF-8 lead byte
+		{"\xff", false}, // invalid UTF-8
+	}
+	for _, test := range tests {
+		if got := isPrintable(test.s); got != test.exp {
+			t.Errorf("isPrintable(%q) = %v, want %v", test.s, got, test.exp)
+		}
+	}
+}
+
+func TestSanitizeName(t *testing.T) {
+	tests := []struct {
+		s, exp string
+	}{
+		{"", ""},
+		{"hello.txt", "hello.txt"},
+		{"日本語", "日本語"},
+		{"a\tb", "a\uFFFDb"},     // tab replaced (not preserved for names)
+		{"a\nb", "a\uFFFDb"},
+		{"a\x00b", "a\uFFFDb"},
+		{"a\x07b", "a\uFFFDb"},
+		{"a\x1bb", "a\uFFFDb"},
+		{"a\x7fb", "a\uFFFDb"},
+		{"a\x80b", "a\uFFFDb"},
+		{"a\x9bb", "a\uFFFDb"},   // single-byte CSI
+		{"\x1b]0;evil\x07", "\uFFFD]0;evil\uFFFD"},
+		{"\x1b[31mfoo\x1b[0m", "\uFFFD[31mfoo\uFFFD[0m"},
+	}
+	for _, test := range tests {
+		if got := sanitizeName(test.s); got != test.exp {
+			t.Errorf("sanitizeName(%q) = %q, want %q", test.s, got, test.exp)
+		}
+	}
+}
+
+func TestSanitizePreview(t *testing.T) {
+	tests := []struct {
+		s, exp string
+	}{
+		{"", ""},
+		{"hello", "hello"},
+		{"日本語", "日本語"},
+		{"a\tb", "a\tb"},          // tab preserved for preview
+		{"a\nb", "a\uFFFDb"},      // newline still stripped (caller splits lines)
+		{"a\x00b", "a\uFFFDb"},
+		{"a\x1bb", "a\uFFFDb"},
+		{"a\x7fb", "a\uFFFDb"},
+		{"a\x9bb", "a\uFFFDb"},
+	}
+	for _, test := range tests {
+		if got := sanitizePreview(test.s); got != test.exp {
+			t.Errorf("sanitizePreview(%q) = %q, want %q", test.s, got, test.exp)
+		}
+	}
+}
+
+func TestSanitizeMessage(t *testing.T) {
+	tests := []struct {
+		s, exp string
+	}{
+		{"", ""},
+		{"hello", "hello"},
+		{"hello\n", "hello"},                                   // trailing newlines trimmed
+		{"hello\r\n", "hello"},
+		{"a\x00b", "a\uFFFDb"},
+		{"a\x1bb", "a\uFFFDb"},                                 // lone ESC (not a recognized sequence)
+		{"a\tb", "a\uFFFDb"},                                   // tab is a control char
+		{"\x1b[31mred\x1b[0m", "\x1b[31mred\x1b[0m"},           // SGR preserved
+		{"\x1b[Kline", "\x1b[Kline"},                           // EL preserved
+		{"\x1b]8;;http://x\x1b\\link\x1b]8;;\x1b\\",            // OSC 8 preserved
+			"\x1b]8;;http://x\x1b\\link\x1b]8;;\x1b\\"},
+		{"\x1b]0;title\x07", "\uFFFD]0;title\uFFFD"},           // non-OSC8 OSC not preserved
+		{"\x1b[2J", "\uFFFD[2J"},                               // disallowed CSI (final byte J) not preserved
+	}
+	for _, test := range tests {
+		if got := sanitizeMessage(test.s); got != test.exp {
+			t.Errorf("sanitizeMessage(%q) = %q, want %q", test.s, got, test.exp)
+		}
+	}
+}

--- a/termseq_test.go
+++ b/termseq_test.go
@@ -294,21 +294,21 @@ func TestIsControlChar(t *testing.T) {
 		r   rune
 		exp bool
 	}{
-		{0x00, true},   // NUL
-		{0x07, true},   // BEL
-		{'\t', true},   // tab (caller decides whether to keep)
-		{'\n', true},   // LF
-		{0x1B, true},   // ESC
-		{0x1F, true},   // last C0
-		{' ', false},   // space
-		{'a', false},   // ASCII letter
-		{0x7E, false},  // ~
-		{0x7F, true},   // DEL
-		{0x80, true},   // first C1
-		{0x9B, true},   // CSI as single byte
-		{0x9F, true},   // last C1
-		{0xA0, false},  // NBSP
-		{'日', false},   // CJK
+		{0x00, true},  // NUL
+		{0x07, true},  // BEL
+		{'\t', true},  // tab (caller decides whether to keep)
+		{'\n', true},  // LF
+		{0x1B, true},  // ESC
+		{0x1F, true},  // last C0
+		{' ', false},  // space
+		{'a', false},  // ASCII letter
+		{0x7E, false}, // ~
+		{0x7F, true},  // DEL
+		{0x80, true},  // first C1
+		{0x9B, true},  // CSI as single byte
+		{0x9F, true},  // last C1
+		{0xA0, false}, // NBSP
+		{'日', false},  // CJK
 	}
 	for _, test := range tests {
 		if got := isControlChar(test.r); got != test.exp {
@@ -349,14 +349,14 @@ func TestSanitizeName(t *testing.T) {
 		{"", ""},
 		{"hello.txt", "hello.txt"},
 		{"日本語", "日本語"},
-		{"a\tb", "a\uFFFDb"},     // tab replaced (not preserved for names)
+		{"a\tb", "a\uFFFDb"}, // tab replaced (not preserved for names)
 		{"a\nb", "a\uFFFDb"},
 		{"a\x00b", "a\uFFFDb"},
 		{"a\x07b", "a\uFFFDb"},
 		{"a\x1bb", "a\uFFFDb"},
 		{"a\x7fb", "a\uFFFDb"},
 		{"a\x80b", "a\uFFFDb"},
-		{"a\x9bb", "a\uFFFDb"},   // single-byte CSI
+		{"a\x9bb", "a\uFFFDb"}, // single-byte CSI
 		{"\x1b]0;evil\x07", "\uFFFD]0;evil\uFFFD"},
 		{"\x1b[31mfoo\x1b[0m", "\uFFFD[31mfoo\uFFFD[0m"},
 	}
@@ -374,8 +374,8 @@ func TestSanitizePreview(t *testing.T) {
 		{"", ""},
 		{"hello", "hello"},
 		{"日本語", "日本語"},
-		{"a\tb", "a\tb"},          // tab preserved for preview
-		{"a\nb", "a\uFFFDb"},      // newline still stripped (caller splits lines)
+		{"a\tb", "a\tb"},     // tab preserved for preview
+		{"a\nb", "a\uFFFDb"}, // newline still stripped (caller splits lines)
 		{"a\x00b", "a\uFFFDb"},
 		{"a\x1bb", "a\uFFFDb"},
 		{"a\x7fb", "a\uFFFDb"},
@@ -394,17 +394,17 @@ func TestSanitizeMessage(t *testing.T) {
 	}{
 		{"", ""},
 		{"hello", "hello"},
-		{"hello\n", "hello"},                                   // trailing newlines trimmed
+		{"hello\n", "hello"}, // trailing newlines trimmed
 		{"hello\r\n", "hello"},
 		{"a\x00b", "a\uFFFDb"},
-		{"a\x1bb", "a\uFFFDb"},                                 // lone ESC (not a recognized sequence)
-		{"a\tb", "a\uFFFDb"},                                   // tab is a control char
-		{"\x1b[31mred\x1b[0m", "\x1b[31mred\x1b[0m"},           // SGR preserved
-		{"\x1b[Kline", "\x1b[Kline"},                           // EL preserved
-		{"\x1b]8;;http://x\x1b\\link\x1b]8;;\x1b\\",            // OSC 8 preserved
+		{"a\x1bb", "a\uFFFDb"},                       // lone ESC (not a recognized sequence)
+		{"a\tb", "a\uFFFDb"},                         // tab is a control char
+		{"\x1b[31mred\x1b[0m", "\x1b[31mred\x1b[0m"}, // SGR preserved
+		{"\x1b[Kline", "\x1b[Kline"},                 // EL preserved
+		{"\x1b]8;;http://x\x1b\\link\x1b]8;;\x1b\\", // OSC 8 preserved
 			"\x1b]8;;http://x\x1b\\link\x1b]8;;\x1b\\"},
-		{"\x1b]0;title\x07", "\uFFFD]0;title\uFFFD"},           // non-OSC8 OSC not preserved
-		{"\x1b[2J", "\uFFFD[2J"},                               // disallowed CSI (final byte J) not preserved
+		{"\x1b]0;title\x07", "\uFFFD]0;title\uFFFD"}, // non-OSC8 OSC not preserved
+		{"\x1b[2J", "\uFFFD[2J"},                     // disallowed CSI (final byte J) not preserved
 	}
 	for _, test := range tests {
 		if got := sanitizeMessage(test.s); got != test.exp {

--- a/ui_test.go
+++ b/ui_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestPrintLength(t *testing.T) {
+	gOpts.tabstop = 8
+
+	tests := []struct {
+		s   string
+		exp int
+	}{
+		{"", 0},
+		{"hello", 5},
+		{"日本語", 6},
+		{"\x1b[31mred\x1b[0m", 3},
+		{"\x1b]8;;http://x\x1b\\link\x1b]8;;\x1b\\", 4},
+		{"\x00", 1},
+		{"\t", 8},
+		{"ab\t", 8},
+	}
+	for _, test := range tests {
+		if got := printLength(test.s); got != test.exp {
+			t.Errorf("at input %q expected %d but got %d", test.s, test.exp, got)
+		}
+	}
+}


### PR DESCRIPTION
This adds unit tests for:

- copy function
- eval for malformed input
- sanitation of input data

Note: this currently depends on some of the recently opened PRs, so this needs to be merged after the other fixes. The tests will fail without those