### PR TITLE
Fix: Main loop blocked by double quit

### DIFF
--- a/app.go
+++ b/app.go
@@ -95,6 +95,14 @@ func (app *app) quit() {
 	}
 }
 
+// requestQuit signals the main loop to quit and never blocks when a request is already pending.
+func (app *app) requestQuit() {
+	select {
+	case app.quitChan <- struct{}{}:
+	default:
+	}
+}
+
 func (app *app) readFile(path string) {
 	log.Printf("reading file: %s", path)
 

--- a/eval.go
+++ b/eval.go
@@ -1046,7 +1046,7 @@ func (e *callExpr) eval(app *app, _ []string) {
 
 	switch e.name {
 	case "quit":
-		app.quitChan <- struct{}{}
+		app.requestQuit()
 	case "up":
 		if app.nav.up(e.count) {
 			app.ui.loadFile(app, true)
@@ -1111,7 +1111,7 @@ func (e *callExpr) eval(app *app, _ []string) {
 		} else {
 			if gSelectionPath != "" || gPrintSelection {
 				app.selectionOut, _ = app.nav.currFileOrSelections()
-				app.quitChan <- struct{}{}
+				app.requestQuit()
 				return
 			}
 


### PR DESCRIPTION
The quit command sends on a channel with one slot from the main loop, which is also the only receiver. A second quit before the loop reads the first one blocks forever. When the application is busy and an impatient user presses q twice this triggers the bug.