### PR TITLE
fix: reload preview immediately after watch file modification

### DIFF
--- a/app.go
+++ b/app.go
@@ -466,7 +466,9 @@ func (app *app) loop() {
 				dir.sel(name, app.nav.height)
 			}
 
-			delete(app.nav.regCache, f.path)
+			if curr := app.nav.currFile(); curr == nil || curr.path != f.path {
+				delete(app.nav.regCache, f.path)
+			}
 			app.ui.loadFile(app, false)
 			onLoad(app, []string{f.path})
 			app.ui.draw(app.nav)

--- a/app.go
+++ b/app.go
@@ -466,10 +466,9 @@ func (app *app) loop() {
 				dir.sel(name, app.nav.height)
 			}
 
-			if curr := app.nav.currFile(); curr == nil || curr.path != f.path {
-				delete(app.nav.regCache, f.path)
+			if r, ok := app.nav.regCache[f.path]; ok {
+				app.nav.checkReg(r)
 			}
-			app.ui.loadFile(app, false)
 			onLoad(app, []string{f.path})
 			app.ui.draw(app.nav)
 		case path := <-app.nav.delChan:


### PR DESCRIPTION
When a file is opened by a terminal editor in lf, saving the file and returning to lf will trigger a flicker where the old contents of the text files are shown as preview for a split second, before the new updated content is drawn in the preview pane.
This is caused by checkReg not marking the cache entry, so printReg still printed the old content. Setting reg.loading now fixes printReg and skips the stale output, so the pane stays empty until the new reg lands.

Note: the bug only triggers when using external preview scripts. 