### PR TITLE
fix: unify file permissions

### DIFF
--- a/app.go
+++ b/app.go
@@ -160,11 +160,11 @@ func loadFiles() (clipboard clipboard, err error) {
 }
 
 func saveFiles(clipboard clipboard) error {
-	if err := os.MkdirAll(filepath.Dir(gFilesPath), os.ModePerm); err != nil {
+	if err := os.MkdirAll(filepath.Dir(gFilesPath), 0o700); err != nil {
 		return fmt.Errorf("creating data directory: %w", err)
 	}
 
-	files, err := os.Create(gFilesPath)
+	files, err := os.OpenFile(gFilesPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("opening file selections file: %w", err)
 	}
@@ -240,11 +240,11 @@ func (app *app) writeHistory() error {
 		app.cmdHistory = app.cmdHistory[len(app.cmdHistory)-1000:]
 	}
 
-	if err := os.MkdirAll(filepath.Dir(gHistoryPath), os.ModePerm); err != nil {
+	if err := os.MkdirAll(filepath.Dir(gHistoryPath), 0o700); err != nil {
 		return fmt.Errorf("creating data directory: %w", err)
 	}
 
-	f, err := os.Create(gHistoryPath)
+	f, err := os.OpenFile(gHistoryPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("creating history file: %w", err)
 	}

--- a/nav.go
+++ b/nav.go
@@ -1867,11 +1867,11 @@ func (nav *nav) readMarks() error {
 }
 
 func (nav *nav) writeMarks() error {
-	if err := os.MkdirAll(filepath.Dir(gMarksPath), os.ModePerm); err != nil {
+	if err := os.MkdirAll(filepath.Dir(gMarksPath), 0o700); err != nil {
 		return fmt.Errorf("creating data directory: %w", err)
 	}
 
-	f, err := os.Create(gMarksPath)
+	f, err := os.OpenFile(gMarksPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("creating marks file: %w", err)
 	}
@@ -1929,11 +1929,11 @@ func (nav *nav) readTags() error {
 }
 
 func (nav *nav) writeTags() error {
-	if err := os.MkdirAll(filepath.Dir(gTagsPath), os.ModePerm); err != nil {
+	if err := os.MkdirAll(filepath.Dir(gTagsPath), 0o700); err != nil {
 		return fmt.Errorf("creating data directory: %w", err)
 	}
 
-	f, err := os.Create(gTagsPath)
+	f, err := os.OpenFile(gTagsPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("creating tags file: %w", err)
 	}


### PR DESCRIPTION
The files like history, marks, tags do not restrict access permissions to be only user readable. This is already done for log files and the runtime dir, so this PR just adds the same for all relevant files that are created to avoid a potential issue on multi user systems.
