### PR TITLE
fix: drop readline markers from colored prompts

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -660,7 +660,9 @@ func (ui *ui) drawPromptLine(nav *nav) {
 
 	var prompt string
 
-	prompt = strings.ReplaceAll(gOpts.promptfmt, "%u", gUser.Username)
+	prompt = strings.ReplaceAll(gOpts.promptfmt, "\x01", "")
+	prompt = strings.ReplaceAll(prompt, "\x02", "")
+	prompt = strings.ReplaceAll(prompt, "%u", gUser.Username)
 	prompt = strings.ReplaceAll(prompt, "%h", gHostname)
 	prompt = strings.ReplaceAll(prompt, "%f", fname)
 

--- a/ui.go
+++ b/ui.go
@@ -660,6 +660,7 @@ func (ui *ui) drawPromptLine(nav *nav) {
 
 	var prompt string
 
+	// git style colored prompts contain hidden bytes that lf would print as extra characters
 	prompt = strings.ReplaceAll(gOpts.promptfmt, "\x01", "")
 	prompt = strings.ReplaceAll(prompt, "\x02", "")
 	prompt = strings.ReplaceAll(prompt, "%u", gUser.Username)


### PR DESCRIPTION
fixes #2656