### PR TITLE
fix: copy loop when pasting into copied path

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -129,6 +129,9 @@ func copyAll(srcs []string, dstDir string, preserve []string) (nums chan int64, 
 					errs <- fmt.Errorf("walk: %w", err)
 					return nil
 				}
+				if info.IsDir() && filepath.Clean(path) == filepath.Clean(dst) {
+					return filepath.SkipDir // don't descend into the copy being made
+				}
 				rel, err := filepath.Rel(src, path)
 				if err != nil {
 					errs <- fmt.Errorf("relative: %w", err)


### PR DESCRIPTION
Pasting a folder into one of its own subdirectories caused the copy function to loop and recurse.
This skips the destination directory, so the copy is a one-time snapshot of the source.

The alternative as done by coreutils cp would be to fail the attempt to copy inside the yanked path, but this is simpler (and less code) and there may be use cases to allow this.

Note to trigger the issue, paste to a subdirectory not directly into the copied patch because the later often gets lucky and succeeds while pasting into sub dirs reliably crashes the application with error.