### PR TITLE
fix: replace tabs in query tables

### DIFF
--- a/main.go
+++ b/main.go
@@ -349,7 +349,11 @@ Options:
 		if term.IsTerminal(int(os.Stdout.Fd())) {
 			lines := strings.Split(resp, "\n")
 			for i := range lines {
-				lines[i] = sanitizeName(lines[i])
+				cells := strings.Split(lines[i], "\t")
+				for j := range cells {
+					cells[j] = sanitizeName(cells[j])
+				}
+				lines[i] = strings.Join(cells, "\t")
 			}
 			resp = strings.Join(lines, "\n")
 		}

--- a/ui.go
+++ b/ui.go
@@ -1250,7 +1250,7 @@ func listBinds(binds map[string]map[string]expr) string {
 		return cmp.Compare(a.mode, b.mode)
 	})
 
-	t.Init(b, 0, gOpts.tabstop, 2, '\t', 0)
+	t.Init(b, 0, gOpts.tabstop, 2, ' ', 0)
 	fmt.Fprintln(t, "mode\tkey\tcommand")
 	for _, e := range entries {
 		fmt.Fprintf(t, "%s\t%s\t%s\n", e.mode, e.key, e.cmd)
@@ -1279,7 +1279,7 @@ func listCmds(cmds map[string]expr) string {
 	t := new(tabwriter.Writer)
 	b := new(bytes.Buffer)
 
-	t.Init(b, 0, gOpts.tabstop, 2, '\t', 0)
+	t.Init(b, 0, gOpts.tabstop, 2, ' ', 0)
 	fmt.Fprintln(t, "name\tcommand")
 	for _, k := range slices.Sorted(maps.Keys(cmds)) {
 		fmt.Fprintf(t, "%s\t%v\n", k, cmds[k])
@@ -1295,7 +1295,7 @@ func listJumps(jumps []string, ind int) string {
 
 	maxlength := len(strconv.Itoa(max(ind, len(jumps)-1-ind)))
 
-	t.Init(b, 0, gOpts.tabstop, 2, '\t', 0)
+	t.Init(b, 0, gOpts.tabstop, 2, ' ', 0)
 	fmt.Fprintln(t, "  jump\tpath")
 	// print jumps in order of most recent, Vim uses the opposite order
 	for i, path := range slices.Backward(jumps) {
@@ -1319,7 +1319,7 @@ func listHistory(history []string) string {
 
 	maxlength := len(strconv.Itoa(len(history)))
 
-	t.Init(b, 0, gOpts.tabstop, 2, '\t', 0)
+	t.Init(b, 0, gOpts.tabstop, 2, ' ', 0)
 	fmt.Fprintln(t, "number\tcommand")
 	for i, cmd := range history {
 		fmt.Fprintf(t, "%*d\t%s\n", maxlength, i+1, cmd)

--- a/ui.go
+++ b/ui.go
@@ -1250,7 +1250,7 @@ func listBinds(binds map[string]map[string]expr) string {
 		return cmp.Compare(a.mode, b.mode)
 	})
 
-	t.Init(b, 0, gOpts.tabstop, 2, ' ', 0)
+	t.Init(b, 0, gOpts.tabstop, 2, '\t', 0)
 	fmt.Fprintln(t, "mode\tkey\tcommand")
 	for _, e := range entries {
 		fmt.Fprintf(t, "%s\t%s\t%s\n", e.mode, e.key, e.cmd)
@@ -1279,7 +1279,7 @@ func listCmds(cmds map[string]expr) string {
 	t := new(tabwriter.Writer)
 	b := new(bytes.Buffer)
 
-	t.Init(b, 0, gOpts.tabstop, 2, ' ', 0)
+	t.Init(b, 0, gOpts.tabstop, 2, '\t', 0)
 	fmt.Fprintln(t, "name\tcommand")
 	for _, k := range slices.Sorted(maps.Keys(cmds)) {
 		fmt.Fprintf(t, "%s\t%v\n", k, cmds[k])
@@ -1295,10 +1295,13 @@ func listJumps(jumps []string, ind int) string {
 
 	maxlength := len(strconv.Itoa(max(ind, len(jumps)-1-ind)))
 
-	t.Init(b, 0, gOpts.tabstop, 2, ' ', 0)
+	t.Init(b, 0, gOpts.tabstop, 2, '\t', 0)
 	fmt.Fprintln(t, "  jump\tpath")
 	// print jumps in order of most recent, Vim uses the opposite order
 	for i, path := range slices.Backward(jumps) {
+		if strings.ContainsAny(path, "\n\r\t") {
+			continue
+		}
 		switch {
 		case i < ind:
 			fmt.Fprintf(t, "  %*d\t%s\n", maxlength, ind-i, path)
@@ -1319,7 +1322,7 @@ func listHistory(history []string) string {
 
 	maxlength := len(strconv.Itoa(len(history)))
 
-	t.Init(b, 0, gOpts.tabstop, 2, ' ', 0)
+	t.Init(b, 0, gOpts.tabstop, 2, '\t', 0)
 	fmt.Fprintln(t, "number\tcommand")
 	for i, cmd := range history {
 		fmt.Fprintf(t, "%*d\t%s\n", maxlength, i+1, cmd)
@@ -1352,7 +1355,7 @@ func listFilesInCurrDir(nav *nav) string {
 
 	b := new(strings.Builder)
 	for _, file := range dir.files {
-		if strings.ContainsAny(file.path, "\n\r") {
+		if strings.ContainsAny(file.path, "\n\r\t") {
 			continue
 		}
 		fmt.Fprintln(b, file.path)


### PR DESCRIPTION
Fix for a regression from #2603
https://github.com/gokcehan/lf/pull/2603#issuecomment-4947539988

the sanitizeName function applies on the entire line, including the tab that lf adds for the table display, wrongly replacing the intended tab.

The most simple way is to just use space instead of tabs, the results should be the same.