### PR TITLE
Fix: preserve option not working

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -12,6 +12,9 @@ import (
 	"github.com/djherbis/times"
 )
 
+// process umask at startup
+var gUmask = getUmask()
+
 type ProgressWriter struct {
 	writer io.Writer
 	nums   chan<- int64
@@ -82,7 +85,7 @@ func copyFile(src, dst string, preserve []string, info os.FileInfo, nums chan<- 
 	}
 
 	// OpenFile reduces the given mode by the umask
-	if slices.Contains(preserve, "mode") {
+	if slices.Contains(preserve, "mode") && info.Mode()&gUmask != 0 {
 		if err := w.Chmod(info.Mode() &^ (os.ModeSetuid | os.ModeSetgid)); err != nil {
 			errs <- err
 		}

--- a/copy.go
+++ b/copy.go
@@ -81,6 +81,13 @@ func copyFile(src, dst string, preserve []string, info os.FileInfo, nums chan<- 
 		return
 	}
 
+	// OpenFile reduces the given mode by the umask
+	if slices.Contains(preserve, "mode") {
+		if err := w.Chmod(info.Mode() &^ (os.ModeSetuid | os.ModeSetgid)); err != nil {
+			errs <- err
+		}
+	}
+
 	if err := w.Close(); err != nil {
 		errs <- err
 		if err = os.Remove(dst); err != nil {

--- a/os.go
+++ b/os.go
@@ -192,6 +192,13 @@ func setUserUmask() {
 	unix.Umask(0o077)
 }
 
+// read the umask without changing it
+func getUmask() os.FileMode {
+	mask := unix.Umask(0)
+	unix.Umask(mask)
+	return os.FileMode(mask)
+}
+
 func isExecutable(f os.FileInfo) bool {
 	return f.Mode()&0o111 != 0
 }

--- a/os_windows.go
+++ b/os_windows.go
@@ -172,6 +172,11 @@ func setDefaults() {
 
 func setUserUmask() {}
 
+// umask does not apply on Windows
+func getUmask() os.FileMode {
+	return 0
+}
+
 func isExecutable(f os.FileInfo) bool {
 	ext := filepath.Ext(f.Name())
 	if ext == "" {


### PR DESCRIPTION
The mode of the source file is passed to OpenFile where umask overwrites it contrary to the documentation. With preserve set to mode (which is default) a file with mode 0664 is created as 0600 under a umask of 077 although the mode should be preserved.

This sets the mode on the open file after its content is written. The suid and guid bits are left out, because the copy belongs to the user who runs lf. (coreutils cp only preserves suid and guid when the user stays the same, but lf doesnt preserver the owner)