### PR TITLE
fix regression from #2620: warn without blocking paste

### DIFF
--- a/app.go
+++ b/app.go
@@ -160,13 +160,6 @@ func loadFiles() (clipboard clipboard, err error) {
 }
 
 func saveFiles(clipboard clipboard) error {
-	for _, path := range clipboard.paths {
-		// the clipboard file stores one path per line so a newline cannot be saved
-		if strings.ContainsAny(path, "\n\r") {
-			return fmt.Errorf("cannot copy %s because the name contains a newline", path)
-		}
-	}
-
 	if err := os.MkdirAll(filepath.Dir(gFilesPath), 0o700); err != nil {
 		return fmt.Errorf("creating data directory: %w", err)
 	}
@@ -190,6 +183,10 @@ func saveFiles(clipboard clipboard) error {
 	}
 
 	for _, path := range clipboard.paths {
+		if strings.ContainsAny(path, "\n\r") {
+			log.Printf("clipboard: skipping path with newline: %q", path)
+			continue
+		}
 		if _, err := fmt.Fprintln(files, path); err != nil {
 			return fmt.Errorf("write path to file: %w", err)
 		}

--- a/eval.go
+++ b/eval.go
@@ -1220,6 +1220,12 @@ func (e *callExpr) eval(app *app, _ []string) {
 			app.ui.echoerrf("copy: %s", err)
 			return
 		}
+		for _, path := range app.nav.clipboard.paths {
+			if strings.ContainsAny(path, "\n\r") {
+				app.ui.echoerrf("copy: cannot copy %s because the name contains a newline", path)
+				break
+			}
+		}
 		app.nav.unselect()
 		if gSingleMode {
 			if err := app.nav.sync(); err != nil {
@@ -1236,6 +1242,12 @@ func (e *callExpr) eval(app *app, _ []string) {
 		if err := app.nav.save(clipboardCut); err != nil {
 			app.ui.echoerrf("cut: %s", err)
 			return
+		}
+		for _, path := range app.nav.clipboard.paths {
+			if strings.ContainsAny(path, "\n\r") {
+				app.ui.echoerrf("cut: cannot move %s because the name contains a newline", path)
+				break
+			}
 		}
 		app.nav.unselect()
 		if gSingleMode {


### PR DESCRIPTION
This reverts #2620 and instead of breaking the paste function, it only prints a warning and keeps things simple