### PR TITLE
fix: sanitize -remote queries

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 
 	_ "embed"
+
+	"golang.org/x/term"
 )
 
 //go:embed doc.txt
@@ -342,6 +344,14 @@ Options:
 		if err != nil {
 			log.Fatalf("remote command: %s", err)
 			return
+		}
+		// sanitize untrusted names when writing to a terminal
+		if term.IsTerminal(int(os.Stdout.Fd())) {
+			lines := strings.Split(resp, "\n")
+			for i := range lines {
+				lines[i] = sanitizeName(lines[i])
+			}
+			resp = strings.Join(lines, "\n")
 		}
 		fmt.Print(resp)
 	case *serverMode:


### PR DESCRIPTION
A crafted filename can inject terminal escape sequences through `lf -remote "query <id> files"`
#2540 fixed the same issue for -print-last-dir/-print-selection but I missed this path (or there was a reason we didn't cover this?)

Poc:
```
mkdir /tmp/poc && cd /tmp/poc
touch -- "$(printf 'x\033]52;c;cHduZWQ=\007')"
lf
# press $ and run:
lf -remote "query $id files"
# clipboard now contains "pwned"
```