### PR TITLE
fix: preview flashing for actively written files

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -137,7 +137,7 @@ func (win *win) printMsg(screen tcell.Screen, s string) {
 
 func (win *win) printReg(screen tcell.Screen, reg *reg, sxs *sixelScreen, previewTimer *time.Timer) {
 	switch {
-	case reg.loading:
+	case reg.loading && len(reg.lines) == 0:
 		if time.Since(reg.loadTime) > previewLoadingDelay {
 			win.printMsg(screen, "loading...")
 		} else {


### PR DESCRIPTION
While a file is being written to, lf reloads its preview repeatedly and blanked it to a "loading" state on each reload even though the previous content was still available, causing annoying preview flashing. With this patch it keeps the previous content shown until the new one is ready.

This is most reproducible when downloading large files which are then selected for preview in lf. Tested with mediainfo as preview content