### PR TITLE
fix: process `load` commands when `watch` is enabled

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -1266,9 +1266,6 @@ func (e *callExpr) eval(app *app, _ []string) {
 		app.ui.loadFile(app, true)
 		onRedraw(app)
 	case "load":
-		if gOpts.watch {
-			return
-		}
 		app.nav.renew()
 		app.ui.loadFile(app, false)
 	case "reload":


### PR DESCRIPTION
Previously, the load case was exited early when the watch feature is used.
However, the watch option already checks the loadTime and would not trigger the update when the load case already ran.
But there are several cases where the watch feature does not catch the update or waits for 100ms.
When one of the fsnotify bugs like renamed parent directory is triggered, pasting a file would not update the view. 
When multiple files were pasted, the watch feature would create a noticeable delay between the paste/display of the first file and before the next file is shown.

Removing this line fixes both issues without causing redundant calls.
