### PR TITLE
feat: parallel preview processing

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -431,6 +432,11 @@ type clipboard struct {
 	mode  clipboardMode
 }
 
+type previewWork struct {
+	path string
+	mode string
+}
+
 type nav struct {
 	dirPaths        []string
 	copyJobs        int
@@ -452,6 +458,7 @@ type nav struct {
 	deleteTotalChan chan int
 	preloadChan     chan string
 	previewChan     chan string
+	workChan        chan previewWork
 	dirChan         chan *dir
 	regChan         chan *reg
 	fileChan        chan *file
@@ -585,6 +592,7 @@ func newNav(ui *ui) *nav {
 		deleteTotalChan: make(chan int, 1024),
 		preloadChan:     make(chan string, 1024),
 		previewChan:     make(chan string, 1024),
+		workChan:        make(chan previewWork),
 		dirChan:         make(chan *dir),
 		regChan:         make(chan *reg),
 		fileChan:        make(chan *file),
@@ -731,6 +739,15 @@ func (nav *nav) exportFiles() {
 }
 
 func (nav *nav) preloadLoop(ui *ui) {
+	workers := max(2, runtime.NumCPU()/2)
+	for i := 0; i < workers; i++ {
+		go func() {
+			for w := range nav.workChan {
+				nav.preview(w.path, ui.wins[len(ui.wins)-1], w.mode)
+			}
+		}()
+	}
+
 	stack := []string{}
 
 	push := func(path string) {
@@ -751,9 +768,8 @@ func (nav *nav) preloadLoop(ui *ui) {
 			select {
 			case path := <-nav.preloadChan:
 				push(path)
-			default:
-				path := pop()
-				nav.preview(path, ui.wins[len(ui.wins)-1], "preload")
+			case nav.workChan <- previewWork{stack[len(stack)-1], "preload"}:
+				pop()
 			}
 		}
 	}
@@ -799,7 +815,7 @@ func (nav *nav) previewLoop(ui *ui) {
 			nav.volatilePreview = false
 		}
 		if len(path) != 0 {
-			nav.preview(path, win, "preview")
+			nav.workChan <- previewWork{path, "preview"}
 			prev = path
 		}
 	}

--- a/nav.go
+++ b/nav.go
@@ -435,6 +435,7 @@ type clipboard struct {
 type previewWork struct {
 	path string
 	mode string
+	done chan struct{}
 }
 
 type nav struct {
@@ -740,10 +741,13 @@ func (nav *nav) exportFiles() {
 
 func (nav *nav) preloadLoop(ui *ui) {
 	workers := max(2, runtime.NumCPU()/2)
-	for i := 0; i < workers; i++ {
+	for range workers {
 		go func() {
 			for w := range nav.workChan {
 				nav.preview(w.path, ui.wins[len(ui.wins)-1], w.mode)
+				if w.done != nil {
+					close(w.done)
+				}
 			}
 		}()
 	}
@@ -768,7 +772,7 @@ func (nav *nav) preloadLoop(ui *ui) {
 			select {
 			case path := <-nav.preloadChan:
 				push(path)
-			case nav.workChan <- previewWork{stack[len(stack)-1], "preload"}:
+			case nav.workChan <- previewWork{stack[len(stack)-1], "preload", nil}:
 				pop()
 			}
 		}
@@ -815,7 +819,9 @@ func (nav *nav) previewLoop(ui *ui) {
 			nav.volatilePreview = false
 		}
 		if len(path) != 0 {
-			nav.workChan <- previewWork{path, "preview"}
+			done := make(chan struct{})
+			nav.workChan <- previewWork{path, "preview", done}
+			<-done
 			prev = path
 		}
 	}


### PR DESCRIPTION
Addresses #2566 

This PR is a very simple and small addition that speeds up preview generation (with or without preload) by using parallel processing of preview files. The number of workers is half the available cpu cores, which avoid a configuration setting and should provide a reasonable approach regardless of hardware.
