### PR TITLE
Fix: use Lstat like copyAll

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -1424,7 +1424,7 @@ func (nav *nav) moveAsync(app *app, srcs []string, dstDir string) {
 		file := filepath.Base(src)
 		dst := filepath.Join(dstDir, file)
 
-		if dstStat, err := os.Stat(dst); err == nil {
+		if dstStat, err := os.Lstat(dst); err == nil {
 			if os.SameFile(srcStat, dstStat) {
 				sendErr("rename %s %s: source and destination are the same file", src, dst)
 				continue


### PR DESCRIPTION
Broken symlinks are silently overwritten on move, whcih can simply be avoided by switching to Lstat which is already used in copyAll anyway. 