### PR TITLE
replace example trash function

### DIFF
--- a/etc/lfrc.example
+++ b/etc/lfrc.example
@@ -61,8 +61,9 @@ map a :push %mkdir<space>
 cmd trash %{{
     set -f
     [ -z "$fx" ] && exit
-    mkdir -p -m 700 -- ~/.local/share/Trash
-    mv --backup=numbered -t ~/.local/share/Trash -- $fx
+    mkdir -p -m 700 -- ~/.local/share/Trash/files
+    t=$(date +%s)
+    for f in $fx; do mv -- "$f" ~/.local/share/Trash/files/"$t-${f##*/}"; done
 }}
 
 # map D trash

--- a/etc/lfrc.example
+++ b/etc/lfrc.example
@@ -56,12 +56,16 @@ map a :push %mkdir<space>
 # cmd rename %[ -e "$1" ] && printf "file exists" || mv "$f" "$1"
 # map r push :rename<space>
 
-# make sure trash folder exists
-# %mkdir -p ~/.trash
-
 # move current file or selected files to trash folder
-# (also see 'man mv' for backup/overwrite options)
-cmd trash %set -f; mv -t ~/.trash -- $fx
+#  --backup=numbered prevents silent overwrite of duplicates
+cmd trash %{{
+    set -f
+    [ -z "$fx" ] && exit
+    mkdir -p -m 700 -- ~/.local/share/Trash
+    mv --backup=numbered -t ~/.local/share/Trash -- $fx
+}}
+
+# map D trash
 
 # define a custom 'delete' command
 # cmd delete ${{


### PR DESCRIPTION
The previous trash example in lfrc.example ir quite risky adn overwrites newly trashed files with the same name. (also noted in the wiki) 
This PR replaces the bad example with a safe version using only 'mv'