### PR TITLE
fix self-copy guard

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -124,7 +124,7 @@ func copyAll(srcs []string, dstDir string, preserve []string) (nums chan int64, 
 				dst = newPath
 			}
 
-			if rel, err := filepath.Rel(src, dst); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+			if rel, err := filepath.Rel(src, dst); err == nil && rel != "." && filepath.IsLocal(rel) {
 				errs <- fmt.Errorf("cannot copy %s into a subdirectory of itself", src)
 				continue
 			}


### PR DESCRIPTION
A destination like proj/..x slipped past the !HasPrefix(rel, "..") check, so copyAll copied the folder into itself until PATH_MAX. filepath.IsLocal implements the clean check intended for exactly this use case and correctly reports paths that stay inside the source.