### PR TITLE
fix: update stale previews when `preload` is enabled

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -994,7 +994,14 @@ func (nav *nav) checkReg(reg *reg) {
 
 	if s.ModTime().After(reg.loadTime) {
 		reg.loadTime = now
-		nav.previewChan <- reg.path
+		if gOpts.preload {
+			select {
+			case nav.preloadChan <- reg.path:
+			default:
+			}
+		} else {
+			nav.previewChan <- reg.path
+		}
 	}
 }
 


### PR DESCRIPTION
checkReg detects external file modifications by comparing mtime to reg.loadTime, but pushes the resulting reload to previewChan. When using the preload option, the deferred regChan send in preview()  checks if gOpts.preload + "preload" and silently drops the result, leaving the cache stale forever. 

This fix now matches the other cases and refreshes the cached preview data when a file changed