### PR TITLE
perf: remove unnecessary sprintf

### DIFF
--- a/app.go
+++ b/app.go
@@ -13,6 +13,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -84,7 +85,7 @@ func (app *app) quit() {
 		}
 	}
 	if !gSingleMode {
-		if _, err := remote(fmt.Sprintf("drop %d", gClientID)); err != nil {
+		if _, err := remote("drop " + strconv.Itoa(gClientID)); err != nil {
 			log.Printf("dropping connection: %s", err)
 		}
 		if gOpts.autoquit {

--- a/key.go
+++ b/key.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -141,7 +140,7 @@ var reModKey = regexp.MustCompile(`<(c|s|a)-(.+)>`)
 func wrapModifier(s string, mod string) string {
 	s = strings.TrimPrefix(s, "<")
 	s = strings.TrimSuffix(s, ">")
-	return fmt.Sprintf("<%s-%s>", mod, s)
+	return "<" + mod + "-" + s + ">"
 }
 
 func addKeyModifier(s string, mod tcell.ModMask) string {

--- a/misc.go
+++ b/misc.go
@@ -275,7 +275,7 @@ func humanize(size int64) string {
 	}
 
 	if size < base {
-		return fmt.Sprintf("%dB", size)
+		return strconv.FormatInt(size, 10) + "B"
 	}
 
 	// Note: due to [fs.FileInfo.Size] being `int64`, the maximum
@@ -298,18 +298,18 @@ func humanize(size int64) string {
 	for _, prefix := range prefixes {
 		// if curr < 99.95 then round to 1 decimal place
 		if curr.Cmp(big.NewRat(9995, 100)) < 0 {
-			return fmt.Sprintf("%s%s", curr.FloatString(1), prefix)
+			return curr.FloatString(1) + prefix
 		}
 
 		// if curr < base-0.5 then round to the nearest integer
 		if curr.Cmp(new(big.Rat).Sub(big.NewRat(base, 1), big.NewRat(1, 2))) < 0 {
-			return fmt.Sprintf("%s%s", curr.FloatString(0), prefix)
+			return curr.FloatString(0) + prefix
 		}
 
 		curr.Quo(curr, big.NewRat(base, 1))
 	}
 
-	return fmt.Sprintf("+999%s", prefixes[len(prefixes)-1])
+	return "+999" + prefixes[len(prefixes)-1]
 }
 
 // permString returns an ls(1)-style string representation of the given file

--- a/nav.go
+++ b/nav.go
@@ -1321,7 +1321,7 @@ func (nav *nav) copyAsync(app *app, srcs []string, dstDir string) {
 	errCount := 0
 	sendErr := func(format string, a ...any) {
 		errCount++
-		msg := fmt.Sprintf("copy [%d]: %s", errCount, fmt.Sprintf(format, a...))
+		msg := "copy [" + strconv.Itoa(errCount) + "]: " + fmt.Sprintf(format, a...)
 		app.ui.exprChan <- &callExpr{"echoerr", []string{msg}, 1}
 	}
 
@@ -1381,7 +1381,7 @@ func (nav *nav) moveAsync(app *app, srcs []string, dstDir string) {
 	errCount := 0
 	sendErr := func(format string, a ...any) {
 		errCount++
-		msg := fmt.Sprintf("move [%d]: %s", errCount, fmt.Sprintf(format, a...))
+		msg := "move [" + strconv.Itoa(errCount) + "]: " + fmt.Sprintf(format, a...)
 		app.ui.exprChan <- &callExpr{"echoerr", []string{msg}, 1}
 	}
 
@@ -1522,7 +1522,7 @@ func (nav *nav) del(app *app) error {
 
 			if err := os.RemoveAll(path); err != nil {
 				errCount++
-				echo.args[0] = fmt.Sprintf("[%d] %s", errCount, err)
+				echo.args[0] = "[" + strconv.Itoa(errCount) + "] " + err.Error()
 				app.ui.exprChan <- echo
 			}
 		}
@@ -1535,7 +1535,7 @@ func (nav *nav) del(app *app) error {
 		} else {
 			if _, err := remote("send load"); err != nil {
 				errCount++
-				echo.args[0] = fmt.Sprintf("[%d] %s", errCount, err)
+				echo.args[0] = "[" + strconv.Itoa(errCount) + "] " + err.Error()
 				app.ui.exprChan <- echo
 			}
 		}

--- a/opts.go
+++ b/opts.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"fmt"
 	"maps"
+	"strconv"
 	"time"
 )
 
@@ -76,7 +76,7 @@ func (s borderStyle) String() string {
 	case borderSeparators:
 		return "separators"
 	default:
-		return fmt.Sprintf("borderStyle(%d)", s)
+		return "borderStyle(" + strconv.Itoa(int(s)) + ")"
 	}
 }
 

--- a/os.go
+++ b/os.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"cmp"
-	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -117,7 +116,7 @@ func init() {
 
 	runtime := cmp.Or(os.Getenv("XDG_RUNTIME_DIR"), os.TempDir())
 
-	gDefaultSocketPath = filepath.Join(runtime, fmt.Sprintf("lf.%s.sock", gUser.Username))
+	gDefaultSocketPath = filepath.Join(runtime, "lf."+gUser.Username+".sock")
 }
 
 func detachedCommand(name string, arg ...string) *exec.Cmd {
@@ -128,7 +127,7 @@ func detachedCommand(name string, arg ...string) *exec.Cmd {
 
 func shellCommand(s string, args []string) *exec.Cmd {
 	if len(gOpts.ifs) != 0 {
-		s = fmt.Sprintf("IFS='%s'; %s", gOpts.ifs, s)
+		s = "IFS='" + gOpts.ifs + "'; " + s
 	}
 
 	args = append([]string{gOpts.shellflag, s, "--"}, args...)

--- a/os_windows.go
+++ b/os_windows.go
@@ -105,7 +105,7 @@ func init() {
 	gHistoryPath = filepath.Join(data, "lf", "history")
 
 	runtime := os.TempDir()
-	gDefaultSocketPath = filepath.Join(runtime, fmt.Sprintf("lf.%s.sock", gUser.Username))
+	gDefaultSocketPath = filepath.Join(runtime, "lf."+gUser.Username+".sock")
 
 	s := cmp.Or(os.Getenv("PATHEXT"), ".COM;.EXE;.BAT;.CMD")
 	for ext := range strings.SplitSeq(s, ";") {
@@ -131,7 +131,7 @@ func shellCommand(s string, args []string) *exec.Cmd {
 			fmt.Fprintf(&builder, ` "%s"`, arg)
 		}
 		shellOpts := strings.Join(gOpts.shellopts, " ")
-		cmdline := fmt.Sprintf(`%s %s %s "%s"`, gOpts.shell, shellOpts, gOpts.shellflag, builder.String())
+		cmdline := gOpts.shell + " " + shellOpts + " " + gOpts.shellflag + ` "` + builder.String() + `"`
 
 		cmd := exec.Command(gOpts.shell)
 		cmd.SysProcAttr = &windows.SysProcAttr{CmdLine: cmdline}
@@ -223,7 +223,7 @@ func errCrossDevice(err error) bool {
 func quoteString(s string) string {
 	// Windows CMD requires special handling to deal with quoted arguments
 	if strings.ToLower(gOpts.shell) == "cmd" {
-		return fmt.Sprintf(`"%s"`, s)
+		return `"` + s + `"`
 	}
 	return s
 }
@@ -231,7 +231,7 @@ func quoteString(s string) string {
 func shellEscape(s string) string {
 	for _, r := range s {
 		if strings.ContainsRune(" !%&'()+,;=[]^`{}~", r) {
-			return fmt.Sprintf(`"%s"`, s)
+			return `"` + s + `"`
 		}
 	}
 	return s

--- a/parse.go
+++ b/parse.go
@@ -59,9 +59,9 @@ type setExpr struct {
 
 func (e *setExpr) String() string {
 	if e.val == "" {
-		return fmt.Sprintf("set %s", e.opt)
+		return "set " + e.opt
 	}
-	return fmt.Sprintf("set %s %s", e.opt, e.val)
+	return "set " + e.opt + " " + e.val
 }
 
 type setLocalExpr struct {
@@ -72,9 +72,9 @@ type setLocalExpr struct {
 
 func (e *setLocalExpr) String() string {
 	if e.val == "" {
-		return fmt.Sprintf("setlocal %s %s", e.path, e.opt)
+		return "setlocal " + e.path + " " + e.opt
 	}
-	return fmt.Sprintf("setlocal %s %s %s", e.path, e.opt, e.val)
+	return "setlocal " + e.path + " " + e.opt + " " + e.val
 }
 
 type mapExpr struct {
@@ -84,9 +84,9 @@ type mapExpr struct {
 
 func (e *mapExpr) String() string {
 	if e.expr == nil {
-		return fmt.Sprintf("map %s", e.keys)
+		return "map " + e.keys
 	}
-	return fmt.Sprintf("map %s %s", e.keys, e.expr)
+	return "map " + e.keys + " " + e.expr.String()
 }
 
 type nmapExpr struct {
@@ -96,9 +96,9 @@ type nmapExpr struct {
 
 func (e *nmapExpr) String() string {
 	if e.expr == nil {
-		return fmt.Sprintf("nmap %s", e.keys)
+		return "nmap " + e.keys
 	}
-	return fmt.Sprintf("nmap %s %s", e.keys, e.expr)
+	return "nmap " + e.keys + " " + e.expr.String()
 }
 
 type vmapExpr struct {
@@ -108,9 +108,9 @@ type vmapExpr struct {
 
 func (e *vmapExpr) String() string {
 	if e.expr == nil {
-		return fmt.Sprintf("vmap %s", e.keys)
+		return "vmap " + e.keys
 	}
-	return fmt.Sprintf("vmap %s %s", e.keys, e.expr)
+	return "vmap " + e.keys + " " + e.expr.String()
 }
 
 type cmapExpr struct {
@@ -120,9 +120,9 @@ type cmapExpr struct {
 
 func (e *cmapExpr) String() string {
 	if e.expr == nil {
-		return fmt.Sprintf("cmap %s", e.key)
+		return "cmap " + e.key
 	}
-	return fmt.Sprintf("cmap %s %s", e.key, e.expr)
+	return "cmap " + e.key + " " + e.expr.String()
 }
 
 type cmdExpr struct {
@@ -132,9 +132,9 @@ type cmdExpr struct {
 
 func (e *cmdExpr) String() string {
 	if e.expr == nil {
-		return fmt.Sprintf("cmd %s", e.name)
+		return "cmd " + e.name
 	}
-	return fmt.Sprintf("cmd %s %s", e.name, e.expr)
+	return "cmd " + e.name + " " + e.expr.String()
 }
 
 type callExpr struct {

--- a/ui.go
+++ b/ui.go
@@ -922,7 +922,7 @@ func (ui *ui) drawRulerFile(nav *nav) {
 	if tot == 0 {
 		linePercentage = "100%"
 	} else {
-		linePercentage = fmt.Sprintf("%d%%", ind*100/tot)
+		linePercentage = strconv.Itoa(ind*100/tot) + "%"
 	}
 
 	var scrollPercentage string
@@ -953,18 +953,18 @@ func (ui *ui) drawRulerFile(nav *nav) {
 
 	if nav.copyJobs > 0 {
 		if nav.copyTotal == 0 {
-			progress = append(progress, fmt.Sprintf("[0%%]"))
+			progress = append(progress, "[0%]")
 		} else {
-			progress = append(progress, fmt.Sprintf("[%d%%]", nav.copyBytes*100/nav.copyTotal))
+			progress = append(progress, "["+strconv.FormatInt(nav.copyBytes*100/nav.copyTotal, 10)+"%]")
 		}
 	}
 
 	if nav.moveTotal > 0 {
-		progress = append(progress, fmt.Sprintf("[%d/%d]", nav.moveCount, nav.moveTotal))
+		progress = append(progress, "["+strconv.Itoa(nav.moveCount)+"/"+strconv.Itoa(nav.moveTotal)+"]")
 	}
 
 	if nav.deleteTotal > 0 {
-		progress = append(progress, fmt.Sprintf("[%d/%d]", nav.deleteCount, nav.deleteTotal))
+		progress = append(progress, "["+strconv.Itoa(nav.deleteCount)+"/"+strconv.Itoa(nav.deleteTotal)+"]")
 	}
 
 	mode := "NORMAL"


### PR DESCRIPTION
Doing direct string concatenations instead of `Sprintf` in all places where `Sprintf` isn't needed for formatting