### PR TITLE
fix: handle missing cache during `fileChan` reload

### DIFF
--- a/app.go
+++ b/app.go
@@ -468,6 +468,17 @@ func (app *app) loop() {
 
 			if r, ok := app.nav.regCache[f.path]; ok {
 				app.nav.checkReg(r)
+			} else {
+				r = &reg{loading: true, loadTime: time.Now(), path: f.path}
+				app.nav.regCache[f.path] = r
+				if gOpts.preload {
+					select {
+					case app.nav.preloadChan <- f.path:
+					default:
+					}
+				} else {
+					app.nav.previewChan <- f.path
+				}
 			}
 			onLoad(app, []string{f.path})
 			app.ui.draw(app.nav)


### PR DESCRIPTION
When saving a file in a text editor, the modification will be reported in `fileChan` which then reloads the cached preview. However the preview may also end up getting deleted from the cache first if the text editor saves using a backup file instead of writing to the file directly. This commit simply adds back the cache entry as a fallback if it is missing.

Maybe it's better to have a function similar to `getDir` that operates for reg previews (i.e. read-through cache).