### PR TITLE
fix!: change fallback socket location to a user-specific directory

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -1744,7 +1744,7 @@ To use this feature, you need to use a client which supports communicating with 
 OpenBSD implementation of netcat (nc) is one such example.
 You can use it to send a command to the socket file:
 
-	echo 'send echo hello world' | nc -U ${XDG_RUNTIME_DIR:-/tmp}/lf.${USER}.sock
+	echo 'send echo hello world' | nc -U ${XDG_RUNTIME_DIR:-/tmp/lf-$(id -u)}/lf.sock
 
 Since such a client may not be available everywhere, lf comes bundled with a command line flag to be used as such.
 When using lf, you do not need to specify the address of the socket file.

--- a/doc.txt
+++ b/doc.txt
@@ -1927,7 +1927,7 @@ communicating with a Unix domain socket. OpenBSD implementation of
 netcat (nc) is one such example. You can use it to send a command to the
 socket file:
 
-    echo 'send echo hello world' | nc -U ${XDG_RUNTIME_DIR:-/tmp}/lf.${USER}.sock
+    echo 'send echo hello world' | nc -U ${XDG_RUNTIME_DIR:-/tmp/lf-$(id -u)}/lf.sock
 
 Since such a client may not be available everywhere, lf comes bundled
 with a command line flag to be used as such. When using lf, you do not

--- a/lf.1
+++ b/lf.1
@@ -1797,7 +1797,7 @@ OpenBSD implementation of netcat (nc) is one such example.
 You can use it to send a command to the socket file:
 .IP
 .EX
-echo \(aqsend echo hello world\(aq | nc \-U ${XDG_RUNTIME_DIR:\-/tmp}/lf.${USER}.sock
+echo \(aqsend echo hello world\(aq | nc \-U ${XDG_RUNTIME_DIR:\-/tmp/lf\-$(id \-u)}/lf.sock
 .EE
 .PP
 Since such a client may not be available everywhere, lf comes bundled

--- a/main.go
+++ b/main.go
@@ -177,9 +177,23 @@ func startServer() {
 }
 
 func checkServer() {
-	if _, err := os.Stat(gSocketPath); os.IsNotExist(err) {
+	st, err := os.Stat(gSocketPath)
+	if os.IsNotExist(err) {
 		startServer()
-	} else if _, err := net.Dial("unix", gSocketPath); err != nil {
+		return
+	}
+	if err != nil {
+		log.Printf("stat socket: %s", err)
+		return
+	}
+
+	// Fail closed if the socket isn't owned by process
+	if !socketOwnedByCurrentUser(st) {
+		log.Printf("refusing to use socket not owned by current user: %s", gSocketPath)
+		return
+	}
+
+	if _, err := net.Dial("unix", gSocketPath); err != nil {
 		if err := os.Remove(gSocketPath); err != nil {
 			log.Print(err)
 		}

--- a/main.go
+++ b/main.go
@@ -177,23 +177,9 @@ func startServer() {
 }
 
 func checkServer() {
-	st, err := os.Stat(gSocketPath)
-	if os.IsNotExist(err) {
+	if _, err := os.Stat(gSocketPath); os.IsNotExist(err) {
 		startServer()
-		return
-	}
-	if err != nil {
-		log.Printf("stat socket: %s", err)
-		return
-	}
-
-	// Fail closed if the socket isn't owned by process
-	if !socketOwnedByCurrentUser(st) {
-		log.Printf("refusing to use socket not owned by current user: %s", gSocketPath)
-		return
-	}
-
-	if _, err := net.Dial("unix", gSocketPath); err != nil {
+	} else if _, err := net.Dial("unix", gSocketPath); err != nil {
 		if err := os.Remove(gSocketPath); err != nil {
 			log.Print(err)
 		}

--- a/os.go
+++ b/os.go
@@ -115,9 +115,26 @@ func init() {
 	gTagsPath = filepath.Join(data, "lf", "tags")
 	gHistoryPath = filepath.Join(data, "lf", "history")
 
-	runtime := cmp.Or(os.Getenv("XDG_RUNTIME_DIR"), os.TempDir())
+	// Use a private per-user dir when XDG_RUNTIME_DIR is unset
+	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
+	if runtimeDir == "" {
+		runtimeDir = filepath.Join(os.TempDir(), fmt.Sprintf("lf-%s", gUser.Uid))
+		if err := os.MkdirAll(runtimeDir, 0700); err != nil {
+			log.Printf("creating runtime dir: %s", err)
+			runtimeDir = os.TempDir()
+		}
+	}
 
-	gDefaultSocketPath = filepath.Join(runtime, fmt.Sprintf("lf.%s.sock", gUser.Username))
+	gDefaultSocketPath = filepath.Join(runtimeDir, fmt.Sprintf("lf.%s.sock", gUser.Username))
+}
+
+// socketOwnedByCurrentUser returns true if info UID matches the process UID
+func socketOwnedByCurrentUser(info os.FileInfo) bool {
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false
+	}
+	return st.Uid == uint32(os.Geteuid())
 }
 
 func detachedCommand(name string, arg ...string) *exec.Cmd {

--- a/os.go
+++ b/os.go
@@ -131,7 +131,7 @@ func init() {
 		}
 	}
 
-	gDefaultSocketPath = filepath.Join(runtimeDir, fmt.Sprintf("lf.%s.sock", gUser.Username))
+	gDefaultSocketPath = filepath.Join(runtimeDir, "lf.sock")
 }
 
 func detachedCommand(name string, arg ...string) *exec.Cmd {

--- a/os.go
+++ b/os.go
@@ -120,21 +120,18 @@ func init() {
 	if runtimeDir == "" {
 		runtimeDir = filepath.Join(os.TempDir(), fmt.Sprintf("lf-%s", gUser.Uid))
 		if err := os.MkdirAll(runtimeDir, 0700); err != nil {
-			log.Printf("creating runtime dir: %s", err)
-			runtimeDir = os.TempDir()
+			log.Fatalf("creating runtime dir: %s", err)
+		}
+		st, err := os.Stat(runtimeDir)
+		if err != nil {
+			log.Fatalf("stat runtime dir: %s", err)
+		}
+		if stat, ok := st.Sys().(*syscall.Stat_t); !ok || stat.Uid != uint32(os.Geteuid()) {
+			log.Fatalf("runtime dir not owned by current user: %s", runtimeDir)
 		}
 	}
 
 	gDefaultSocketPath = filepath.Join(runtimeDir, fmt.Sprintf("lf.%s.sock", gUser.Username))
-}
-
-// socketOwnedByCurrentUser returns true if info UID matches the process UID
-func socketOwnedByCurrentUser(info os.FileInfo) bool {
-	st, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		return false
-	}
-	return st.Uid == uint32(os.Geteuid())
 }
 
 func detachedCommand(name string, arg ...string) *exec.Cmd {

--- a/os_windows.go
+++ b/os_windows.go
@@ -105,7 +105,7 @@ func init() {
 	gHistoryPath = filepath.Join(data, "lf", "history")
 
 	runtimeDir := os.TempDir()
-	gDefaultSocketPath = filepath.Join(runtimeDir, fmt.Sprintf("lf.%s.sock", gUser.Username))
+	gDefaultSocketPath = filepath.Join(runtimeDir, "lf.sock")
 
 	s := cmp.Or(os.Getenv("PATHEXT"), ".COM;.EXE;.BAT;.CMD")
 	for ext := range strings.SplitSeq(s, ";") {

--- a/os_windows.go
+++ b/os_windows.go
@@ -104,8 +104,8 @@ func init() {
 	gTagsPath = filepath.Join(data, "lf", "tags")
 	gHistoryPath = filepath.Join(data, "lf", "history")
 
-	runtime := os.TempDir()
-	gDefaultSocketPath = filepath.Join(runtime, fmt.Sprintf("lf.%s.sock", gUser.Username))
+	runtimeDir := os.TempDir()
+	gDefaultSocketPath = filepath.Join(runtimeDir, fmt.Sprintf("lf.%s.sock", gUser.Username))
 
 	s := cmp.Or(os.Getenv("PATHEXT"), ".COM;.EXE;.BAT;.CMD")
 	for ext := range strings.SplitSeq(s, ";") {
@@ -120,11 +120,6 @@ func detachedCommand(name string, arg ...string) *exec.Cmd {
 	cmd := exec.Command(name, arg...)
 	cmd.SysProcAttr = &windows.SysProcAttr{CreationFlags: 8}
 	return cmd
-}
-
-// socketOwnedByCurrentUser is a no-op on Windows
-func socketOwnedByCurrentUser(_ os.FileInfo) bool {
-	return true
 }
 
 func shellCommand(s string, args []string) *exec.Cmd {

--- a/os_windows.go
+++ b/os_windows.go
@@ -122,6 +122,11 @@ func detachedCommand(name string, arg ...string) *exec.Cmd {
 	return cmd
 }
 
+// socketOwnedByCurrentUser is a no-op on Windows
+func socketOwnedByCurrentUser(_ os.FileInfo) bool {
+	return true
+}
+
 func shellCommand(s string, args []string) *exec.Cmd {
 	// Windows CMD requires special handling to deal with quoted arguments
 	if strings.ToLower(gOpts.shell) == "cmd" {


### PR DESCRIPTION
When XDG_RUNTIME_DIR is not set, the socket is created in /tmp. Any other user can create a socket file in that path and cause lf to connect to it, resulting in the other user gaining control of the legit users lf process.

This PR ensures that the socket is owned by the process user 