### PR TITLE
Fix: shorten home path correctly

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -647,8 +647,9 @@ func (ui *ui) drawPromptLine(nav *nav) {
 	dir := nav.currDir()
 	pwd := sanitizeName(dir.path)
 
-	if after, ok := strings.CutPrefix(pwd, gUser.HomeDir); ok {
-		pwd = filepath.Join("~", after)
+	// shorten the home directory itself and paths inside
+	if rel, err := filepath.Rel(gUser.HomeDir, pwd); err == nil && filepath.IsLocal(rel) {
+		pwd = filepath.Join("~", rel)
 	}
 
 	sep := string(filepath.Separator)


### PR DESCRIPTION
A home directory `/home/user2` is shortened as `~/2` because lf cuts the home directory off the front of the path as text and never checks that a separator follows.

poc:
```
sudo mkdir /home/user2
lf /home/user2
```