### PR TITLE
fix tcell sync

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -1279,7 +1279,10 @@ func (e *callExpr) eval(app *app, _ []string) {
 		}
 	case "draw":
 	case "redraw":
-		app.ui.screen.Sync()
+		// Skip Sync() for resize events, tcell v3 already redraws on SIGWINCH
+		if !slices.Contains(e.args, "resize") {
+			app.ui.screen.Sync()
+		}
 		app.ui.renew()
 		app.nav.resize(app.ui)
 		app.ui.sxScreen.forceClear = true

--- a/sixel.go
+++ b/sixel.go
@@ -72,11 +72,9 @@ func (sxs *sixelScreen) printSixel(win *win, screen tcell.Screen, reg *reg) {
 		y += sh
 	}
 
-	fmt.Fprint(os.Stderr, "\033[?2026h") // Begin synchronized update
-	fmt.Fprint(os.Stderr, "\0337")       // Save cursor position
-	fmt.Fprint(os.Stderr, b.String())    // Write data
-	fmt.Fprint(os.Stderr, "\0338")       // Restore cursor position
-	fmt.Fprint(os.Stderr, "\033[?2026l") // End synchronized update
+	fmt.Fprint(os.Stderr, "\0337")    // Save cursor position
+	fmt.Fprint(os.Stderr, b.String()) // Write data
+	fmt.Fprint(os.Stderr, "\0338")    // Restore cursor position
 
 	sxs.lastFile = reg.path
 	sxs.lastWin = *win

--- a/ui.go
+++ b/ui.go
@@ -1537,7 +1537,7 @@ func (ui *ui) readNormalEvent(ev tcell.Event, nav *nav) expr {
 			return &callExpr{"cd", []string{dir.path}, 1}
 		}
 	case *tcell.EventResize:
-		return &callExpr{"redraw", nil, 1}
+		return &callExpr{"redraw", []string{"resize"}, 1}
 	case *tcell.EventError:
 		log.Printf("Got EventError: '%s' at %s", tev.Error(), tev.When())
 	case *tcell.EventInterrupt:


### PR DESCRIPTION
tcell version 3.4.0 now handles all synchronized updates and lfs own calls of [?2026h and [?2026l are gettign in the way, probably causing #2581