### PR TITLE
Fix: copy read-only files correctly

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -104,6 +104,11 @@ func copyAll(srcs []string, dstDir string, preserve []string) (nums chan int64, 
 
 	go func() {
 		dirInfos := make(map[string]os.FileInfo)
+		type dirMode struct {
+			path string
+			mode os.FileMode
+		}
+		var dirModes []dirMode
 
 		for _, src := range srcs {
 			file := filepath.Base(src)
@@ -148,6 +153,14 @@ func copyAll(srcs []string, dstDir string, preserve []string) (nums chan int64, 
 					}
 					if err := os.MkdirAll(newPath, dstMode); err != nil {
 						errs <- fmt.Errorf("mkdir: %w", err)
+					} else if stat, err := os.Stat(newPath); err != nil {
+						errs <- fmt.Errorf("stat: %w", err)
+					} else if stat.Mode()&0o300 != 0o300 {
+						// open the directory for writing until its content is copied
+						dirModes = append(dirModes, dirMode{newPath, stat.Mode()})
+						if err := os.Chmod(newPath, stat.Mode()|0o300); err != nil {
+							errs <- fmt.Errorf("chmod: %w", err)
+						}
 					}
 					if slices.Contains(preserve, "timestamps") {
 						dirInfos[newPath] = info
@@ -177,6 +190,13 @@ func copyAll(srcs []string, dstDir string, preserve []string) (nums chan int64, 
 			mtime := info.ModTime()
 			if err := os.Chtimes(path, atime, mtime); err != nil {
 				errs <- err
+			}
+		}
+
+		// restore the modes of directories that were opened for writing
+		for _, d := range slices.Backward(dirModes) {
+			if err := os.Chmod(d.path, d.mode); err != nil {
+				errs <- fmt.Errorf("chmod: %w", err)
 			}
 		}
 


### PR DESCRIPTION
Copying a directory whose mode has no write bit creates the directory in the destination without any content, because lf creates it with the mode of the source before it copies the files into it.

This happens for example when copying files from the the go module cache that all have have permission mode 0555

the copy operation fails with an error at least

Reproduction:
```
mkdir -p /tmp/l/ro /tmp/l/dst
echo x > /tmp/l/ro/f
chmod 555 /tmp/l/ro
lf -log /tmp/l/log /tmp/l
```

In lf copy the ro dir and paste into dst /tmp/l/dst/ro is created with mode 0555 and the attempt to write files inside fails with "permisison denied"

Note: cp behaves the same way, but there is a theoretical race condition that this adds (which also exists in coreutils cp)