### PR TITLE
fix: error handling for broken marks

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -1833,7 +1833,8 @@ func (nav *nav) readMarks() error {
 	for scanner.Scan() {
 		mark, path, found := strings.Cut(scanner.Text(), ":")
 		if !found {
-			return fmt.Errorf("invalid marks file entry: %s", scanner.Text())
+			log.Printf("marks: skipping invalid entry: %q", scanner.Text())
+			continue
 		}
 		if _, ok := nav.marks[mark]; !ok {
 			nav.marks[mark] = path
@@ -1888,7 +1889,8 @@ func (nav *nav) readTags() error {
 
 		ind := strings.LastIndex(text, ":")
 		if ind == -1 {
-			return fmt.Errorf("invalid tags file entry: %s", text)
+			log.Printf("tags: skipping invalid entry: %q", text)
+			continue
 		}
 
 		path := text[0:ind]


### PR DESCRIPTION
readMarks aborts with an error on the first line missing a colon and silently stops loading of every subsequent mark in the file. A single corrupt entry makes all later marks unreachable until the file is cleaned. readTags had the same bug pattern with the same consequences for the tags file.