### PR TITLE
fix: disable pathname expansion

### DIFF
--- a/etc/lfrc.example
+++ b/etc/lfrc.example
@@ -42,6 +42,7 @@ map O $mimeopen --ask "$f"
 # use either file extensions and/or mime types here. Below uses an editor for
 # text files and a file opener for the rest.
 cmd open &{{
+    set -f
     case $(file --mime-type -Lb "$f") in
         text/*) lf -remote "send $id \$$EDITOR \$fx";;
         *) for f in $fx; do $OPENER "$f" > /dev/null 2> /dev/null & done;;


### PR DESCRIPTION
Prevent globbing e.g. when a filename is `a*.txt`