### PR TITLE
fix: infinite loop when paste cannot find a free name

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -98,6 +98,31 @@ func copyFile(src, dst string, preserve []string, info os.FileInfo, nums chan<- 
 	}
 }
 
+// dupFilePath returns a path for a duplicate of name in dstDir based on the dupfilefmt option.
+func dupFilePath(dstDir, name string, info os.FileInfo) (string, error) {
+	ext := getFileExtension(info)
+	basename := strings.TrimSuffix(name, ext)
+	hasNum := strings.Contains(gOpts.dupfilefmt, "%n")
+
+	for i := 1; ; i++ {
+		dupName := strings.ReplaceAll(gOpts.dupfilefmt, "%f", name)
+		dupName = strings.ReplaceAll(dupName, "%b", basename)
+		dupName = strings.ReplaceAll(dupName, "%e", ext)
+		dupName = strings.ReplaceAll(dupName, "%n", strconv.Itoa(i))
+		path := filepath.Join(dstDir, dupName)
+
+		_, err := os.Lstat(path)
+		switch {
+		case os.IsNotExist(err):
+			return path, nil
+		case err != nil:
+			return "", fmt.Errorf("finding duplicate name for %s: %w", name, err)
+		case !hasNum:
+			return "", fmt.Errorf("finding duplicate name for %s: dupfilefmt must contain %%n", name)
+		}
+	}
+}
+
 func copyAll(srcs []string, dstDir string, preserve []string) (nums chan int64, errs chan error) {
 	nums = make(chan int64, 1024)
 	errs = make(chan error, 1024)
@@ -110,18 +135,10 @@ func copyAll(srcs []string, dstDir string, preserve []string) (nums chan int64, 
 			dst := filepath.Join(dstDir, file)
 
 			if lstat, err := os.Lstat(dst); err == nil {
-				ext := getFileExtension(lstat)
-				basename := file[:len(file)-len(ext)]
-				var newPath string
-				for i := 1; !os.IsNotExist(err); i++ {
-					file = strings.ReplaceAll(gOpts.dupfilefmt, "%f", basename+ext)
-					file = strings.ReplaceAll(file, "%b", basename)
-					file = strings.ReplaceAll(file, "%e", ext)
-					file = strings.ReplaceAll(file, "%n", strconv.Itoa(i))
-					newPath = filepath.Join(dstDir, file)
-					_, err = os.Lstat(newPath)
+				if dst, err = dupFilePath(dstDir, file, lstat); err != nil {
+					errs <- err
+					continue
 				}
-				dst = newPath
 			}
 
 			if rel, err := filepath.Rel(src, dst); err == nil && rel != "." && filepath.IsLocal(rel) {

--- a/copy_test.go
+++ b/copy_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCopyAllDupName(t *testing.T) {
+	old := gOpts.dupfilefmt
+	defer func() { gOpts.dupfilefmt = old }()
+
+	tests := []struct {
+		name    string
+		format  string
+		file    string
+		wantErr bool
+	}{
+		{"duplicate with default format", "%f.~%n~", "file.txt", false},
+		{"name too long", "%f.~%n~", strings.Repeat("a", 255), true},
+		{"format without %n", "%f", "file.txt", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gOpts.dupfilefmt = test.format
+			dir := t.TempDir()
+			src := filepath.Join(dir, test.file)
+			if err := os.WriteFile(src, nil, 0o600); err != nil {
+				t.Skipf("creating %d-byte filename: %s", len(test.file), err)
+			}
+
+			// copying a file into its own directory forces a duplicate name
+			nums, errs := copyAll([]string{src}, dir, nil)
+			var gotErr bool
+			deadline := time.After(5 * time.Second)
+			for {
+				select {
+				case <-nums:
+				case err, ok := <-errs:
+					if !ok {
+						if gotErr != test.wantErr {
+							t.Errorf("expected error: %v, got error: %v", test.wantErr, gotErr)
+						}
+						return
+					}
+					t.Log(err)
+					gotErr = true
+				case <-deadline:
+					t.Fatal("copyAll did not finish, duplicate name loop is stuck")
+				}
+			}
+		})
+	}
+}

--- a/nav.go
+++ b/nav.go
@@ -1429,18 +1429,10 @@ func (nav *nav) moveAsync(app *app, srcs []string, dstDir string) {
 				sendErr("rename %s %s: source and destination are the same file", src, dst)
 				continue
 			}
-			ext := getFileExtension(dstStat)
-			basename := file[:len(file)-len(ext)]
-			var newPath string
-			for i := 1; !os.IsNotExist(err); i++ {
-				file = strings.ReplaceAll(gOpts.dupfilefmt, "%f", basename+ext)
-				file = strings.ReplaceAll(file, "%b", basename)
-				file = strings.ReplaceAll(file, "%e", ext)
-				file = strings.ReplaceAll(file, "%n", strconv.Itoa(i))
-				newPath = filepath.Join(dstDir, file)
-				_, err = os.Lstat(newPath)
+			if dst, err = dupFilePath(dstDir, file, dstStat); err != nil {
+				sendErr("%v", err)
+				continue
 			}
-			dst = newPath
 		}
 
 		if err := os.Rename(src, dst); err != nil {


### PR DESCRIPTION
When a pasted file name already exists, lf tries new names like file.~1~, file.~2~ etc. and only stops once a name is free. 
But when that files e.g. because the new name is too long for the file system lf retries forever. 
There are probably more cases where this can be triggered but the long name is the most obvious and easy to test

To trigger the issue, just create a filename with 255 characters (on ext4) and copy it in the same dir. since the appended ~N~ will exceed the limit, the loop will be infinite retries.
