### PR TITLE
fix: prevent preview flicker when terminal height decreases

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -676,8 +676,9 @@ func (nav *nav) resize(ui *ui) {
 		return
 	}
 
-	// only width affects preview output so height changes keep the cache
-	widthChanged := previewWin.w != nav.previewWidth
+	// preview output is capped at the preview window height, so a height
+	// increase requires re-running the previewer; a decrease does not
+	resized := previewWin.w != nav.previewWidth || previewWin.h > nav.height
 
 	nav.height = previewWin.h
 	nav.previewWidth = previewWin.w
@@ -686,15 +687,8 @@ func (nav *nav) resize(ui *ui) {
 		nav.getDir(path).boundPos(nav.height)
 	}
 
-	if widthChanged {
+	if resized {
 		clear(nav.regCache)
-	} else {
-		// drop only volatile regs whose previewer opted in to size dependence
-		for path, r := range nav.regCache {
-			if r.volatile {
-				delete(nav.regCache, path)
-			}
-		}
 	}
 	nav.preloadTimer.Reset(200 * time.Millisecond)
 }

--- a/nav.go
+++ b/nav.go
@@ -676,9 +676,7 @@ func (nav *nav) resize(ui *ui) {
 		return
 	}
 
-	// preview output is capped at the preview window height, so a height
-	// increase requires re-running the previewer; a decrease does not
-	resized := previewWin.w != nav.previewWidth || previewWin.h > nav.height
+	widthChanged := previewWin.w != nav.previewWidth
 
 	nav.height = previewWin.h
 	nav.previewWidth = previewWin.w
@@ -687,8 +685,16 @@ func (nav *nav) resize(ui *ui) {
 		nav.getDir(path).boundPos(nav.height)
 	}
 
-	if resized {
+	if widthChanged {
 		clear(nav.regCache)
+	} else {
+		// drop cached previews only when the new window height exceeds the
+		// cached line count and the previewer was not exhausted at load time
+		for path, r := range nav.regCache {
+			if !r.loading && len(r.lines) < previewWin.h && len(r.lines) == r.loadHeight {
+				delete(nav.regCache, path)
+			}
+		}
 	}
 	nav.preloadTimer.Reset(200 * time.Millisecond)
 }
@@ -861,7 +867,7 @@ func (nav *nav) preload() {
 }
 
 func (nav *nav) preview(path string, win *win, mode string) {
-	reg := &reg{loadTime: time.Now(), path: path}
+	reg := &reg{loadTime: time.Now(), path: path, loadHeight: win.h}
 	defer func() {
 		if (gOpts.preload && mode == "preview") || (!gOpts.preload && reg.volatile) {
 			nav.volatilePreview = true

--- a/nav.go
+++ b/nav.go
@@ -676,6 +676,9 @@ func (nav *nav) resize(ui *ui) {
 		return
 	}
 
+	// only width affects preview output so height changes keep the cache
+	widthChanged := previewWin.w != nav.previewWidth
+
 	nav.height = previewWin.h
 	nav.previewWidth = previewWin.w
 
@@ -683,7 +686,16 @@ func (nav *nav) resize(ui *ui) {
 		nav.getDir(path).boundPos(nav.height)
 	}
 
-	clear(nav.regCache)
+	if widthChanged {
+		clear(nav.regCache)
+	} else {
+		// drop only volatile regs whose previewer opted in to size dependence
+		for path, r := range nav.regCache {
+			if r.volatile {
+				delete(nav.regCache, path)
+			}
+		}
+	}
 	nav.preloadTimer.Reset(200 * time.Millisecond)
 }
 

--- a/nav.go
+++ b/nav.go
@@ -685,18 +685,27 @@ func (nav *nav) resize(ui *ui) {
 		nav.getDir(path).boundPos(nav.height)
 	}
 
+	dropped := false
 	if widthChanged {
-		clear(nav.regCache)
+		if len(nav.regCache) > 0 {
+			clear(nav.regCache)
+			dropped = true
+		}
 	} else {
-		// drop cached previews only when the new window height exceeds the
-		// cached line count and the previewer was not exhausted at load time
+		// drop entries that no longer match the new pane height
 		for path, r := range nav.regCache {
-			if !r.loading && len(r.lines) < previewWin.h && len(r.lines) == r.loadHeight {
+			if r.loading {
+				continue
+			}
+			if r.sixel || (previewWin.h > len(r.lines) && len(r.lines) == r.loadHeight) {
 				delete(nav.regCache, path)
+				dropped = true
 			}
 		}
 	}
-	nav.preloadTimer.Reset(200 * time.Millisecond)
+	if dropped {
+		nav.preloadTimer.Reset(200 * time.Millisecond)
+	}
 }
 
 func (nav *nav) position() {

--- a/nav.go
+++ b/nav.go
@@ -690,7 +690,7 @@ func (nav *nav) resize(ui *ui) {
 	} else {
 		// drop entries that no longer match the new pane height
 		for path, r := range nav.regCache {
-			if r.loading || r.sixel || (previewWin.h > len(r.lines) && len(r.lines) == r.loadHeight) {
+			if r.loading || r.sixel || (previewWin.h > len(r.lines) && len(r.lines) == r.height) {
 				delete(nav.regCache, path)
 			}
 		}
@@ -866,7 +866,7 @@ func (nav *nav) preload() {
 }
 
 func (nav *nav) preview(path string, win *win, mode string) {
-	reg := &reg{loadTime: time.Now(), path: path, loadHeight: win.h}
+	reg := &reg{loadTime: time.Now(), path: path, height: win.h}
 	defer func() {
 		if (gOpts.preload && mode == "preview") || (!gOpts.preload && reg.volatile) {
 			nav.volatilePreview = true

--- a/nav.go
+++ b/nav.go
@@ -685,27 +685,17 @@ func (nav *nav) resize(ui *ui) {
 		nav.getDir(path).boundPos(nav.height)
 	}
 
-	dropped := false
 	if widthChanged {
-		if len(nav.regCache) > 0 {
-			clear(nav.regCache)
-			dropped = true
-		}
+		clear(nav.regCache)
 	} else {
 		// drop entries that no longer match the new pane height
 		for path, r := range nav.regCache {
-			if r.loading {
-				continue
-			}
-			if r.sixel || (previewWin.h > len(r.lines) && len(r.lines) == r.loadHeight) {
+			if r.loading || r.sixel || (previewWin.h > len(r.lines) && len(r.lines) == r.loadHeight) {
 				delete(nav.regCache, path)
-				dropped = true
 			}
 		}
 	}
-	if dropped {
-		nav.preloadTimer.Reset(200 * time.Millisecond)
-	}
+	nav.preloadTimer.Reset(200 * time.Millisecond)
 }
 
 func (nav *nav) position() {

--- a/ui.go
+++ b/ui.go
@@ -607,12 +607,13 @@ func (ui *ui) echoerrf(format string, a ...any) {
 // Note: the name `reg` is historical. It originally meant "regular"
 // file preview, but `previewer` now also supports non-regular files.
 type reg struct {
-	loading  bool
-	volatile bool
-	loadTime time.Time
-	path     string
-	lines    []string
-	sixel    bool
+	loading    bool
+	volatile   bool
+	loadTime   time.Time
+	path       string
+	lines      []string
+	loadHeight int
+	sixel      bool
 }
 
 func (ui *ui) loadFile(app *app, volatile bool) {

--- a/ui.go
+++ b/ui.go
@@ -607,13 +607,13 @@ func (ui *ui) echoerrf(format string, a ...any) {
 // Note: the name `reg` is historical. It originally meant "regular"
 // file preview, but `previewer` now also supports non-regular files.
 type reg struct {
-	loading    bool
-	volatile   bool
-	loadTime   time.Time
-	path       string
-	lines      []string
-	loadHeight int
-	sixel      bool
+	loading  bool
+	volatile bool
+	loadTime time.Time
+	path     string
+	lines    []string
+	sixel    bool
+	height   int
 }
 
 func (ui *ui) loadFile(app *app, volatile bool) {


### PR DESCRIPTION
The preview pane is redrawn on vertical resize in tiling window managers like sway when opening a sibling window below the lf terminal window, causing a visual flicker in the preview pane only. This is the case when gui apps are opened by lf in vertical setups.

The patch addresses this by only dropping cached regs when the preview width actually changed