### PR TITLE
fix: restrict octal parsing to single-byte range

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -88,7 +88,7 @@ func isSpace(b byte) bool {
 }
 
 func isDigit(b byte) bool {
-	return '0' <= b && b <= '7'
+	return '0' <= b && b <= '9'
 }
 
 func isPrefix(b byte) bool {

--- a/scan.go
+++ b/scan.go
@@ -88,7 +88,7 @@ func isSpace(b byte) bool {
 }
 
 func isDigit(b byte) bool {
-	return '0' <= b && b <= '9'
+	return '0' <= b && b <= '7'
 }
 
 func isPrefix(b byte) bool {
@@ -242,7 +242,7 @@ scan:
 						oct = append(oct, s.chr)
 						s.next()
 					}
-					n, err := strconv.ParseInt(string(oct), 8, 0)
+					n, err := strconv.ParseUint(string(oct), 8, 8)
 					if err != nil {
 						log.Printf("scanning: %s", err)
 					}


### PR DESCRIPTION
Restrict isDigit from 0-9 to 0-7 since it is only used for octal values to prevent silent fails.