### PR TITLE
fix: preserve successfully copied files with timestamp failure

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -171,7 +171,7 @@ func copyAll(srcs []string, dstDir string, preserve []string) (nums chan int64, 
 			atime := times.Get(info).AccessTime()
 			mtime := info.ModTime()
 			if err := os.Chtimes(path, atime, mtime); err != nil {
-				errs <- fmt.Errorf("chtimes: %w", err)
+				errs <- err
 			}
 		}
 

--- a/copy.go
+++ b/copy.go
@@ -94,10 +94,6 @@ func copyFile(src, dst string, preserve []string, info os.FileInfo, nums chan<- 
 		mtime := info.ModTime()
 		if err := os.Chtimes(dst, atime, mtime); err != nil {
 			errs <- err
-			if err = os.Remove(dst); err != nil {
-				errs <- err
-			}
-			return
 		}
 	}
 }


### PR DESCRIPTION
When timestamp preservation failed after a complete copy, copyFile deleted the destination file even though its content was correct. This was already handled correctly for directories but missed for files. This PR adds the same fix or files.

Note: Failed timestamp preservation happens on all filesystems that dont support them, e.g. FAT and likely any file shares mounted with fuse