### PR TITLE
docs: Add `-trimpath` to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,21 +42,21 @@ Building from the source requires [Go](https://go.dev/).
 On Unix:
 
 ```bash
-env CGO_ENABLED=0 go install -ldflags="-s -w" github.com/gokcehan/lf@latest
+env CGO_ENABLED=0 go install -trimpath -ldflags="-s -w" github.com/gokcehan/lf@latest
 ```
 
 On Windows `cmd`:
 
 ```cmd
 set CGO_ENABLED=0
-go install -ldflags="-s -w" github.com/gokcehan/lf@latest
+go install -trimpath -ldflags="-s -w" github.com/gokcehan/lf@latest
 ```
 
 On Windows `PowerShell`:
 
 ```powershell
 $env:CGO_ENABLED = '0'
-go install -ldflags="-s -w" github.com/gokcehan/lf@latest
+go install -trimpath -ldflags="-s -w" github.com/gokcehan/lf@latest
 ```
 
 ## Usage


### PR DESCRIPTION
cc #2525 