### PR TITLE
clear stale preview pane cells on draw

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -1039,6 +1039,16 @@ func (ui *ui) drawPreview(nav *nav, context *dirContext) {
 			win.printDir(ui, dir, context, dirStyle, nav.previewTimer)
 		}
 	}
+
+	// Force re-emit of preview cells to clear pixels bled past cell bounds by previous content.
+	if cs, ok := ui.screen.(interface{ GetCells() *tcell.CellBuffer }); ok {
+		cells := cs.GetCells()
+		for y := win.y; y < win.y+win.h; y++ {
+			for x := win.x; x < win.x+win.w; x++ {
+				cells.SetDirty(x, y, true)
+			}
+		}
+	}
 }
 
 func (ui *ui) drawBox() {

--- a/ui.go
+++ b/ui.go
@@ -539,6 +539,7 @@ type ui struct {
 	ruler       *template.Template // compiled `rulerfile`
 	rulerErr    error              // `rulerfile` parse error (if any)
 	currentFile string             // last path passed to `on-select`
+	forceSync   bool               // force full screen repaint on next draw
 	pasteEvent  bool               // whether paste event is active (to ignore pasted input in Normal mode)
 }
 
@@ -627,6 +628,7 @@ func (ui *ui) loadFile(app *app, volatile bool) {
 
 	if curr.path != ui.currentFile {
 		ui.currentFile = curr.path
+		ui.forceSync = true
 		onSelect(app)
 	}
 
@@ -1143,6 +1145,14 @@ func (ui *ui) draw(nav *nav) {
 	context := dirContext{selections: nav.selections, clipboard: nav.clipboard, tags: nav.tags}
 
 	ui.screen.Clear()
+
+	// On file change, force re-emit of every cell to clear pixels bled past cell bounds.
+	if ui.forceSync {
+		ui.forceSync = false
+		if cs, ok := ui.screen.(interface{ GetCells() *tcell.CellBuffer }); ok {
+			cs.GetCells().Invalidate()
+		}
+	}
 
 	ui.drawPromptLine(nav)
 

--- a/ui.go
+++ b/ui.go
@@ -1039,16 +1039,6 @@ func (ui *ui) drawPreview(nav *nav, context *dirContext) {
 			win.printDir(ui, dir, context, dirStyle, nav.previewTimer)
 		}
 	}
-
-	// Force re-emit of preview cells to clear pixels bled past cell bounds by previous content.
-	if cs, ok := ui.screen.(interface{ GetCells() *tcell.CellBuffer }); ok {
-		cells := cs.GetCells()
-		for y := win.y; y < win.y+win.h; y++ {
-			for x := win.x; x < win.x+win.w; x++ {
-				cells.SetDirty(x, y, true)
-			}
-		}
-	}
 }
 
 func (ui *ui) drawBox() {


### PR DESCRIPTION
Previously, lf relied on tcell's diff to decide which cells to re-emit when redrawing the preview pane. If a cell's buffer state matched what was last drawn there, tcell skipped it. This left two visible issues:

1. Pixels that bleed past cell boundaries (combining marks, fallback glyphs, width-table mismatches) sometimes stuck around because tcell saw the buffer as unchanged and skipped re-emit. Per the tcell discussion https://github.com/gdamore/tcell/pull/1079 this is a terminal/font issue we can't fix in tcell or lf, so the workaround is to just force a re-emit.

2. When a previous file's preview was bigger than the new one, the leftover cells outside the new preview kept their old content instead of being cleared.

This patch reemits all cells in the preview pane after the preview content is written. Valid sixel images stay locked and aren't touched, so they're preserved, but the outdated preview data is cleaned.

CPU cost is a few µs even on a 4K screen, so this is every efficient.