### PR TITLE
Fix: dont silently drop pasted files with newlines

### DIFF
--- a/app.go
+++ b/app.go
@@ -160,6 +160,13 @@ func loadFiles() (clipboard clipboard, err error) {
 }
 
 func saveFiles(clipboard clipboard) error {
+	for _, path := range clipboard.paths {
+		// the clipboard file stores one path per line so a newline cannot be saved
+		if strings.ContainsAny(path, "\n\r") {
+			return fmt.Errorf("cannot copy %s because the name contains a newline", path)
+		}
+	}
+
 	if err := os.MkdirAll(filepath.Dir(gFilesPath), 0o700); err != nil {
 		return fmt.Errorf("creating data directory: %w", err)
 	}
@@ -183,10 +190,6 @@ func saveFiles(clipboard clipboard) error {
 	}
 
 	for _, path := range clipboard.paths {
-		if strings.ContainsAny(path, "\n\r") {
-			log.Printf("clipboard: skipping path with newline: %q", path)
-			continue
-		}
 		if _, err := fmt.Fprintln(files, path); err != nil {
 			return fmt.Errorf("write path to file: %w", err)
 		}


### PR DESCRIPTION
When pasting files with newlines in their name, the operation silently fails instead of throwing an error.

POC:

```
mkdir -p /tmp/lf-newline-demo/dest
touch "/tmp/lf-newline-demo/$(printf 'report\nDRAFT.txt')"
touch /tmp/lf-newline-demo/keep.txt
lf /tmp/lf-newline-demo
```
copy and paste in lf