### PR TITLE
fix: update view on cd

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -1613,6 +1613,7 @@ func (nav *nav) cd(path string) error {
 	}
 
 	nav.loadDirs(path)
+	nav.renew()
 	nav.addJumpList()
 	return nil
 }


### PR DESCRIPTION
When navigating to some non home directory after home was already visited/cached, pressing "gh" to go to the home directory calls "
cd() but does not update the view, which causes stale information to be displayed. Updated sort and other options like toggling hidden files are also ignored.

cd() was missing a call for renew() that fixes the issue