### PR TITLE
fix: complete isControlChar

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -1296,7 +1296,7 @@ func (e *callExpr) eval(app *app, _ []string) {
 			}
 			normal(app)
 			if len(list) == 1 {
-				app.ui.cmdPrefix = "delete '" + list[0] + "'? [y/N] "
+				app.ui.cmdPrefix = "delete '" + sanitizeName(list[0]) + "'? [y/N] "
 			} else {
 				app.ui.cmdPrefix = "delete " + strconv.Itoa(len(list)) + " items? [y/N] "
 			}

--- a/termseq.go
+++ b/termseq.go
@@ -279,9 +279,15 @@ func applyOSC(body string, st tcell.Style) tcell.Style {
 
 // isControlChar reports whether a rune is a control character or otherwise
 // unsafe to display in a terminal.
-// Covers C0 (0x00-0x1F), DEL (0x7F), and C1 (0x80-0x9F).
+// Covers C0, DEL, C1, and the BiDi override/isolate runes
 func isControlChar(r rune) bool {
-	return r < 0x20 || r == 0x7F || r >= 0x80 && r <= 0x9F
+	if r < 0x20 || r == 0x7F || (r >= 0x80 && r <= 0x9F) {
+		return true
+	}
+	if (r >= 0x202A && r <= 0x202E) || (r >= 0x2066 && r <= 0x2069) {
+		return true
+	}
+	return false
 }
 
 // sanitizeForDisplay replaces control characters and invalid bytes with the

--- a/ui.go
+++ b/ui.go
@@ -1332,7 +1332,7 @@ func listMarks(marks map[string]string) string {
 	t.Init(b, 0, gOpts.tabstop, 2, '\t', 0)
 	fmt.Fprintln(t, "mark\tpath")
 	for _, k := range slices.Sorted(maps.Keys(marks)) {
-		fmt.Fprintf(t, "%s\t%s\n", k, marks[k])
+		fmt.Fprintf(t, "%s\t%s\n", k, sanitizeName(marks[k]))
 	}
 	t.Flush()
 
@@ -1615,10 +1615,15 @@ func listMatches(screen tcell.Screen, matches []compMatch, selectedInd int) (str
 		return "", nil
 	}
 
+	names := make([]string, len(matches))
+	for i, m := range matches {
+		names[i] = sanitizeName(m.name)
+	}
+
 	wtot, _ := screen.Size()
 	wcol := 0
-	for _, m := range matches {
-		wcol = max(wcol, printLength(m.name))
+	for _, n := range names {
+		wcol = max(wcol, printLength(n))
 	}
 	wcol += gOpts.tabstop - wcol%gOpts.tabstop
 	ncol := max(wtot/wcol, 1)
@@ -1626,19 +1631,19 @@ func listMatches(screen tcell.Screen, matches []compMatch, selectedInd int) (str
 	var b strings.Builder
 	b.WriteString("possible matches")
 
-	for i, match := range matches {
+	for i, n := range names {
 		if i%ncol == 0 {
 			b.WriteByte('\n')
 		}
-		w := printLength(match.name)
-		fmt.Fprintf(&b, "%s%*s", match.name, wcol-w, "")
+		w := printLength(n)
+		fmt.Fprintf(&b, "%s%*s", n, wcol-w, "")
 	}
 
 	b.WriteByte('\n')
 
 	var selection *menuSelect
 	if selectedInd != -1 {
-		selection = &menuSelect{selectedInd % ncol * wcol, selectedInd/ncol + 1, matches[selectedInd].name}
+		selection = &menuSelect{selectedInd % ncol * wcol, selectedInd/ncol + 1, names[selectedInd]}
 	}
 
 	return b.String(), selection


### PR DESCRIPTION
isControlChar  did not treat the Unicode bidirectional override, allowing filename spoofing.
also adds sanitizeName to missed cases
This PR completes the filter to ensure filenames are treated as untrusted
