### PR TITLE
fix: restrict preloading files

### DIFF
--- a/app.go
+++ b/app.go
@@ -471,17 +471,6 @@ func (app *app) loop() {
 
 			if r, ok := app.nav.regCache[f.path]; ok {
 				app.nav.checkReg(r)
-			} else {
-				r = &reg{loading: true, loadTime: time.Now(), path: f.path}
-				app.nav.regCache[f.path] = r
-				if gOpts.preload {
-					select {
-					case app.nav.preloadChan <- f.path:
-					default:
-					}
-				} else {
-					app.nav.previewChan <- f.path
-				}
 			}
 			onLoad(app, []string{f.path})
 			app.ui.draw(app.nav)

--- a/ui.go
+++ b/ui.go
@@ -1028,9 +1028,12 @@ func (ui *ui) drawPreview(nav *nav, context *dirContext) {
 
 	if gOpts.preview {
 		if curr.isPreviewable() {
-			if reg, ok := nav.regCache[curr.path]; ok {
-				win.printReg(ui.screen, reg, &ui.sxScreen, nav.previewTimer)
+			reg, ok := nav.regCache[curr.path]
+			if !ok {
+				// the shown file can lose its cache entry, e.g. a save that deletes and recreates it
+				reg = nav.loadReg(curr.path, false)
 			}
+			win.printReg(ui.screen, reg, &ui.sxScreen, nav.previewTimer)
 		} else if curr.IsDir() {
 			ui.sxScreen.lastFile = ""
 			dir := nav.getDir(curr.path)


### PR DESCRIPTION
Any change in a watched directory pushed every modified path to the previewer causing unrelated files to generate previews even outside the current directory (unlrelated to preload)

Fixes #2646

Note:
This is a significant regression and should be part of the next release.