### PR TITLE
feat: add sigstore signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,12 +78,27 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: write
+      id-token: write   # required for cosign keyless OIDC signing
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
+
+      - name: Generate checksums
+        working-directory: dist
+        shell: bash
+        run: sha256sum lf-*.{zip,tar.gz} > sha256sums.txt
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign checksums (sigstore keyless)
+        working-directory: dist
+        run: cosign sign-blob --yes --bundle sha256sums.txt.sigstore.json sha256sums.txt
 
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ See [faq](https://github.com/gokcehan/lf/wiki/FAQ) for more information and [tut
 See [packages](https://github.com/gokcehan/lf/wiki/Packages) for community maintained packages.
 
 See [releases](https://github.com/gokcehan/lf/releases) for pre-built binaries.
+See [security](SECURITY.md) for release verification and reproducible builds.
 
 Building from the source requires [Go](https://go.dev/).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,9 @@
 # Verifying Releases
 
-Release binaries are signed using [sigstore cosign](https://github.com/sigstore/cosign) with keyless signing.
-Each signing event is recorded in the [Rekor](https://rekor.sigstore.dev) transparency log, providing a public auditable record that the binary was built by the official GitHub Actions release workflow.
+Release artifacts are signed using [sigstore cosign](https://github.com/sigstore/cosign) with keyless signing.
+Each signing event is recorded in the [Rekor](https://rekor.sigstore.dev) transparency log, providing a public auditable record that the artifacts were built by the official GitHub Actions release workflow.
+
+A single signature is produced over `sha256sums.txt`, which lists the SHA-256 of every release archive. Verifying the signature on `sha256sums.txt` and then verifying each archive against `sha256sums.txt` gives the same end-to-end guarantee as a per-archive signature.
 
 ## Verify a download
 
@@ -9,18 +11,18 @@ Install cosign:
 
     go install github.com/sigstore/cosign/v3/cmd/cosign@latest
 
-Download the binary, checksums, and sigstore bundle for your platform from the [releases page](https://github.com/gokcehan/lf/releases), then run:
+Download `sha256sums.txt`, `sha256sums.txt.sigstore.json`, and the archive(s) you want from the [releases page](https://github.com/gokcehan/lf/releases), then:
 
-    cosign verify-blob lf-linux-amd64.tar.gz \
-      --bundle lf-linux-amd64.tar.gz.sigstore.json \
+    cosign verify-blob sha256sums.txt \
+      --bundle sha256sums.txt.sigstore.json \
       --certificate-identity "https://github.com/gokcehan/lf/.github/workflows/release.yml@refs/tags/TAG" \
       --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 
 Replace `TAG` with the release tag (e.g. `r33`).
 
-## Verify checksums
+Once `sha256sums.txt` is trusted, verify the archive(s) against it:
 
-    sha256sum -c sha256sums.txt
+    sha256sum --check --ignore-missing sha256sums.txt
 
 ## Reproduce a build
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Verifying Releases
+
+Release binaries are signed using [sigstore cosign](https://github.com/sigstore/cosign) with keyless signing.
+Each signing event is recorded in the [Rekor](https://rekor.sigstore.dev) transparency log, providing a public auditable record that the binary was built by the official GitHub Actions release workflow.
+
+## Verify a download
+
+Install cosign:
+
+    go install github.com/sigstore/cosign/v3/cmd/cosign@latest
+
+Download the binary, checksums, and sigstore bundle for your platform from the [releases page](https://github.com/gokcehan/lf/releases), then run:
+
+    cosign verify-blob lf-linux-amd64.tar.gz \
+      --bundle lf-linux-amd64.tar.gz.sigstore.json \
+      --certificate-identity "https://github.com/gokcehan/lf/.github/workflows/release.yml@refs/tags/TAG" \
+      --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+
+Replace `TAG` with the release tag (e.g. `r33`).
+
+## Verify checksums
+
+    sha256sum -c sha256sums.txt
+
+## Reproduce a build
+
+Builds are reproducible given the same Go version and source:
+
+    go version -m ./lf              # shows the exact Go version used
+    git checkout TAG
+    CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.gVersion=TAG"
+    sha256sum lf                    # compare with sha256sums.txt

--- a/gen/build.sh
+++ b/gen/build.sh
@@ -10,6 +10,6 @@ set -o errexit -o nounset
 
 [ -z "${version:-}" ] && version=$(git describe --tags --abbrev=0)
 
-CGO_ENABLED=0 go build -ldflags="-s -w -X main.gVersion=$version" "$@"
+CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.gVersion=$version" "$@"
 
 # vim: tabstop=4 shiftwidth=4 textwidth=80 colorcolumn=80

--- a/gen/build.sh
+++ b/gen/build.sh
@@ -10,6 +10,6 @@ set -o errexit -o nounset
 
 [ -z "${version:-}" ] && version=$(git describe --tags --abbrev=0)
 
-CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.gVersion=$version" "$@"
+CGO_ENABLED=0 go build -ldflags="-s -w -X main.gVersion=$version" "$@"
 
 # vim: tabstop=4 shiftwidth=4 textwidth=80 colorcolumn=80


### PR DESCRIPTION
The adds the sigstore signing process to the build and release of lf.

[Sigstore](https://www.sigstore.dev/ ) provides open source tools and infrastructure to sign releases without using permanent signing keys. It can easily be integrated into the release process and is supported by github. The signatures are recorded in the Rekor transparency log with the release. 

Adding `-trimpath` to the build also provides reproducible builds, so user can not only verify the binaries but also confirm that they were build using the source code from this repository.

The go ecosystem uses a very similar system for the source code infrastructure and package managers should already be covered by it. This adds the verification of the git releases for everyone who downloads the binaries from github directly.

