### PR TITLE
Fix: concurrency in server connection

### DIFF
--- a/client.go
+++ b/client.go
@@ -129,7 +129,8 @@ func readExpr() <-chan expr {
 		}
 
 		if _, err := fmt.Fprintf(c, "conn %d\n", gClientID); err != nil {
-			log.Fatalf("registering with server: %s", err)
+			log.Printf("registering with server: %s", err)
+			return
 		}
 
 		ch <- &callExpr{"sync", nil, 1}
@@ -148,7 +149,8 @@ func readExpr() <-chan expr {
 				state := gState.data[rest]
 				gState.mutex.Unlock()
 				if _, err := fmt.Fprintln(c, state); err != nil {
-					log.Fatalf("sending response to server: %s", err)
+					log.Printf("sending response to server: %s", err)
+					return
 				}
 			} else {
 				p := newParser(strings.NewReader(s.Text()))

--- a/server.go
+++ b/server.go
@@ -9,12 +9,18 @@ import (
 	"os"
 	"slices"
 	"strconv"
-	"sync"
 )
 
+type srvCmd struct {
+	op   string
+	id   int
+	msg  string
+	c    net.Conn
+	done chan struct{}
+}
+
 var (
-	gConnMu   sync.Mutex
-	gConnList = make(map[int]net.Conn)
+	gCmdChan  = make(chan srvCmd)
 	gQuitChan = make(chan struct{}, 1)
 	gListener net.Listener
 )
@@ -42,7 +48,82 @@ func serve() {
 
 	gListener = l
 
+	go manage()
+
 	listen(l)
+}
+
+func manage() {
+	connList := make(map[int]net.Conn)
+	for cmd := range gCmdChan {
+		switch cmd.op {
+		case "conn":
+			// lifetime of the connection is managed by the server and
+			// will be cleaned up via the `drop` command
+			connList[cmd.id] = cmd.c
+		case "drop":
+			if c2, ok := connList[cmd.id]; ok {
+				c2.Close()
+				delete(connList, cmd.id)
+			}
+		case "list":
+			for _, id := range slices.Sorted(maps.Keys(connList)) {
+				fmt.Fprintln(cmd.c, id)
+			}
+		case "broadcast":
+			for id, c2 := range connList {
+				if _, err := fmt.Fprintln(c2, cmd.msg); err != nil {
+					echoerrf(cmd.c, "failed to send command to client %v: %s", id, err)
+				}
+			}
+		case "send":
+			if c2, ok := connList[cmd.id]; ok {
+				if _, err := fmt.Fprintln(c2, cmd.msg); err != nil {
+					echoerrf(cmd.c, "failed to send command to client %v: %s", cmd.id, err)
+				}
+			} else {
+				echoerr(cmd.c, "listen: send: no such client id is connected")
+			}
+		case "query":
+			c2, ok := connList[cmd.id]
+			if !ok {
+				echoerr(cmd.c, "listen: query: no such client id is connected")
+				break
+			}
+			if _, err := fmt.Fprintln(c2, "query "+cmd.msg); err != nil {
+				echoerrf(cmd.c, "failed to send query to client %v: %s", cmd.id, err)
+				break
+			}
+			s2 := bufio.NewScanner(c2)
+			for s2.Scan() && s2.Text() != "" {
+				if _, err := fmt.Fprintln(cmd.c, s2.Text()); err != nil {
+					log.Printf("failed to forward query response from client %v: %s", cmd.id, err)
+				}
+			}
+			if s2.Err() != nil {
+				echoerrf(cmd.c, "failed to read query response from client %v: %s", cmd.id, s2.Err())
+			}
+		case "quit":
+			if len(connList) == 0 {
+				gQuitChan <- struct{}{}
+				gListener.Close()
+				close(cmd.done)
+				return
+			}
+		case "quit!":
+			gQuitChan <- struct{}{}
+			for _, c := range connList {
+				fmt.Fprintln(c, "echo server is quitting...")
+				c.Close()
+			}
+			gListener.Close()
+			close(cmd.done)
+			return
+		}
+		if cmd.done != nil {
+			close(cmd.done)
+		}
+	}
 }
 
 func listen(l net.Listener) {
@@ -70,6 +151,12 @@ func echoerrf(c net.Conn, format string, a ...any) {
 	echoerr(c, fmt.Sprintf(format, a...))
 }
 
+func send(cmd srvCmd) {
+	cmd.done = make(chan struct{})
+	gCmdChan <- cmd
+	<-cmd.done
+}
+
 func handleConn(c net.Conn) {
 	s := bufio.NewScanner(c)
 
@@ -78,7 +165,6 @@ Loop:
 		log.Printf("listen: %s", s.Text())
 		word, rest := splitWord(s.Text())
 
-		gConnMu.Lock()
 		switch word {
 		case "conn":
 			if rest != "" {
@@ -87,10 +173,7 @@ Loop:
 				if err != nil {
 					echoerr(c, "listen: conn: client id should be a number")
 				} else {
-					// lifetime of the connection is managed by the server and
-					// will be cleaned up via the `drop` command
-					gConnList[id] = c
-					gConnMu.Unlock()
+					send(srvCmd{op: "conn", id: id, c: c})
 					return
 				}
 			} else {
@@ -103,36 +186,21 @@ Loop:
 				if err != nil {
 					echoerr(c, "listen: drop: client id should be a number")
 				} else {
-					if c2, ok := gConnList[id]; ok {
-						c2.Close()
-					}
-					delete(gConnList, id)
+					send(srvCmd{op: "drop", id: id})
 				}
 			} else {
 				echoerr(c, "listen: drop: requires a client id")
 			}
 		case "list":
-			for _, id := range slices.Sorted(maps.Keys(gConnList)) {
-				fmt.Fprintln(c, id)
-			}
+			send(srvCmd{op: "list", c: c})
 		case "send":
 			if rest != "" {
 				word2, rest2 := splitWord(rest)
 				id, err := strconv.Atoi(word2)
 				if err != nil {
-					for id, c2 := range gConnList {
-						if _, err := fmt.Fprintln(c2, rest); err != nil {
-							echoerrf(c, "failed to send command to client %v: %s", id, err)
-						}
-					}
+					send(srvCmd{op: "broadcast", msg: rest, c: c})
 				} else {
-					if c2, ok := gConnList[id]; ok {
-						if _, err := fmt.Fprintln(c2, rest2); err != nil {
-							echoerrf(c, "failed to send command to client %v: %s", id, err)
-						}
-					} else {
-						echoerr(c, "listen: send: no such client id is connected")
-					}
+					send(srvCmd{op: "send", id: id, msg: rest2, c: c})
 				}
 			}
 		case "query":
@@ -146,44 +214,16 @@ Loop:
 				echoerr(c, "listen: query: client id should be a number")
 				break
 			}
-			c2, ok := gConnList[id]
-			if !ok {
-				echoerr(c, "listen: query: no such client id is connected")
-				break
-			}
-			if _, err := fmt.Fprintln(c2, "query "+rest2); err != nil {
-				echoerrf(c, "failed to send query to client %v: %s", id, err)
-				break
-			}
-			s2 := bufio.NewScanner(c2)
-			for s2.Scan() && s2.Text() != "" {
-				if _, err := fmt.Fprintln(c, s2.Text()); err != nil {
-					log.Printf("failed to forward query response from client %v: %s", id, err)
-				}
-			}
-			if s2.Err() != nil {
-				echoerrf(c, "failed to read query response from client %v: %s", id, s2.Err())
-			}
+			send(srvCmd{op: "query", id: id, msg: rest2, c: c})
 		case "quit":
-			if len(gConnList) == 0 {
-				gQuitChan <- struct{}{}
-				gListener.Close()
-				gConnMu.Unlock()
-				break Loop
-			}
+			send(srvCmd{op: "quit"})
+			break Loop
 		case "quit!":
-			gQuitChan <- struct{}{}
-			for _, c := range gConnList {
-				fmt.Fprintln(c, "echo server is quitting...")
-				c.Close()
-			}
-			gListener.Close()
-			gConnMu.Unlock()
+			send(srvCmd{op: "quit!"})
 			break Loop
 		default:
 			echoerrf(c, "listen: unexpected command: %s", word)
 		}
-		gConnMu.Unlock()
 	}
 
 	if s.Err() != nil {

--- a/server.go
+++ b/server.go
@@ -9,9 +9,11 @@ import (
 	"os"
 	"slices"
 	"strconv"
+	"sync"
 )
 
 var (
+	gConnMu   sync.Mutex
 	gConnList = make(map[int]net.Conn)
 	gQuitChan = make(chan struct{}, 1)
 	gListener net.Listener
@@ -75,6 +77,8 @@ Loop:
 	for s.Scan() {
 		log.Printf("listen: %s", s.Text())
 		word, rest := splitWord(s.Text())
+
+		gConnMu.Lock()
 		switch word {
 		case "conn":
 			if rest != "" {
@@ -86,6 +90,7 @@ Loop:
 					// lifetime of the connection is managed by the server and
 					// will be cleaned up via the `drop` command
 					gConnList[id] = c
+					gConnMu.Unlock()
 					return
 				}
 			} else {
@@ -163,6 +168,7 @@ Loop:
 			if len(gConnList) == 0 {
 				gQuitChan <- struct{}{}
 				gListener.Close()
+				gConnMu.Unlock()
 				break Loop
 			}
 		case "quit!":
@@ -172,10 +178,12 @@ Loop:
 				c.Close()
 			}
 			gListener.Close()
+			gConnMu.Unlock()
 			break Loop
 		default:
 			echoerrf(c, "listen: unexpected command: %s", word)
 		}
+		gConnMu.Unlock()
 	}
 
 	if s.Err() != nil {


### PR DESCRIPTION
The server can be accessed by multiple -remote calls at the same time
This PR just adds a mutex to make this safe and ensure that when a connection breaks, it does so cleanly.

This was flagged by static analysis and Im not sure if it really needs fixing, but its a minimal change. If there any any issues, we can just drop it.