### PR TITLE
feat!: Add `sortignorecase`/`sortignoredia` options to decouple sorting from searching

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -317,6 +317,7 @@ The following options can be used to customize the behavior of lf:
 	smartdia          bool      (default false)
 	sortby            string    (default 'natural')
 	sortignorecase    bool      (default true)
+	sortignoredia     bool      (default true)
 	statfmt           string    (default "\033[36m%p\033[0m| %c| %u| %g| %S| %t| -> %l")
 	tabstop           int       (default 8)
 	tagfmt            string    (default "\033[31m")
@@ -986,7 +987,7 @@ Ignore case in search patterns. See also `sortignorecase`.
 
 ## ignoredia (bool) (default true)
 
-Ignore diacritics in sorting and search patterns.
+Ignore diacritics in search patterns. See also `sortignoredia`.
 
 ## incfilter (bool) (default false)
 
@@ -1224,7 +1225,11 @@ The following sort types are supported:
 
 ## sortignorecase (bool) (default true)
 
-Ignore case in sorting. See also `ignorecase`.
+Ignore case when sorting. See also `ignorecase`.
+
+## sortignoredia (bool) (default true)
+
+Ignore diacritics when sorting. See also `ignoredia`.
 
 ## statfmt (string) (default `\033[36m%p\033[0m| %c| %u| %g| %S| %t| -> %l`)
 
@@ -1499,7 +1504,7 @@ Command `set` is used to set an option which can be a boolean, integer, or strin
 	set sortby "time"  # string value with double quotes (backslash escapes)
 
 Command `setlocal` is used to set a local option for a directory which can be a boolean or string.
-Currently supported local options are `dircounts`, `dirfirst`, `dironly`, `hidden`, `info`, `reverse`, `sortby` and `sortignorecase`.
+Currently supported local options are `dircounts`, `dirfirst`, `dironly`, `hidden`, `info`, `reverse`, `sortby`, `sortignorecase` and `sortignoredia`.
 
 	setlocal /foo/bar hidden         # boolean enable
 	setlocal /foo/bar hidden true    # boolean enable

--- a/doc.md
+++ b/doc.md
@@ -316,6 +316,7 @@ The following options can be used to customize the behavior of lf:
 	smartcase         bool      (default true)
 	smartdia          bool      (default false)
 	sortby            string    (default 'natural')
+	sortignorecase    bool      (default true)
 	statfmt           string    (default "\033[36m%p\033[0m| %c| %u| %g| %S| %t| -> %l")
 	tabstop           int       (default 8)
 	tagfmt            string    (default "\033[31m")
@@ -981,7 +982,7 @@ This option does not have any effect on Windows.
 
 ## ignorecase (bool) (default true)
 
-Ignore case in sorting and search patterns.
+Ignore case in search patterns. See also `sortignorecase`.
 
 ## ignoredia (bool) (default true)
 
@@ -1197,7 +1198,7 @@ Determines whether file sizes are displayed using binary units (`1K` is 1024 byt
 
 ## smartcase (bool) (default true)
 
-Override `ignorecase` option when the pattern contains an uppercase character.
+Override `ignorecase` option for searching when the pattern contains an uppercase character.
 This option has no effect when `ignorecase` is disabled.
 
 ## smartdia (bool) (default false)
@@ -1220,6 +1221,10 @@ The following sort types are supported:
 	btime     time of file birth
 	ctime     time of last status (inode) change
 	custom    property defined via `addcustominfo` (empty by default)
+
+## sortignorecase (bool) (default true)
+
+Ignore case in sorting. See also `ignorecase`.
 
 ## statfmt (string) (default `\033[36m%p\033[0m| %c| %u| %g| %S| %t| -> %l`)
 
@@ -1494,7 +1499,7 @@ Command `set` is used to set an option which can be a boolean, integer, or strin
 	set sortby "time"  # string value with double quotes (backslash escapes)
 
 Command `setlocal` is used to set a local option for a directory which can be a boolean or string.
-Currently supported local options are `dircounts`, `dirfirst`, `dironly`, `hidden`, `info`, `reverse` and `sortby`.
+Currently supported local options are `dircounts`, `dirfirst`, `dironly`, `hidden`, `info`, `reverse`, `sortby` and `sortignorecase`.
 
 	setlocal /foo/bar hidden         # boolean enable
 	setlocal /foo/bar hidden true    # boolean enable

--- a/doc.txt
+++ b/doc.txt
@@ -328,6 +328,7 @@ The following options can be used to customize the behavior of lf:
     smartcase         bool      (default true)
     smartdia          bool      (default false)
     sortby            string    (default 'natural')
+    sortignorecase    bool      (default true)
     statfmt           string    (default "\033[36m%p\033[0m| %c| %u| %g| %S| %t| -> %l")
     tabstop           int       (default 8)
     tagfmt            string    (default "\033[31m")
@@ -1059,7 +1060,7 @@ option does not have any effect on Windows.
 
 ignorecase (bool) (default true)
 
-Ignore case in sorting and search patterns.
+Ignore case in search patterns. See also sortignorecase.
 
 ignoredia (bool) (default true)
 
@@ -1304,8 +1305,9 @@ Determines whether file sizes are displayed using binary units (1K is
 
 smartcase (bool) (default true)
 
-Override ignorecase option when the pattern contains an uppercase
-character. This option has no effect when ignorecase is disabled.
+Override ignorecase option for searching when the pattern contains an
+uppercase character. This option has no effect when ignorecase is
+disabled.
 
 smartdia (bool) (default false)
 
@@ -1327,6 +1329,10 @@ The following sort types are supported:
     btime     time of file birth
     ctime     time of last status (inode) change
     custom    property defined via `addcustominfo` (empty by default)
+
+sortignorecase (bool) (default true)
+
+Ignore case in sorting. See also ignorecase.
 
 statfmt (string) (default \033[36m%p\033[0m| %c| %u| %g| %S| %t| -> %l)
 
@@ -1643,7 +1649,7 @@ string:
 
 Command setlocal is used to set a local option for a directory which can
 be a boolean or string. Currently supported local options are dircounts,
-dirfirst, dironly, hidden, info, reverse and sortby.
+dirfirst, dironly, hidden, info, reverse, sortby and sortignorecase.
 
     setlocal /foo/bar hidden         # boolean enable
     setlocal /foo/bar hidden true    # boolean enable

--- a/doc.txt
+++ b/doc.txt
@@ -329,6 +329,7 @@ The following options can be used to customize the behavior of lf:
     smartdia          bool      (default false)
     sortby            string    (default 'natural')
     sortignorecase    bool      (default true)
+    sortignoredia     bool      (default true)
     statfmt           string    (default "\033[36m%p\033[0m| %c| %u| %g| %S| %t| -> %l")
     tabstop           int       (default 8)
     tagfmt            string    (default "\033[31m")
@@ -1064,7 +1065,7 @@ Ignore case in search patterns. See also sortignorecase.
 
 ignoredia (bool) (default true)
 
-Ignore diacritics in sorting and search patterns.
+Ignore diacritics in search patterns. See also sortignoredia.
 
 incfilter (bool) (default false)
 
@@ -1332,7 +1333,11 @@ The following sort types are supported:
 
 sortignorecase (bool) (default true)
 
-Ignore case in sorting. See also ignorecase.
+Ignore case when sorting. See also ignorecase.
+
+sortignoredia (bool) (default true)
+
+Ignore diacritics when sorting. See also ignoredia.
 
 statfmt (string) (default \033[36m%p\033[0m| %c| %u| %g| %S| %t| -> %l)
 
@@ -1649,7 +1654,8 @@ string:
 
 Command setlocal is used to set a local option for a directory which can
 be a boolean or string. Currently supported local options are dircounts,
-dirfirst, dironly, hidden, info, reverse, sortby and sortignorecase.
+dirfirst, dironly, hidden, info, reverse, sortby, sortignorecase and
+sortignoredia.
 
     setlocal /foo/bar hidden         # boolean enable
     setlocal /foo/bar hidden true    # boolean enable

--- a/eval.go
+++ b/eval.go
@@ -173,6 +173,13 @@ func (e *setExpr) eval(app *app, _ []string) {
 			app.nav.position()
 			app.ui.loadFile(app, true)
 		}
+	case "sortignorecase", "nosortignorecase", "sortignorecase!":
+		err = applyBoolOpt(&gOpts.sortignorecase, e)
+		if err == nil {
+			app.nav.sort()
+			app.nav.position()
+			app.ui.loadFile(app, true)
+		}
 	case "watch", "nowatch", "watch!":
 		err = applyBoolOpt(&gOpts.watch, e)
 		if err == nil {
@@ -531,6 +538,11 @@ func (e *setLocalExpr) eval(app *app, _ []string) {
 		}
 	case "reverse", "noreverse", "reverse!":
 		err = applyLocalBoolOpt(gLocalOpts.reverse, gOpts.reverse, e)
+		if err == nil {
+			app.nav.sort()
+		}
+	case "sortignorecase", "nosortignorecase", "sortignorecase!":
+		err = applyLocalBoolOpt(gLocalOpts.sortignorecase, gOpts.sortignorecase, e)
 		if err == nil {
 			app.nav.sort()
 		}

--- a/eval.go
+++ b/eval.go
@@ -80,8 +80,6 @@ func (e *setExpr) eval(app *app, _ []string) {
 		err = applyBoolOpt(&gOpts.dironly, e)
 		if err == nil {
 			app.nav.sort()
-			app.nav.position()
-			app.ui.loadFile(app, true)
 		}
 	case "dirpreviews", "nodirpreviews", "dirpreviews!":
 		err = applyBoolOpt(&gOpts.dirpreviews, e)
@@ -96,8 +94,6 @@ func (e *setExpr) eval(app *app, _ []string) {
 		err = applyBoolOpt(&gOpts.hidden, e)
 		if err == nil {
 			app.nav.sort()
-			app.nav.position()
-			app.ui.loadFile(app, true)
 		}
 	case "history", "nohistory", "history!":
 		err = applyBoolOpt(&gOpts.history, e)
@@ -107,15 +103,11 @@ func (e *setExpr) eval(app *app, _ []string) {
 		err = applyBoolOpt(&gOpts.ignorecase, e)
 		if err == nil {
 			app.nav.sort()
-			app.nav.position()
-			app.ui.loadFile(app, true)
 		}
 	case "ignoredia", "noignoredia", "ignoredia!":
 		err = applyBoolOpt(&gOpts.ignoredia, e)
 		if err == nil {
 			app.nav.sort()
-			app.nav.position()
-			app.ui.loadFile(app, true)
 		}
 	case "incfilter", "noincfilter", "incfilter!":
 		err = applyBoolOpt(&gOpts.incfilter, e)
@@ -163,22 +155,16 @@ func (e *setExpr) eval(app *app, _ []string) {
 		err = applyBoolOpt(&gOpts.smartcase, e)
 		if err == nil {
 			app.nav.sort()
-			app.nav.position()
-			app.ui.loadFile(app, true)
 		}
 	case "smartdia", "nosmartdia", "smartdia!":
 		err = applyBoolOpt(&gOpts.smartdia, e)
 		if err == nil {
 			app.nav.sort()
-			app.nav.position()
-			app.ui.loadFile(app, true)
 		}
 	case "sortignorecase", "nosortignorecase", "sortignorecase!":
 		err = applyBoolOpt(&gOpts.sortignorecase, e)
 		if err == nil {
 			app.nav.sort()
-			app.nav.position()
-			app.ui.loadFile(app, true)
 		}
 	case "watch", "nowatch", "watch!":
 		err = applyBoolOpt(&gOpts.watch, e)
@@ -244,8 +230,6 @@ func (e *setExpr) eval(app *app, _ []string) {
 			return
 		}
 		app.nav.sort()
-		app.nav.position()
-		app.ui.loadFile(app, true)
 	case "findlen":
 		n, err := strconv.Atoi(e.val)
 		if err != nil {
@@ -272,8 +256,6 @@ func (e *setExpr) eval(app *app, _ []string) {
 		}
 		gOpts.hiddenfiles = toks
 		app.nav.sort()
-		app.nav.position()
-		app.ui.loadFile(app, true)
 	case "ifs":
 		gOpts.ifs = e.val
 	case "info":
@@ -526,15 +508,11 @@ func (e *setLocalExpr) eval(app *app, _ []string) {
 		err = applyLocalBoolOpt(gLocalOpts.dironly, gOpts.dironly, e)
 		if err == nil {
 			app.nav.sort()
-			app.nav.position()
-			app.ui.loadFile(app, true)
 		}
 	case "hidden", "nohidden", "hidden!":
 		err = applyLocalBoolOpt(gLocalOpts.hidden, gOpts.hidden, e)
 		if err == nil {
 			app.nav.sort()
-			app.nav.position()
-			app.ui.loadFile(app, true)
 		}
 	case "reverse", "noreverse", "reverse!":
 		err = applyLocalBoolOpt(gLocalOpts.reverse, gOpts.reverse, e)

--- a/eval.go
+++ b/eval.go
@@ -80,6 +80,8 @@ func (e *setExpr) eval(app *app, _ []string) {
 		err = applyBoolOpt(&gOpts.dironly, e)
 		if err == nil {
 			app.nav.sort()
+			app.nav.position()
+			app.ui.loadFile(app, true)
 		}
 	case "dirpreviews", "nodirpreviews", "dirpreviews!":
 		err = applyBoolOpt(&gOpts.dirpreviews, e)
@@ -94,6 +96,8 @@ func (e *setExpr) eval(app *app, _ []string) {
 		err = applyBoolOpt(&gOpts.hidden, e)
 		if err == nil {
 			app.nav.sort()
+			app.nav.position()
+			app.ui.loadFile(app, true)
 		}
 	case "history", "nohistory", "history!":
 		err = applyBoolOpt(&gOpts.history, e)
@@ -103,11 +107,15 @@ func (e *setExpr) eval(app *app, _ []string) {
 		err = applyBoolOpt(&gOpts.ignorecase, e)
 		if err == nil {
 			app.nav.sort()
+			app.nav.position()
+			app.ui.loadFile(app, true)
 		}
 	case "ignoredia", "noignoredia", "ignoredia!":
 		err = applyBoolOpt(&gOpts.ignoredia, e)
 		if err == nil {
 			app.nav.sort()
+			app.nav.position()
+			app.ui.loadFile(app, true)
 		}
 	case "incfilter", "noincfilter", "incfilter!":
 		err = applyBoolOpt(&gOpts.incfilter, e)
@@ -155,11 +163,15 @@ func (e *setExpr) eval(app *app, _ []string) {
 		err = applyBoolOpt(&gOpts.smartcase, e)
 		if err == nil {
 			app.nav.sort()
+			app.nav.position()
+			app.ui.loadFile(app, true)
 		}
 	case "smartdia", "nosmartdia", "smartdia!":
 		err = applyBoolOpt(&gOpts.smartdia, e)
 		if err == nil {
 			app.nav.sort()
+			app.nav.position()
+			app.ui.loadFile(app, true)
 		}
 	case "sortignorecase", "nosortignorecase", "sortignorecase!":
 		err = applyBoolOpt(&gOpts.sortignorecase, e)
@@ -235,6 +247,8 @@ func (e *setExpr) eval(app *app, _ []string) {
 			return
 		}
 		app.nav.sort()
+		app.nav.position()
+		app.ui.loadFile(app, true)
 	case "findlen":
 		n, err := strconv.Atoi(e.val)
 		if err != nil {
@@ -261,6 +275,8 @@ func (e *setExpr) eval(app *app, _ []string) {
 		}
 		gOpts.hiddenfiles = toks
 		app.nav.sort()
+		app.nav.position()
+		app.ui.loadFile(app, true)
 	case "ifs":
 		gOpts.ifs = e.val
 	case "info":
@@ -513,11 +529,15 @@ func (e *setLocalExpr) eval(app *app, _ []string) {
 		err = applyLocalBoolOpt(gLocalOpts.dironly, gOpts.dironly, e)
 		if err == nil {
 			app.nav.sort()
+			app.nav.position()
+			app.ui.loadFile(app, true)
 		}
 	case "hidden", "nohidden", "hidden!":
 		err = applyLocalBoolOpt(gLocalOpts.hidden, gOpts.hidden, e)
 		if err == nil {
 			app.nav.sort()
+			app.nav.position()
+			app.ui.loadFile(app, true)
 		}
 	case "reverse", "noreverse", "reverse!":
 		err = applyLocalBoolOpt(gLocalOpts.reverse, gOpts.reverse, e)

--- a/eval.go
+++ b/eval.go
@@ -166,6 +166,11 @@ func (e *setExpr) eval(app *app, _ []string) {
 		if err == nil {
 			app.nav.sort()
 		}
+	case "sortignoredia", "nosortignoredia", "sortignoredia!":
+		err = applyBoolOpt(&gOpts.sortignoredia, e)
+		if err == nil {
+			app.nav.sort()
+		}
 	case "watch", "nowatch", "watch!":
 		err = applyBoolOpt(&gOpts.watch, e)
 		if err == nil {
@@ -521,6 +526,11 @@ func (e *setLocalExpr) eval(app *app, _ []string) {
 		}
 	case "sortignorecase", "nosortignorecase", "sortignorecase!":
 		err = applyLocalBoolOpt(gLocalOpts.sortignorecase, gOpts.sortignorecase, e)
+		if err == nil {
+			app.nav.sort()
+		}
+	case "sortignoredia", "nosortignoredia", "sortignoredia!":
+		err = applyLocalBoolOpt(gLocalOpts.sortignoredia, gOpts.sortignoredia, e)
 		if err == nil {
 			app.nav.sort()
 		}

--- a/nav.go
+++ b/nav.go
@@ -179,9 +179,8 @@ type dir struct {
 	visualWrap     int        // wrap direction in Visual mode (0: none, +: bottom->top, -: top->bottom)
 	hiddenfiles    []string   // hiddenfiles value from last sort
 	filter         []string   // last filter for this directory
-	ignorecase     bool       // ignorecase value from last sort
 	sortignorecase bool       // sortignorecase value from last sort
-	ignoredia      bool       // ignoredia value from last sort
+	sortignoredia  bool       // sortignoredia value from last sort
 	noPerm         bool       // whether lf has no permission to open the directory
 }
 
@@ -209,9 +208,8 @@ func (dir *dir) sort() {
 	dir.hidden = getHidden(dir.path)
 	dir.reverse = getReverse(dir.path)
 	dir.hiddenfiles = gOpts.hiddenfiles
-	dir.ignorecase = gOpts.ignorecase
 	dir.sortignorecase = getSortIgnoreCase(dir.path)
-	dir.ignoredia = gOpts.ignoredia
+	dir.sortignoredia = getSortIgnoreDia(dir.path)
 
 	dir.files = dir.allFiles
 
@@ -261,7 +259,7 @@ func (dir *dir) sort() {
 		if dir.sortignorecase {
 			s = strings.ToLower(s)
 		}
-		if dir.ignoredia {
+		if dir.sortignoredia {
 			s = removeDiacritics(s)
 		}
 		return s
@@ -504,9 +502,8 @@ func (nav *nav) getDir(path string) *dir {
 		reverse:        getReverse(path),
 		visualAnchor:   -1,
 		hiddenfiles:    gOpts.hiddenfiles,
-		ignorecase:     gOpts.ignorecase,
 		sortignorecase: getSortIgnoreCase(path),
-		ignoredia:      gOpts.ignoredia,
+		sortignoredia:  getSortIgnoreDia(path),
 	}
 	nav.dirCache[path] = d
 	return d
@@ -549,9 +546,8 @@ func (nav *nav) checkDir(dir *dir) {
 		dir.hidden != getHidden(dir.path) ||
 		dir.reverse != getReverse(dir.path) ||
 		!slices.Equal(dir.hiddenfiles, gOpts.hiddenfiles) ||
-		dir.ignorecase != gOpts.ignorecase ||
 		dir.sortignorecase != getSortIgnoreCase(dir.path) ||
-		dir.ignoredia != gOpts.ignoredia:
+		dir.sortignoredia != getSortIgnoreDia(dir.path):
 		dir.loading = true
 		sd := *dir
 		go func() {

--- a/nav.go
+++ b/nav.go
@@ -162,27 +162,27 @@ func readdir(path string) ([]*file, error) {
 }
 
 type dir struct {
-	loading      bool       // whether directory is loading from disk
-	loadTime     time.Time  // last load time
-	ind          int        // 0-based index of current entry in dir.files
-	pos          int        // 0-based cursor row in directory window
-	path         string     // full path of directory
-	files        []*file    // displayed files in directory including or excluding hidden ones
-	allFiles     []*file    // all files in directory including hidden ones (same array as files)
-	sortby       sortMethod // sortby value from last sort
-	dircounts    bool       // dircounts value from last sort
-	dirfirst     bool       // dirfirst value from last sort
-	dironly      bool       // dironly value from last sort
-	hidden       bool       // hidden value from last sort
-	reverse      bool       // reverse value from last sort
-	visualAnchor int        // index where Visual mode was initiated
-	visualWrap   int        // wrap direction in Visual mode (0: none, +: bottom->top, -: top->bottom)
-	hiddenfiles  []string   // hiddenfiles value from last sort
-	filter       []string   // last filter for this directory
-	ignorecase   bool       // ignorecase value from last sort
-	sortignorecase bool     // sortignorecase value from last sort
-	ignoredia    bool       // ignoredia value from last sort
-	noPerm       bool       // whether lf has no permission to open the directory
+	loading        bool       // whether directory is loading from disk
+	loadTime       time.Time  // last load time
+	ind            int        // 0-based index of current entry in dir.files
+	pos            int        // 0-based cursor row in directory window
+	path           string     // full path of directory
+	files          []*file    // displayed files in directory including or excluding hidden ones
+	allFiles       []*file    // all files in directory including hidden ones (same array as files)
+	sortby         sortMethod // sortby value from last sort
+	dircounts      bool       // dircounts value from last sort
+	dirfirst       bool       // dirfirst value from last sort
+	dironly        bool       // dironly value from last sort
+	hidden         bool       // hidden value from last sort
+	reverse        bool       // reverse value from last sort
+	visualAnchor   int        // index where Visual mode was initiated
+	visualWrap     int        // wrap direction in Visual mode (0: none, +: bottom->top, -: top->bottom)
+	hiddenfiles    []string   // hiddenfiles value from last sort
+	filter         []string   // last filter for this directory
+	ignorecase     bool       // ignorecase value from last sort
+	sortignorecase bool       // sortignorecase value from last sort
+	ignoredia      bool       // ignoredia value from last sort
+	noPerm         bool       // whether lf has no permission to open the directory
 }
 
 func newDir(path string) *dir {
@@ -493,20 +493,20 @@ func (nav *nav) getDir(path string) *dir {
 	}()
 
 	d := &dir{
-		loading:      true,
-		loadTime:     time.Now(),
-		path:         path,
-		sortby:       getSortBy(path),
-		dircounts:    getDirCounts(path),
-		dirfirst:     getDirFirst(path),
-		dironly:      getDirOnly(path),
-		hidden:       getHidden(path),
-		reverse:      getReverse(path),
-		visualAnchor: -1,
-		hiddenfiles:  gOpts.hiddenfiles,
-		ignorecase:   gOpts.ignorecase,
+		loading:        true,
+		loadTime:       time.Now(),
+		path:           path,
+		sortby:         getSortBy(path),
+		dircounts:      getDirCounts(path),
+		dirfirst:       getDirFirst(path),
+		dironly:        getDirOnly(path),
+		hidden:         getHidden(path),
+		reverse:        getReverse(path),
+		visualAnchor:   -1,
+		hiddenfiles:    gOpts.hiddenfiles,
+		ignorecase:     gOpts.ignorecase,
 		sortignorecase: getSortIgnoreCase(path),
-		ignoredia:    gOpts.ignoredia,
+		ignoredia:      gOpts.ignoredia,
 	}
 	nav.dirCache[path] = d
 	return d

--- a/nav.go
+++ b/nav.go
@@ -180,6 +180,7 @@ type dir struct {
 	hiddenfiles  []string   // hiddenfiles value from last sort
 	filter       []string   // last filter for this directory
 	ignorecase   bool       // ignorecase value from last sort
+	sortignorecase bool     // sortignorecase value from last sort
 	ignoredia    bool       // ignoredia value from last sort
 	noPerm       bool       // whether lf has no permission to open the directory
 }
@@ -209,6 +210,7 @@ func (dir *dir) sort() {
 	dir.reverse = getReverse(dir.path)
 	dir.hiddenfiles = gOpts.hiddenfiles
 	dir.ignorecase = gOpts.ignorecase
+	dir.sortignorecase = getSortIgnoreCase(dir.path)
 	dir.ignoredia = gOpts.ignoredia
 
 	dir.files = dir.allFiles
@@ -256,7 +258,7 @@ func (dir *dir) sort() {
 	}
 
 	normalize := func(s string) string {
-		if dir.ignorecase {
+		if dir.sortignorecase {
 			s = strings.ToLower(s)
 		}
 		if dir.ignoredia {
@@ -503,6 +505,7 @@ func (nav *nav) getDir(path string) *dir {
 		visualAnchor: -1,
 		hiddenfiles:  gOpts.hiddenfiles,
 		ignorecase:   gOpts.ignorecase,
+		sortignorecase: getSortIgnoreCase(path),
 		ignoredia:    gOpts.ignoredia,
 	}
 	nav.dirCache[path] = d
@@ -547,6 +550,7 @@ func (nav *nav) checkDir(dir *dir) {
 		dir.reverse != getReverse(dir.path) ||
 		!slices.Equal(dir.hiddenfiles, gOpts.hiddenfiles) ||
 		dir.ignorecase != gOpts.ignorecase ||
+		dir.sortignorecase != getSortIgnoreCase(dir.path) ||
 		dir.ignoredia != gOpts.ignoredia:
 		dir.loading = true
 		sd := *dir

--- a/opts.go
+++ b/opts.go
@@ -166,13 +166,13 @@ var gOpts struct {
 }
 
 var gLocalOpts struct {
-	dircounts map[string]bool
-	dirfirst  map[string]bool
-	dironly   map[string]bool
-	hidden    map[string]bool
-	info      map[string][]string
-	reverse   map[string]bool
-	sortby    map[string]sortMethod
+	dircounts      map[string]bool
+	dirfirst       map[string]bool
+	dironly        map[string]bool
+	hidden         map[string]bool
+	info           map[string][]string
+	reverse        map[string]bool
+	sortby         map[string]sortMethod
 	sortignorecase map[string]bool
 }
 

--- a/opts.go
+++ b/opts.go
@@ -145,6 +145,7 @@ var gOpts struct {
 	smartdia         bool
 	sortby           sortMethod
 	sortignorecase   bool
+	sortignoredia    bool
 	statfmt          string
 	tabstop          int
 	tagfmt           string
@@ -174,6 +175,7 @@ var gLocalOpts struct {
 	reverse        map[string]bool
 	sortby         map[string]sortMethod
 	sortignorecase map[string]bool
+	sortignoredia  map[string]bool
 }
 
 func getDirCounts(path string) bool {
@@ -230,6 +232,13 @@ func getSortIgnoreCase(path string) bool {
 		return val
 	}
 	return gOpts.sortignorecase
+}
+
+func getSortIgnoreDia(path string) bool {
+	if val, ok := gLocalOpts.sortignoredia[path]; ok {
+		return val
+	}
+	return gOpts.sortignoredia
 }
 
 func init() {
@@ -297,6 +306,7 @@ func init() {
 	gOpts.smartdia = false
 	gOpts.sortby = naturalSort
 	gOpts.sortignorecase = true
+	gOpts.sortignoredia = true
 	gOpts.statfmt = "\033[36m%p\033[0m| %c| %u| %g| %S| %t| -> %l"
 	gOpts.tabstop = 8
 	gOpts.tagfmt = "\033[31m"
@@ -449,6 +459,7 @@ func init() {
 	gLocalOpts.reverse = make(map[string]bool)
 	gLocalOpts.sortby = make(map[string]sortMethod)
 	gLocalOpts.sortignorecase = make(map[string]bool)
+	gLocalOpts.sortignoredia = make(map[string]bool)
 
 	setDefaults()
 }

--- a/opts.go
+++ b/opts.go
@@ -144,6 +144,7 @@ var gOpts struct {
 	smartcase        bool
 	smartdia         bool
 	sortby           sortMethod
+	sortignorecase   bool
 	statfmt          string
 	tabstop          int
 	tagfmt           string
@@ -172,6 +173,7 @@ var gLocalOpts struct {
 	info      map[string][]string
 	reverse   map[string]bool
 	sortby    map[string]sortMethod
+	sortignorecase map[string]bool
 }
 
 func getDirCounts(path string) bool {
@@ -221,6 +223,13 @@ func getSortBy(path string) sortMethod {
 		return val
 	}
 	return gOpts.sortby
+}
+
+func getSortIgnoreCase(path string) bool {
+	if val, ok := gLocalOpts.sortignorecase[path]; ok {
+		return val
+	}
+	return gOpts.sortignorecase
 }
 
 func init() {
@@ -287,6 +296,7 @@ func init() {
 	gOpts.smartcase = true
 	gOpts.smartdia = false
 	gOpts.sortby = naturalSort
+	gOpts.sortignorecase = true
 	gOpts.statfmt = "\033[36m%p\033[0m| %c| %u| %g| %S| %t| -> %l"
 	gOpts.tabstop = 8
 	gOpts.tagfmt = "\033[31m"
@@ -438,6 +448,7 @@ func init() {
 	gLocalOpts.info = make(map[string][]string)
 	gLocalOpts.reverse = make(map[string]bool)
 	gLocalOpts.sortby = make(map[string]sortMethod)
+	gLocalOpts.sortignorecase = make(map[string]bool)
 
 	setDefaults()
 }


### PR DESCRIPTION
This PR decouples case sensitivity for sorting from searching by introducing a new option:

`sortignorecase`

Previously, `ignorecase` affected both:
* searching
* sorting

This made it impossible to configure:
* case-sensitive sorting
* case-insensitive searching (with optional smartcase)

With this change:
* `ignorecase` and `smartcase` now affect searching only
* `sortignorecase` controls sorting behavior independently


## Changes

### Added

* global `sortignorecase` option
* local `sortignorecase` option via `setlocal`

### Updated
* sorting logic in `nav.go` to use `sortignorecase`
* option evaluation in `eval.go`
* option definitions/getters/defaults in `opts.go`

### Documentation

Updated:

* `doc.md`
* `doc.txt`

to document the new option and clarify behavior of `ignorecase` / `smartcase`.

## Backward Compatibility

Default value:

```lf
set sortignorecase true
```

which preserves existing default behavior.

Fixes #2102
