### PR TITLE
Perf: cleanup redundant getwd calls

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ var (
 	gConfigPath     string
 	gCommands       arrayFlag
 	gVersion        string
+	gInitialWd      string
 )
 
 func (a *arrayFlag) Set(v string) error {
@@ -74,11 +75,7 @@ func exportEnvVars() {
 	os.Setenv("PAGER", envPager)
 	os.Setenv("SHELL", envShell)
 
-	dir, err := os.Getwd()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "getting current directory: %s\n", err)
-	}
-	os.Setenv("OLDPWD", dir)
+	os.Setenv("OLDPWD", gInitialWd)
 
 	level, err := strconv.Atoi(envLevel)
 	if err != nil {
@@ -371,11 +368,15 @@ Options:
 
 		gClientID = os.Getpid()
 
+		var err error
+		gInitialWd, err = os.Getwd()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "getting current directory: %s\n", err)
+		}
+
 		switch flag.NArg() {
 		case 0:
-			_, err := os.Getwd()
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "getting current directory: %s\n", err)
 				os.Exit(2)
 			}
 		case 1:

--- a/nav.go
+++ b/nav.go
@@ -1954,11 +1954,7 @@ func (nav *nav) writeTags() error {
 
 func (nav *nav) currDir() *dir {
 	if len(nav.dirPaths) == 0 {
-		wd, err := os.Getwd()
-		if err != nil {
-			log.Printf("getting current directory: %s", err)
-		}
-		nav.loadDirs(wd)
+		nav.loadDirs(gInitialWd)
 	}
 
 	path := nav.dirPaths[len(nav.dirPaths)-1]

--- a/nav.go
+++ b/nav.go
@@ -1954,7 +1954,11 @@ func (nav *nav) writeTags() error {
 
 func (nav *nav) currDir() *dir {
 	if len(nav.dirPaths) == 0 {
-		nav.loadDirs(gInitialWd)
+		wd, err := os.Getwd()
+		if err != nil {
+			log.Printf("getting current directory: %s", err)
+		}
+		nav.loadDirs(wd)
 	}
 
 	path := nav.dirPaths[len(nav.dirPaths)-1]


### PR DESCRIPTION
During startup os.Getwd was called three times before the first ui draw.
once to check the working directory, once to set oldpwd, and again to load the initial directory. 
Not sure this has a measurable impact but it does appear to be redundant work that can just be avoided

The working directory is now read once in main before the screen is initialized