### PR TITLE
Fix: dont follow broken shortcuts

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -66,7 +66,11 @@ func copyFile(src, dst string, preserve []string, info os.FileInfo, nums chan<- 
 	if slices.Contains(preserve, "mode") {
 		dstMode = info.Mode()
 	}
-	w, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, dstMode)
+	flags := os.O_RDWR | os.O_CREATE | os.O_EXCL
+	if _, err := os.Lstat(dst); err == nil {
+		flags = os.O_RDWR | os.O_TRUNC
+	}
+	w, err := os.OpenFile(dst, flags, dstMode)
 	if err != nil {
 		errs <- err
 		return


### PR DESCRIPTION
This patch prevents lf from accidentally overwriting unrelated files when the destination folder contains a leftover broken shortcut with the same name as the file being copied. Without the patch, lf creates a real file at wherever the shortcut points. The patch stops with an error and the unrelated location is left alone.