### PR TITLE
Perf: remove redundant sync call

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -1279,7 +1279,10 @@ func (e *callExpr) eval(app *app, _ []string) {
 		}
 	case "draw":
 	case "redraw":
-		app.ui.screen.Sync()
+		// Skip Sync() for resize events; tcell already repaints on SIGWINCH
+		if !slices.Contains(e.args, "resize") {
+			app.ui.screen.Sync()
+		}
 		app.ui.renew()
 		app.nav.resize(app.ui)
 		app.ui.sxScreen.forceClear = true

--- a/ui.go
+++ b/ui.go
@@ -1543,7 +1543,7 @@ func (ui *ui) readNormalEvent(ev tcell.Event, nav *nav) expr {
 			return &callExpr{"cd", []string{dir.path}, 1}
 		}
 	case *tcell.EventResize:
-		return &callExpr{"redraw", nil, 1}
+		return &callExpr{"redraw", []string{"resize"}, 1}
 	case *tcell.EventError:
 		log.Printf("Got EventError: '%s' at %s", tev.Error(), tev.When())
 	case *tcell.EventInterrupt:


### PR DESCRIPTION
When the terminal is resized, lf does a full repaint via screen.Sync(). But tcell already repaints by itself on resize, before it even notifies lf about the event. So every resize causes two repaints instead of one.
This PR skips the Sync() call when the redraw was triggered by a resize.