### PR TITLE
fix!: enhance detection for binary previews

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -1077,7 +1077,7 @@ Note that preserving other attributes like ownership of change/birth timestamp i
 
 Show previews of files and directories at the rightmost pane.
 If the file has more lines than the preview pane, the rest of the lines are not read.
-Files containing the null character (U+0000) in the read portion are considered binary files and displayed as `binary`.
+Files are considered binary and displayed as `binary` if the read portion contains a control character other than tab, newline, vertical tab, form feed, carriage return, backspace, or escape.
 
 ## previewer (string) (default ``) (not filtered if empty)
 

--- a/misc.go
+++ b/misc.go
@@ -501,9 +501,11 @@ func readLines(reader io.ByteReader, maxLines int) (lines []string, binary bool,
 
 		switch currState {
 		case stateNormal:
-			switch b {
-			case 0:
+			// C0 controls outside \b \t \n \v \f \r \033 and DEL indicate binary content.
+			if b < 0x07 || (b > 0x0D && b < 0x1B) || (b > 0x1B && b < 0x20) || b == 0x7F {
 				return nil, true, false
+			}
+			switch b {
 			case '\033':
 				currState = stateEsc
 			case '\r':


### PR DESCRIPTION
At the moment, small binaries and random files are detected as text with high probability by lf and passed to the internal previewer. This is the most likely cause of artifacts due to character width mismatch in terminal (a terminal bug)
Details are discussed in #2560 and https://github.com/gdamore/tcell/pull/1079

Displaying binary as text preview is ugly on its own too.

This PR improves the detection of valid text files significantly.

Previously, a 100 byte file with random data would be detected as text more then half the time. a common 200 bytes encrypted pgp file would still be detected about 1 in 3 times as text.

This patch reduces the chance of false positive detection to a very low percentage that causes almost no false positives - unless the file is very small, e.g. 10 bytes, which is very rare  
