### PR TITLE
Wait briefly for the server socket in lf -remote

### DIFF
--- a/client.go
+++ b/client.go
@@ -201,8 +201,37 @@ func readExpr() <-chan expr {
 	return ch
 }
 
+// dialServer connects to the server socket, briefly waiting for the socket
+// file to appear when a starting lf instance has not created it yet. An
+// lfrc command like `lf -remote "send $id ..."` races the server process
+// that this very instance just spawned, and without the wait the command
+// is silently dropped (#2660). The wait only happens while the socket file
+// is absent, so a genuinely stopped server still fails without delay.
+func dialServer() (net.Conn, error) {
+	const (
+		retryDelay  = 20 * time.Millisecond
+		retryBudget = 2 * time.Second
+	)
+	deadline := time.Now().Add(retryBudget)
+	for {
+		c, err := net.Dial("unix", gSocketPath)
+		if err == nil {
+			return c, nil
+		}
+		if _, statErr := os.Stat(gSocketPath); statErr == nil || !os.IsNotExist(statErr) {
+			// The socket exists (or its state is unknown) — the dial
+			// failure is real, not the startup race.
+			return nil, err
+		}
+		if time.Now().After(deadline) {
+			return nil, err
+		}
+		time.Sleep(retryDelay)
+	}
+}
+
 func remote(req string) (string, error) {
-	c, err := net.Dial("unix", gSocketPath)
+	c, err := dialServer()
 	if err != nil {
 		return "", fmt.Errorf("connecting to server: %w", err)
 	}

--- a/client_remote_test.go
+++ b/client_remote_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestDialServerWaitsForStartupRace pins #2660: an lfrc `lf -remote "send
+// $id ..."` runs while this lf instance is still spawning the server, so
+// the socket file may not exist yet. dialServer must wait briefly and then
+// connect once the server creates the socket.
+func TestDialServerWaitsForStartupRace(t *testing.T) {
+	dir := t.TempDir()
+	gSocketPath = filepath.Join(dir, "lf.sock")
+	t.Cleanup(func() { gSocketPath = gDefaultSocketPath })
+
+	ready := make(chan net.Listener, 1)
+	go func() {
+		// Simulate the server process creating the socket mid-race.
+		time.Sleep(300 * time.Millisecond)
+		l, err := net.Listen("unix", gSocketPath)
+		if err != nil {
+			close(ready)
+			return
+		}
+		ready <- l
+		go func() {
+			for {
+				conn, err := l.Accept()
+				if err != nil {
+					return
+				}
+				conn.Close()
+			}
+		}()
+	}()
+
+	start := time.Now()
+	conn, err := dialServer()
+	if err != nil {
+		t.Fatalf("dialServer: %v", err)
+	}
+	defer conn.Close()
+
+	if elapsed := time.Since(start); elapsed < 250*time.Millisecond {
+		t.Errorf("dialServer connected after %v, expected it to wait for the late socket", elapsed)
+	}
+	if l, ok := <-ready; ok {
+		defer l.Close()
+	}
+}
+
+// TestDialServerFailsWhenServerNeverStarts ensures the wait is bounded: a
+// socket that never appears errors out instead of hanging.
+func TestDialServerFailsWhenServerNeverStarts(t *testing.T) {
+	dir := t.TempDir()
+	gSocketPath = filepath.Join(dir, "lf.sock")
+	t.Cleanup(func() { gSocketPath = gDefaultSocketPath })
+
+	if _, err := os.Stat(gSocketPath); !os.IsNotExist(err) {
+		t.Fatalf("precondition: no socket at %s", gSocketPath)
+	}
+
+	start := time.Now()
+	_, err := dialServer()
+	if err == nil {
+		t.Fatal("dialServer should fail when the server never starts")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("dialServer took %v to fail, wait budget is 2s", elapsed)
+	}
+}
+
+// TestDialServerFailsFastWhenSocketExistsButDead ensures the retry only
+// covers the missing-socket race: a socket file that exists but refuses
+// connections errors immediately.
+func TestDialServerFailsFastWhenSocketExistsButDead(t *testing.T) {
+	dir := t.TempDir()
+	gSocketPath = filepath.Join(dir, "lf.sock")
+	t.Cleanup(func() { gSocketPath = gDefaultSocketPath })
+
+	// A path that exists but is not a listening socket (a plain file): the
+	// stat succeeds, so dialServer must not enter the retry loop.
+	if err := os.WriteFile(gSocketPath, []byte("not a socket"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(gSocketPath) })
+
+	start := time.Now()
+	_, err := dialServer()
+	if err == nil {
+		t.Fatal("dialServer should fail on a dead socket")
+	}
+	if elapsed := time.Since(start); elapsed > 250*time.Millisecond {
+		t.Errorf("dialServer took %v on a dead socket, expected immediate failure", elapsed)
+	}
+}


### PR DESCRIPTION
Fixes #2660.

## Root cause

An lfrc command like `lf -remote "send $id ..."` races the server process that this very lf instance spawns during startup (`checkServer()` → `startServer()` → the `lf -server` child creating the socket). When the async lfrc command wins the race, `remote()` dials a socket that does not exist yet, the send is dropped, and — as the issue shows — the failure only lands in lf's log file, invisible to the user.

## Fix

`remote()` now dials through `dialServer()`, which retries every 20 ms for up to 2 s — **but only while the socket file is absent**:

- the moment the file appears, the dial proceeds (normally succeeding);
- a socket that exists but refuses connections fails immediately — no retry delay is added to any real failure;
- a server that never starts errors out after the bounded 2 s budget instead of hanging, preserving `lf -remote`'s error path.

## Tests

`client_remote_test.go`:

- `TestDialServerWaitsForStartupRace` — the socket is created 300 ms into the call; `dialServer` waits and then connects;
- `TestDialServerFailsWhenServerNeverStarts` — the wait is bounded (~2 s, asserted under 5 s);
- `TestDialServerFailsFastWhenSocketExistsButDead` — a path that exists but is not a listening socket fails in milliseconds.

`go build`, `go vet`, and the package tests pass (the new tests use only a temp-dir socket).