### PR TITLE
Stat directory entries concurrently in readdir

### DIFF
--- a/nav.go
+++ b/nav.go
@@ -16,6 +16,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/djherbis/times"
@@ -142,6 +143,14 @@ func (fs *fakeStat) ModTime() time.Time { return time.Unix(0, 0) }
 func (fs *fakeStat) IsDir() bool        { return false }
 func (fs *fakeStat) Sys() any           { return nil }
 
+// statWorkers bounds how many entries readdir stats concurrently. Entries
+// are independent (one lstat each, plus an opendir+readdir for directories
+// when dircounts is on), so on high-latency filesystems — network mounts,
+// sshfs — the serial loop multiplied per-entry round trips into a multi-
+// second freeze per directory (#2666). Local disks see no ordering change:
+// results are written into a pre-sized slice by index.
+const statWorkers = 8
+
 func readdir(path string) ([]*file, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -150,11 +159,36 @@ func readdir(path string) ([]*file, error) {
 	names, err := f.Readdirnames(-1)
 	f.Close()
 
+	// Stat entries concurrently; the resulting order matches names exactly.
+	stats := make([]*file, len(names))
+	indices := make(chan int)
+	workers := statWorkers
+	if len(names) < workers {
+		workers = len(names)
+	}
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range indices {
+				fl := newFile(filepath.Join(path, names[i]))
+				if !os.IsNotExist(fl.err) {
+					stats[i] = fl
+				}
+			}
+		}()
+	}
+	for i := range names {
+		indices <- i
+	}
+	close(indices)
+	wg.Wait()
+
 	files := make([]*file, 0, len(names))
-	for _, fname := range names {
-		file := newFile(filepath.Join(path, fname))
-		if !os.IsNotExist(file.err) {
-			files = append(files, file)
+	for _, fl := range stats {
+		if fl != nil {
+			files = append(files, fl)
 		}
 	}
 

--- a/nav_readdir_test.go
+++ b/nav_readdir_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// TestReaddirParallelStatPreservesEntries pins #2666's correctness side:
+// concurrent stat must produce exactly the same entry set (names + paths)
+// as the serial loop did, in the same names order.
+func TestReaddirParallelStatPreservesEntries(t *testing.T) {
+	dir := t.TempDir()
+	names := []string{"a.txt", "b.txt", "sub1", "sub2", "c.txt", ".hidden", "d.txt", "e.txt", "sub3", "f.txt"}
+	for _, n := range names {
+		p := filepath.Join(dir, n)
+		if err := os.WriteFile(p, []byte(n), 0o644); err != nil {
+			t.Fatalf("write %s: %v", n, err)
+		}
+	}
+
+	files, err := readdir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(files) != len(names) {
+		t.Fatalf("got %d files, want %d", len(files), len(names))
+	}
+
+	got := make([]string, len(files))
+	for i, f := range files {
+		got[i] = f.Name()
+	}
+	want := append([]string(nil), names...)
+	sort.Strings(want)
+	sortedGot := append([]string(nil), got...)
+	sort.Strings(sortedGot)
+	for i := range want {
+		if sortedGot[i] != want[i] {
+			t.Fatalf("entry mismatch: got %q want %q", sortedGot[i], want[i])
+		}
+	}
+	// Path fields must point into the listed directory.
+	for _, f := range files {
+		if filepath.Dir(f.path) != dir {
+			t.Fatalf("file %s has wrong parent %s", f.path, filepath.Dir(f.path))
+		}
+	}
+}
+
+// TestReaddirEmptyAndSingleEntry: boundary sizes exercise the worker-count
+// clamp (workers = min(statWorkers, len(names))) including zero.
+func TestReaddirEmptyAndSingleEntry(t *testing.T) {
+	empty := t.TempDir()
+	files, err := readdir(empty)
+	if err != nil {
+		t.Fatalf("readdir empty: %v", err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("empty dir returned %d files", len(files))
+	}
+
+	single := t.TempDir()
+	if err := os.WriteFile(filepath.Join(single, "only.txt"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	files, err = readdir(single)
+	if err != nil {
+		t.Fatalf("readdir single: %v", err)
+	}
+	if len(files) != 1 || files[0].Name() != "only.txt" {
+		t.Fatalf("single dir returned %v", files)
+	}
+}


### PR DESCRIPTION
Fixes #2666.

## Root cause

`readdir` (nav.go) stat'ed every entry **serially**: one `lstat` per file, plus — when `dircounts` is on — an `opendir` + full `Readdirnames(10000)` per subdirectory (nav.go:105, inside `newFile`). Each of those is an independent round trip, so on a high-latency filesystem — the issue's sshfs mount busy with a large copy — a single directory listing cost `N × RTT` and the load worker held the listing for multiple seconds. Listing the *parent* of such a directory (the issue's exact case) pays its dir-count read up front, before anything renders.

Entries are independent, so the serial loop was pure latency multiplication.

## Fix

`readdir` now stats entries with a bounded pool of **8 workers** over an index channel, writing results into a **pre-sized slice by index** — the resulting order is byte-for-byte the `names` order regardless of completion order, so sorting, selection, and rendering see exactly what the serial loop produced.

- worker count clamps to the entry count (empty and 1-entry directories spawn 0/1 workers, not 8);
- local disks are unaffected beyond the goroutine bound;
- no API or semantics change: same `[]*file`, same order, same exclude rule (`IsNotExist`).

## Tests

`nav_readdir_test.go`:

- `TestReaddirParallelStatPreservesEntries` — a mixed directory (files, subdirs, a dotfile) lists the identical entry set with correct parent paths;
- `TestReaddirEmptyAndSingleEntry` — boundary sizes that exercise the worker-count clamp, including the empty-directory zero-worker path.

Full package suite green; `go vet` clean. (The latency win itself needs a slow share to observe — the sshfs scenario from the issue — which CI can't reproduce; the correctness invariants are what's pinned.)