### PR TITLE
feat!: remove TCP socket support for server connections

### DIFF
--- a/client.go
+++ b/client.go
@@ -120,12 +120,12 @@ func readExpr() <-chan expr {
 	go func() {
 		duration := 100 * time.Millisecond
 
-		c, err := net.Dial(gSocketProt, gSocketPath)
+		c, err := net.Dial("unix", gSocketPath)
 		for err != nil {
 			log.Printf("connecting server: %s", err)
 			time.Sleep(duration)
 			duration *= 2
-			c, err = net.Dial(gSocketProt, gSocketPath)
+			c, err = net.Dial("unix", gSocketPath)
 		}
 
 		if _, err := fmt.Fprintf(c, "conn %d\n", gClientID); err != nil {
@@ -169,7 +169,7 @@ func readExpr() <-chan expr {
 }
 
 func remote(req string) (string, error) {
-	c, err := net.Dial(gSocketProt, gSocketPath)
+	c, err := net.Dial("unix", gSocketPath)
 	if err != nil {
 		return "", fmt.Errorf("connecting to server: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -35,7 +35,6 @@ var (
 	gHostname       string
 	gLastDirPath    string
 	gSelectionPath  string
-	gSocketProt     string
 	gSocketPath     string
 	gLogPath        string
 	gSelect         string
@@ -178,19 +177,13 @@ func startServer() {
 }
 
 func checkServer() {
-	if gSocketProt == "unix" {
-		if _, err := os.Stat(gSocketPath); os.IsNotExist(err) {
-			startServer()
-		} else if _, err := net.Dial(gSocketProt, gSocketPath); err != nil {
-			if err := os.Remove(gSocketPath); err != nil {
-				log.Print(err)
-			}
-			startServer()
+	if _, err := os.Stat(gSocketPath); os.IsNotExist(err) {
+		startServer()
+	} else if _, err := net.Dial("unix", gSocketPath); err != nil {
+		if err := os.Remove(gSocketPath); err != nil {
+			log.Print(err)
 		}
-	} else {
-		if _, err := net.Dial(gSocketProt, gSocketPath); err != nil {
-			startServer()
-		}
+		startServer()
 	}
 }
 
@@ -316,7 +309,6 @@ Options:
 
 	flag.Parse()
 
-	gSocketProt = gDefaultSocketProt
 	gSocketPath = gDefaultSocketPath
 
 	if gLogPath != "" {

--- a/os.go
+++ b/os.go
@@ -28,7 +28,6 @@ var (
 var (
 	gDefaultShell       = "sh"
 	gDefaultShellFlag   = "-c"
-	gDefaultSocketProt  = "unix"
 	gDefaultSocketPath  string
 	gDefaultHiddenFiles = []string{".*"}
 )

--- a/os_windows.go
+++ b/os_windows.go
@@ -3,14 +3,12 @@ package main
 import (
 	"cmp"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"os/user"
 	"path/filepath"
 	"slices"
 	"strings"
-	"syscall"
 
 	"golang.org/x/sys/windows"
 )
@@ -27,7 +25,6 @@ var envPathExts []string
 var (
 	gDefaultShell       = "cmd"
 	gDefaultShellFlag   = "/c"
-	gDefaultSocketProt  = "unix"
 	gDefaultSocketPath  string
 	gDefaultHiddenFiles []string
 )
@@ -107,13 +104,8 @@ func init() {
 	gTagsPath = filepath.Join(data, "lf", "tags")
 	gHistoryPath = filepath.Join(data, "lf", "history")
 
-	socket, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
-	if err != nil {
-		log.Fatalf("AF_UNIX sockets are not supported: %s", err)
-	}
 	runtime := os.TempDir()
 	gDefaultSocketPath = filepath.Join(runtime, fmt.Sprintf("lf.%s.sock", gUser.Username))
-	syscall.Close(socket)
 
 	s := cmp.Or(os.Getenv("PATHEXT"), ".COM;.EXE;.BAT;.CMD")
 	for ext := range strings.SplitSeq(s, ";") {

--- a/os_windows.go
+++ b/os_windows.go
@@ -3,6 +3,7 @@ package main
 import (
 	"cmp"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"os/user"
@@ -108,13 +109,11 @@ func init() {
 
 	socket, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
 	if err != nil {
-		gDefaultSocketProt = "tcp"
-		gDefaultSocketPath = "127.0.0.1:12345"
-	} else {
-		runtime := os.TempDir()
-		gDefaultSocketPath = filepath.Join(runtime, fmt.Sprintf("lf.%s.sock", gUser.Username))
-		syscall.Close(socket)
+		log.Fatalf("AF_UNIX sockets are not supported: %s", err)
 	}
+	runtime := os.TempDir()
+	gDefaultSocketPath = filepath.Join(runtime, fmt.Sprintf("lf.%s.sock", gUser.Username))
+	syscall.Close(socket)
 
 	s := cmp.Or(os.Getenv("PATHEXT"), ".COM;.EXE;.BAT;.CMD")
 	for ext := range strings.SplitSeq(s, ";") {

--- a/server.go
+++ b/server.go
@@ -29,11 +29,9 @@ func serve() {
 
 	log.Print("*************** starting server ***************")
 
-	if gSocketProt == "unix" {
-		setUserUmask()
-	}
+	setUserUmask()
 
-	l, err := net.Listen(gSocketProt, gSocketPath)
+	l, err := net.Listen("unix", gSocketPath)
 	if err != nil {
 		log.Printf("listening socket: %s", err)
 		return


### PR DESCRIPTION
Since windows 10 (1803) the OS supports unix sockets
Older systems that dont have them would fall back to tcp sockets for the lf server client connection, which then listens to localhost, where the lf server can be reached by all local users, allowing access to the actual users files and shell (in theory, I dont have windows for testing)

Fortunately this should no longer be an issue on supported windows systems, but its probably better to just remove the fallback